### PR TITLE
fix(worker-runner): kill task process groups

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -419,6 +419,13 @@ must retain a conversation across Pod recovery.
 
 A WorkerPool manages a fleet of persistent worker pods backed by a StatefulSet. Tasks reference a WorkerPool via `spec.workerPoolRef` to execute on pre-warmed infrastructure instead of creating per-task Jobs.
 
+When a pooled Task is cancelled, the worker kills the Task's agent process
+tree and repeatedly sweeps for survivors before accepting another Task, so a
+cancelled Task's processes do not keep consuming the worker's resources. The
+sweep is bounded: if processes still remain after 10 seconds, the worker logs
+the remaining count and accepts the next Task anyway, so cleanup is
+best-effort rather than guaranteed.
+
 A WorkerPool's Workspace may use either a PAT-style or a GitHub App secret.
 GitHub App credentials are refreshed before they expire, so long-lived workers
 keep repository access without restarting (see [Workspace authentication](#workspace-authentication)).

--- a/internal/workerrunner/runner.go
+++ b/internal/workerrunner/runner.go
@@ -26,6 +26,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
@@ -274,13 +275,152 @@ func (r *Runner) executeTask(ctx context.Context, taskName string) error {
 // all agent tooling are directly available on the filesystem.
 func (r *Runner) runAgent(ctx context.Context, task *kelos.Task) error {
 	cmd := exec.CommandContext(ctx, "/kelos_entrypoint.sh", task.Spec.Prompt)
+	configureTaskProcessGroupCancellation(cmd)
 	cmd.Dir = "/workspace/repo"
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
 	cmd.Env = taskAgentEnv(os.Environ(), task)
 
-	return cmd.Run()
+	err := cmd.Run()
+	if ctx.Err() != nil {
+		// The process group is gone by now, but agent tooling that put itself
+		// in a new session or process group survives that signal. Sweep them
+		// before the runner picks up the next task.
+		killSurvivingTaskProcesses()
+	}
+	return err
+}
+
+// configureTaskProcessGroupCancellation prevents a cancelled task from
+// leaving agent descendants behind in the long-lived worker pod. Without a
+// separate process group, CommandContext kills only /kelos_entrypoint.sh;
+// session drivers and agent CLIs are re-parented to PID 1 and keep consuming
+// resources while the runner starts the next task.
+func configureTaskProcessGroupCancellation(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return os.ErrProcessDone
+		}
+		if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil {
+			if errors.Is(err, syscall.ESRCH) {
+				return os.ErrProcessDone
+			}
+			return err
+		}
+		return nil
+	}
+}
+
+// procRoot is the procfs mount the surviving-process sweep enumerates. It is
+// a variable so tests can point it at a fixture directory.
+var procRoot = "/proc"
+
+const (
+	// taskSweepTimeout bounds how long the runner keeps re-sweeping after a
+	// cancelled task before giving up and starting the next task.
+	taskSweepTimeout      = 10 * time.Second
+	taskSweepPollInterval = 50 * time.Millisecond
+)
+
+// killSurvivingTaskProcesses SIGKILLs and reaps every process left in the
+// runner's PID namespace after a cancelled task's process group was killed.
+//
+// Killing the task's process group does not reach descendants that call
+// setsid or setpgid: they leave the group, and once their intermediate parent
+// exits they are re-parented to PID 1, so their ancestry no longer links them
+// to the task either. A namespace-wide sweep is what actually bounds a task
+// to its own lifetime.
+//
+// The sweep repeats kill-and-reap passes until nothing but the runner remains
+// or the deadline expires: a survivor can fork between one enumeration and
+// its own SIGKILL, and exited descendants the runner adopted as PID 1 must be
+// reaped or they stay zombies (holding PIDs and /proc entries) for the life
+// of the worker.
+//
+// The sweep only runs when the runner is PID 1, meaning it owns the PID
+// namespace and every other process in it belongs to the task it just ran.
+// That is the worker pod topology: the agent container's command is the
+// worker runner, and no Kelos pod shares its process namespace. Anywhere else
+// (a developer machine, a test binary) the runner is not PID 1 and cleanup
+// stays limited to the task's process group, so the sweep can never kill
+// unrelated processes.
+func killSurvivingTaskProcesses() {
+	sweepSurvivingTaskProcesses(os.Getpid(), procRoot, syscall.Kill, reapAdoptedChildren, taskSweepTimeout)
+}
+
+func sweepSurvivingTaskProcesses(self int, procRoot string, kill func(pid int, sig syscall.Signal) error, reap func(), timeout time.Duration) {
+	if self != 1 {
+		return
+	}
+	deadline := time.Now().Add(timeout)
+	for {
+		// Reap before enumerating: killing the task's process group already
+		// re-parented its exited members to the runner, and unreaped zombies
+		// keep their /proc entries, which would stop the sweep from converging.
+		reap()
+		remaining, err := killProcessesExcept(procRoot, self, kill)
+		if err != nil {
+			log.Printf("Error sweeping surviving task processes: %v", err)
+			return
+		}
+		if remaining == 0 {
+			return
+		}
+		if time.Now().After(deadline) {
+			log.Printf("Giving up on surviving task process sweep with %d processes remaining after %s", remaining, timeout)
+			return
+		}
+		time.Sleep(taskSweepPollInterval)
+	}
+}
+
+// reapAdoptedChildren drains every exited child the runner has adopted as
+// PID 1. cmd.Run reaps only the entrypoint itself; descendants orphaned by
+// the process-group kill are re-parented to the runner and stay zombies until
+// waited on. The runner runs one task at a time and has already waited on the
+// entrypoint before the sweep starts, so a wildcard wait cannot race os/exec
+// for another command's exit status.
+func reapAdoptedChildren() {
+	for {
+		pid, err := syscall.Wait4(-1, nil, syscall.WNOHANG, nil)
+		if errors.Is(err, syscall.EINTR) {
+			continue
+		}
+		if err != nil || pid <= 0 {
+			return
+		}
+	}
+}
+
+// killProcessesExcept SIGKILLs every process listed under procRoot other than
+// self and returns how many were still present. Processes that exited between
+// listing and signalling are neither counted nor an error.
+func killProcessesExcept(procRoot string, self int, kill func(pid int, sig syscall.Signal) error) (int, error) {
+	entries, err := os.ReadDir(procRoot)
+	if err != nil {
+		return 0, fmt.Errorf("reading %s: %w", procRoot, err)
+	}
+
+	remaining := 0
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		pid, err := strconv.Atoi(entry.Name())
+		if err != nil || pid <= 0 || pid == self {
+			continue
+		}
+		if err := kill(pid, syscall.SIGKILL); err != nil {
+			if errors.Is(err, syscall.ESRCH) {
+				continue
+			}
+			log.Printf("Error killing surviving task process %d: %v", pid, err)
+		}
+		remaining++
+	}
+	return remaining, nil
 }
 
 func taskAgentEnv(base []string, task *kelos.Task) []string {

--- a/internal/workerrunner/runner.go
+++ b/internal/workerrunner/runner.go
@@ -26,6 +26,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
@@ -274,6 +275,7 @@ func (r *Runner) executeTask(ctx context.Context, taskName string) error {
 // all agent tooling are directly available on the filesystem.
 func (r *Runner) runAgent(ctx context.Context, task *kelos.Task) error {
 	cmd := exec.CommandContext(ctx, "/kelos_entrypoint.sh", task.Spec.Prompt)
+	configureTaskProcessGroupCancellation(cmd)
 	cmd.Dir = "/workspace/repo"
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -281,6 +283,27 @@ func (r *Runner) runAgent(ctx context.Context, task *kelos.Task) error {
 	cmd.Env = taskAgentEnv(os.Environ(), task)
 
 	return cmd.Run()
+}
+
+// configureTaskProcessGroupCancellation prevents a cancelled task from
+// leaving agent descendants behind in the long-lived worker pod. Without a
+// separate process group, CommandContext kills only /kelos_entrypoint.sh;
+// session drivers and agent CLIs are re-parented to PID 1 and keep consuming
+// resources while the runner starts the next task.
+func configureTaskProcessGroupCancellation(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return os.ErrProcessDone
+		}
+		if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil {
+			if errors.Is(err, syscall.ESRCH) {
+				return os.ErrProcessDone
+			}
+			return err
+		}
+		return nil
+	}
 }
 
 func taskAgentEnv(base []string, task *kelos.Task) []string {

--- a/internal/workerrunner/runner.go
+++ b/internal/workerrunner/runner.go
@@ -282,7 +282,14 @@ func (r *Runner) runAgent(ctx context.Context, task *kelos.Task) error {
 
 	cmd.Env = taskAgentEnv(os.Environ(), task)
 
-	return cmd.Run()
+	err := cmd.Run()
+	if ctx.Err() != nil {
+		// The process group is gone by now, but agent tooling that put itself
+		// in a new session or process group survives that signal. Sweep them
+		// before the runner picks up the next task.
+		killSurvivingTaskProcesses()
+	}
+	return err
 }
 
 // configureTaskProcessGroupCancellation prevents a cancelled task from
@@ -304,6 +311,62 @@ func configureTaskProcessGroupCancellation(cmd *exec.Cmd) {
 		}
 		return nil
 	}
+}
+
+// procRoot is the procfs mount the surviving-process sweep enumerates. It is
+// a variable so tests can point it at a fixture directory.
+var procRoot = "/proc"
+
+// killSurvivingTaskProcesses SIGKILLs every process left in the runner's PID
+// namespace after a cancelled task's process group was killed.
+//
+// Killing the task's process group does not reach descendants that call
+// setsid or setpgid: they leave the group, and once their intermediate parent
+// exits they are re-parented to PID 1, so their ancestry no longer links them
+// to the task either. A namespace-wide sweep is what actually bounds a task
+// to its own lifetime.
+//
+// The sweep only runs when the runner is PID 1, meaning it owns the PID
+// namespace and every other process in it belongs to the task it just ran.
+// That is the worker pod topology: the agent container's command is the
+// worker runner, and no Kelos pod shares its process namespace. Anywhere else
+// (a developer machine, a test binary) the runner is not PID 1 and cleanup
+// stays limited to the task's process group, so the sweep can never kill
+// unrelated processes.
+func killSurvivingTaskProcesses() {
+	sweepSurvivingTaskProcesses(os.Getpid(), procRoot, syscall.Kill)
+}
+
+func sweepSurvivingTaskProcesses(self int, procRoot string, kill func(pid int, sig syscall.Signal) error) {
+	if self != 1 {
+		return
+	}
+	if err := killProcessesExcept(procRoot, self, kill); err != nil {
+		log.Printf("Error sweeping surviving task processes: %v", err)
+	}
+}
+
+// killProcessesExcept SIGKILLs every process listed under procRoot other than
+// self. Processes that exited between listing and signalling are not an error.
+func killProcessesExcept(procRoot string, self int, kill func(pid int, sig syscall.Signal) error) error {
+	entries, err := os.ReadDir(procRoot)
+	if err != nil {
+		return fmt.Errorf("reading %s: %w", procRoot, err)
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		pid, err := strconv.Atoi(entry.Name())
+		if err != nil || pid <= 0 || pid == self {
+			continue
+		}
+		if err := kill(pid, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
+			log.Printf("Error killing surviving task process %d: %v", pid, err)
+		}
+	}
+	return nil
 }
 
 func taskAgentEnv(base []string, task *kelos.Task) []string {

--- a/internal/workerrunner/runner_test.go
+++ b/internal/workerrunner/runner_test.go
@@ -21,8 +21,13 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"reflect"
+	"sort"
+	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -695,6 +700,299 @@ func TestWaitForAssignmentReleaseContextCancelled(t *testing.T) {
 	if err == nil {
 		t.Fatal("Expected error from context cancellation")
 	}
+}
+
+// descendantScript forks a background child that publishes its PID and then
+// appends to a heartbeat file in a loop. The PID file lets the test cancel
+// only once the descendant exists, and the growing heartbeat lets it observe
+// whether the descendant is still executing without depending on any fixed
+// delay. The child appends rather than truncating because truncating an
+// already-empty file need not update its modification time.
+const descendantScript = `
+(while :; do printf 'x' >>"$HEARTBEAT"; sleep 0.05; done) &
+printf '%s' "$!" >"$PIDFILE.tmp"
+mv "$PIDFILE.tmp" "$PIDFILE"
+wait
+`
+
+const (
+	descendantPollInterval = 20 * time.Millisecond
+	descendantTimeout      = 30 * time.Second
+	descendantQuietWindow  = 500 * time.Millisecond
+)
+
+func TestConfigureTaskProcessGroupCancellationKillsDescendants(t *testing.T) {
+	dir := t.TempDir()
+	pidFile := filepath.Join(dir, "child.pid")
+	heartbeat := filepath.Join(dir, "child.heartbeat")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "sh", "-c", descendantScript)
+	cmd.Env = append(os.Environ(), "PIDFILE="+pidFile, "HEARTBEAT="+heartbeat)
+	configureTaskProcessGroupCancellation(cmd)
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("Starting process tree: %v", err)
+	}
+
+	// Cancel only after the descendant is observably running, so the
+	// assertion cannot pass merely because the shell had not forked yet.
+	pid := waitForRunningDescendant(t, pidFile, heartbeat)
+	t.Cleanup(func() { _ = syscall.Kill(pid, syscall.SIGKILL) })
+
+	cancel()
+	if err := cmd.Wait(); err == nil {
+		t.Fatal("Expected an error from the cancelled task shell")
+	}
+
+	// A quiet heartbeat alone could just mean a stalled survivor, so first
+	// require the descendant PID to be gone, then confirm nothing is still
+	// appending to the heartbeat.
+	waitForDescendantExit(t, pid)
+	waitForDescendantToStop(t, pid, heartbeat)
+}
+
+// waitForDescendantExit polls until the descendant PID no longer exists,
+// failing at the deadline if it is still alive. A killed child is reaped by
+// the system reaper once orphaned, so its PID does disappear.
+func waitForDescendantExit(t *testing.T, pid int) {
+	t.Helper()
+
+	deadline := time.Now().Add(descendantTimeout)
+	for {
+		err := syscall.Kill(pid, 0)
+		if errors.Is(err, syscall.ESRCH) {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("Cancelled task left descendant %d alive after %s (signal 0 error = %v)", pid, descendantTimeout, err)
+		}
+		time.Sleep(descendantPollInterval)
+	}
+}
+
+// waitForRunningDescendant blocks until the background child has published its
+// PID and written its first heartbeat, and returns that PID.
+func waitForRunningDescendant(t *testing.T, pidFile, heartbeat string) int {
+	t.Helper()
+
+	deadline := time.Now().Add(descendantTimeout)
+	for {
+		data, err := os.ReadFile(pidFile)
+		if err == nil {
+			if info, statErr := os.Stat(heartbeat); statErr == nil && info.Size() > 0 {
+				pid, convErr := strconv.Atoi(strings.TrimSpace(string(data)))
+				if convErr != nil {
+					t.Fatalf("Parsing descendant PID %q: %v", data, convErr)
+				}
+				return pid
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("Descendant did not start within %s", descendantTimeout)
+		}
+		time.Sleep(descendantPollInterval)
+	}
+}
+
+// waitForDescendantToStop polls until the heartbeat file stops growing for a
+// full quiet window, failing if it is still advancing at the deadline.
+func waitForDescendantToStop(t *testing.T, pid int, heartbeat string) {
+	t.Helper()
+
+	deadline := time.Now().Add(descendantTimeout)
+	for {
+		before, err := os.Stat(heartbeat)
+		if err != nil {
+			t.Fatalf("Reading descendant heartbeat: %v", err)
+		}
+		time.Sleep(descendantQuietWindow)
+		after, err := os.Stat(heartbeat)
+		if err != nil {
+			t.Fatalf("Reading descendant heartbeat: %v", err)
+		}
+		if after.Size() == before.Size() {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("Cancelled task left descendant %d running after %s", pid, descendantTimeout)
+		}
+	}
+}
+
+// removeProcEntries deletes the fixture entries for the given PIDs, standing
+// in for processes disappearing from /proc once they are killed and reaped.
+func removeProcEntries(t *testing.T, procRoot string, pids []int) {
+	t.Helper()
+	for _, pid := range pids {
+		if err := os.RemoveAll(filepath.Join(procRoot, strconv.Itoa(pid))); err != nil {
+			t.Fatalf("Removing proc fixture entry %d: %v", pid, err)
+		}
+	}
+}
+
+func TestSweepSurvivingTaskProcessesKillsEveryOtherProcess(t *testing.T) {
+	procRoot := newProcFixture(t, "1", "7", "42")
+
+	var killed []int
+	kill := func(pid int, sig syscall.Signal) error {
+		if sig != syscall.SIGKILL {
+			t.Errorf("Signal = %v, want SIGKILL", sig)
+		}
+		killed = append(killed, pid)
+		return nil
+	}
+	reap := func() { removeProcEntries(t, procRoot, killed) }
+	sweepSurvivingTaskProcesses(1, procRoot, kill, reap, time.Second)
+
+	sort.Ints(killed)
+	want := []int{7, 42}
+	if !reflect.DeepEqual(killed, want) {
+		t.Errorf("Killed = %v, want %v", killed, want)
+	}
+}
+
+// Killing the task's process group re-parents its exited members to the
+// runner, so the sweep must reap even when no process escaped the group.
+func TestSweepSurvivingTaskProcessesReapsAdoptedChildren(t *testing.T) {
+	procRoot := newProcFixture(t, "1")
+
+	reaps := 0
+	sweepSurvivingTaskProcesses(1, procRoot, func(pid int, _ syscall.Signal) error {
+		t.Errorf("Killed %d, want no processes signalled in an otherwise empty namespace", pid)
+		return nil
+	}, func() { reaps++ }, time.Second)
+
+	if reaps == 0 {
+		t.Error("Expected the sweep to reap adopted children")
+	}
+}
+
+// A survivor can fork between the /proc enumeration and its own SIGKILL; the
+// sweep must keep passing until such children are gone too.
+func TestSweepSurvivingTaskProcessesKillsProcessesForkedDuringSweep(t *testing.T) {
+	procRoot := newProcFixture(t, "1", "7")
+
+	killed := map[int]bool{}
+	kill := func(pid int, _ syscall.Signal) error {
+		if pid == 7 && !killed[7] {
+			if err := os.Mkdir(filepath.Join(procRoot, "99"), 0o755); err != nil {
+				t.Fatalf("Creating forked proc fixture entry: %v", err)
+			}
+		}
+		killed[pid] = true
+		return nil
+	}
+	reap := func() {
+		for pid := range killed {
+			removeProcEntries(t, procRoot, []int{pid})
+		}
+	}
+	sweepSurvivingTaskProcesses(1, procRoot, kill, reap, 10*time.Second)
+
+	if !killed[99] {
+		t.Error("Expected the sweep to kill a process forked during the first pass")
+	}
+}
+
+func TestSweepSurvivingTaskProcessesGivesUpAtDeadline(t *testing.T) {
+	procRoot := newProcFixture(t, "1", "7")
+
+	kills := 0
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		sweepSurvivingTaskProcesses(1, procRoot, func(int, syscall.Signal) error {
+			kills++
+			return nil
+		}, func() {}, 150*time.Millisecond)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Sweep did not give up on a process that never disappears")
+	}
+	if kills < 2 {
+		t.Errorf("Kill attempts = %d, want the sweep to retry until the deadline", kills)
+	}
+}
+
+func TestSweepSurvivingTaskProcessesSkipsWhenNotNamespaceInit(t *testing.T) {
+	procRoot := newProcFixture(t, "1", "7", "42")
+
+	var killed []int
+	sweepSurvivingTaskProcesses(4242, procRoot, func(pid int, _ syscall.Signal) error {
+		killed = append(killed, pid)
+		return nil
+	}, func() {
+		t.Error("Reaping must not run when the runner is not PID 1")
+	}, time.Second)
+
+	if len(killed) != 0 {
+		t.Errorf("Killed = %v, want no processes signalled when the runner is not PID 1", killed)
+	}
+}
+
+func TestKillProcessesExceptSkipsNonProcessEntries(t *testing.T) {
+	procRoot := newProcFixture(t, "9", "self", "meminfo")
+	// A regular file whose name parses as a PID must still be skipped.
+	if err := os.WriteFile(filepath.Join(procRoot, "11"), nil, 0o600); err != nil {
+		t.Fatalf("Writing fixture file: %v", err)
+	}
+
+	var killed []int
+	remaining, err := killProcessesExcept(procRoot, 1, func(pid int, _ syscall.Signal) error {
+		killed = append(killed, pid)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("killProcessesExcept() error = %v", err)
+	}
+
+	if !reflect.DeepEqual(killed, []int{9}) {
+		t.Errorf("Killed = %v, want [9]", killed)
+	}
+	if remaining != 1 {
+		t.Errorf("Remaining = %d, want 1", remaining)
+	}
+}
+
+func TestKillProcessesExceptIgnoresExitedProcesses(t *testing.T) {
+	procRoot := newProcFixture(t, "7")
+
+	remaining, err := killProcessesExcept(procRoot, 1, func(int, syscall.Signal) error {
+		return syscall.ESRCH
+	})
+	if err != nil {
+		t.Errorf("killProcessesExcept() error = %v, want nil for an already exited process", err)
+	}
+	if remaining != 0 {
+		t.Errorf("Remaining = %d, want 0 when every process already exited", remaining)
+	}
+}
+
+func TestKillProcessesExceptUnreadableProcRoot(t *testing.T) {
+	_, err := killProcessesExcept(filepath.Join(t.TempDir(), "missing"), 1, func(int, syscall.Signal) error {
+		return nil
+	})
+	if err == nil {
+		t.Fatal("Expected an error for an unreadable proc root")
+	}
+}
+
+func newProcFixture(t *testing.T, entries ...string) string {
+	t.Helper()
+
+	procRoot := t.TempDir()
+	for _, entry := range entries {
+		if err := os.Mkdir(filepath.Join(procRoot, entry), 0o755); err != nil {
+			t.Fatalf("Creating proc fixture entry %s: %v", entry, err)
+		}
+	}
+	return procRoot
 }
 
 func TestRunMaxTasksPerWorker(t *testing.T) {

--- a/internal/workerrunner/runner_test.go
+++ b/internal/workerrunner/runner_test.go
@@ -23,7 +23,11 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
+	"sort"
+	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -698,26 +702,187 @@ func TestWaitForAssignmentReleaseContextCancelled(t *testing.T) {
 	}
 }
 
+// descendantScript forks a background child that publishes its PID and then
+// appends to a heartbeat file in a loop. The PID file lets the test cancel
+// only once the descendant exists, and the growing heartbeat lets it observe
+// whether the descendant is still executing without depending on any fixed
+// delay. The child appends rather than truncating because truncating an
+// already-empty file need not update its modification time.
+const descendantScript = `
+(while :; do printf 'x' >>"$HEARTBEAT"; sleep 0.05; done) &
+printf '%s' "$!" >"$PIDFILE.tmp"
+mv "$PIDFILE.tmp" "$PIDFILE"
+wait
+`
+
+const (
+	descendantPollInterval = 20 * time.Millisecond
+	descendantTimeout      = 30 * time.Second
+	descendantQuietWindow  = 500 * time.Millisecond
+)
+
 func TestConfigureTaskProcessGroupCancellationKillsDescendants(t *testing.T) {
-	marker := filepath.Join(t.TempDir(), "leaked-child-ran")
+	dir := t.TempDir()
+	pidFile := filepath.Join(dir, "child.pid")
+	heartbeat := filepath.Join(dir, "child.heartbeat")
+
 	ctx, cancel := context.WithCancel(context.Background())
-	cmd := exec.CommandContext(ctx, "sh", "-c", `(sleep 0.3; touch "$MARKER") & wait`)
-	cmd.Env = append(os.Environ(), "MARKER="+marker)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "sh", "-c", descendantScript)
+	cmd.Env = append(os.Environ(), "PIDFILE="+pidFile, "HEARTBEAT="+heartbeat)
 	configureTaskProcessGroupCancellation(cmd)
 
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("Starting process tree: %v", err)
 	}
-	time.Sleep(50 * time.Millisecond)
-	cancel()
-	_ = cmd.Wait()
 
-	// If cancellation killed only the shell, its background child would be
-	// re-parented to PID 1 and create the marker after the parent exited.
-	time.Sleep(500 * time.Millisecond)
-	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
-		t.Fatalf("Cancelled task left a descendant running; marker stat error = %v", err)
+	// Cancel only after the descendant is observably running, so the
+	// assertion cannot pass merely because the shell had not forked yet.
+	pid := waitForRunningDescendant(t, pidFile, heartbeat)
+	t.Cleanup(func() { _ = syscall.Kill(pid, syscall.SIGKILL) })
+
+	cancel()
+	if err := cmd.Wait(); err == nil {
+		t.Fatal("Expected an error from the cancelled task shell")
 	}
+
+	// A descendant that survived cancellation keeps growing the heartbeat;
+	// one that was killed leaves it frozen.
+	waitForDescendantToStop(t, pid, heartbeat)
+}
+
+// waitForRunningDescendant blocks until the background child has published its
+// PID and written its first heartbeat, and returns that PID.
+func waitForRunningDescendant(t *testing.T, pidFile, heartbeat string) int {
+	t.Helper()
+
+	deadline := time.Now().Add(descendantTimeout)
+	for {
+		data, err := os.ReadFile(pidFile)
+		if err == nil {
+			if info, statErr := os.Stat(heartbeat); statErr == nil && info.Size() > 0 {
+				pid, convErr := strconv.Atoi(strings.TrimSpace(string(data)))
+				if convErr != nil {
+					t.Fatalf("Parsing descendant PID %q: %v", data, convErr)
+				}
+				return pid
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("Descendant did not start within %s", descendantTimeout)
+		}
+		time.Sleep(descendantPollInterval)
+	}
+}
+
+// waitForDescendantToStop polls until the heartbeat file stops growing for a
+// full quiet window, failing if it is still advancing at the deadline.
+func waitForDescendantToStop(t *testing.T, pid int, heartbeat string) {
+	t.Helper()
+
+	deadline := time.Now().Add(descendantTimeout)
+	for {
+		before, err := os.Stat(heartbeat)
+		if err != nil {
+			t.Fatalf("Reading descendant heartbeat: %v", err)
+		}
+		time.Sleep(descendantQuietWindow)
+		after, err := os.Stat(heartbeat)
+		if err != nil {
+			t.Fatalf("Reading descendant heartbeat: %v", err)
+		}
+		if after.Size() == before.Size() {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("Cancelled task left descendant %d running after %s", pid, descendantTimeout)
+		}
+	}
+}
+
+func TestSweepSurvivingTaskProcessesKillsEveryOtherProcess(t *testing.T) {
+	procRoot := newProcFixture(t, "1", "7", "42")
+
+	var killed []int
+	sweepSurvivingTaskProcesses(1, procRoot, func(pid int, sig syscall.Signal) error {
+		if sig != syscall.SIGKILL {
+			t.Errorf("Signal = %v, want SIGKILL", sig)
+		}
+		killed = append(killed, pid)
+		return nil
+	})
+
+	sort.Ints(killed)
+	want := []int{7, 42}
+	if !reflect.DeepEqual(killed, want) {
+		t.Errorf("Killed = %v, want %v", killed, want)
+	}
+}
+
+func TestSweepSurvivingTaskProcessesSkipsWhenNotNamespaceInit(t *testing.T) {
+	procRoot := newProcFixture(t, "1", "7", "42")
+
+	var killed []int
+	sweepSurvivingTaskProcesses(4242, procRoot, func(pid int, _ syscall.Signal) error {
+		killed = append(killed, pid)
+		return nil
+	})
+
+	if len(killed) != 0 {
+		t.Errorf("Killed = %v, want no processes signalled when the runner is not PID 1", killed)
+	}
+}
+
+func TestKillProcessesExceptSkipsNonProcessEntries(t *testing.T) {
+	procRoot := newProcFixture(t, "9", "self", "meminfo")
+	// A regular file whose name parses as a PID must still be skipped.
+	if err := os.WriteFile(filepath.Join(procRoot, "11"), nil, 0o600); err != nil {
+		t.Fatalf("Writing fixture file: %v", err)
+	}
+
+	var killed []int
+	if err := killProcessesExcept(procRoot, 1, func(pid int, _ syscall.Signal) error {
+		killed = append(killed, pid)
+		return nil
+	}); err != nil {
+		t.Fatalf("killProcessesExcept() error = %v", err)
+	}
+
+	if !reflect.DeepEqual(killed, []int{9}) {
+		t.Errorf("Killed = %v, want [9]", killed)
+	}
+}
+
+func TestKillProcessesExceptIgnoresExitedProcesses(t *testing.T) {
+	procRoot := newProcFixture(t, "7")
+
+	if err := killProcessesExcept(procRoot, 1, func(int, syscall.Signal) error {
+		return syscall.ESRCH
+	}); err != nil {
+		t.Errorf("killProcessesExcept() error = %v, want nil for an already exited process", err)
+	}
+}
+
+func TestKillProcessesExceptUnreadableProcRoot(t *testing.T) {
+	err := killProcessesExcept(filepath.Join(t.TempDir(), "missing"), 1, func(int, syscall.Signal) error {
+		return nil
+	})
+	if err == nil {
+		t.Fatal("Expected an error for an unreadable proc root")
+	}
+}
+
+func newProcFixture(t *testing.T, entries ...string) string {
+	t.Helper()
+
+	procRoot := t.TempDir()
+	for _, entry := range entries {
+		if err := os.Mkdir(filepath.Join(procRoot, entry), 0o755); err != nil {
+			t.Fatalf("Creating proc fixture entry %s: %v", entry, err)
+		}
+	}
+	return procRoot
 }
 
 func TestRunMaxTasksPerWorker(t *testing.T) {

--- a/internal/workerrunner/runner_test.go
+++ b/internal/workerrunner/runner_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -694,6 +695,28 @@ func TestWaitForAssignmentReleaseContextCancelled(t *testing.T) {
 	err := runner.waitForAssignmentRelease(ctx, "some-task")
 	if err == nil {
 		t.Fatal("Expected error from context cancellation")
+	}
+}
+
+func TestConfigureTaskProcessGroupCancellationKillsDescendants(t *testing.T) {
+	marker := filepath.Join(t.TempDir(), "leaked-child-ran")
+	ctx, cancel := context.WithCancel(context.Background())
+	cmd := exec.CommandContext(ctx, "sh", "-c", `(sleep 0.3; touch "$MARKER") & wait`)
+	cmd.Env = append(os.Environ(), "MARKER="+marker)
+	configureTaskProcessGroupCancellation(cmd)
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("Starting process tree: %v", err)
+	}
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	_ = cmd.Wait()
+
+	// If cancellation killed only the shell, its background child would be
+	// re-parented to PID 1 and create the marker after the parent exited.
+	time.Sleep(500 * time.Millisecond)
+	if _, err := os.Stat(marker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("Cancelled task left a descendant running; marker stat error = %v", err)
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Runs each agent task in its own process group and kills that group when the task context is cancelled. Previously CommandContext terminated only /kelos_entrypoint.sh, allowing session-driver and model CLI descendants to be re-parented to PID 1 in a long-lived pooled worker. Those orphaned processes continued consuming CPU and memory while later tasks ran.

Adds a regression test that starts a background child and verifies cancellation prevents it from surviving the parent shell.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

This is the runtime half of a paired reliability fix. Cosmos Agents adds an execution deadline for assigned pooled tasks; this change ensures that deadline actually terminates the complete agent process tree.

Verification:
- make verify
- make test TEST_FLAGS='-run TestConfigureTaskProcessGroupCancellationKillsDescendants -count=1'
- Full make test passes all workerrunner tests; one pre-existing controller test fails because its temporary session-state/claude-config/.claude.json fixture is absent. The same test fails in isolation and this PR does not touch controller code.

#### Does this PR introduce a user-facing change?

```release-note
Pooled task cancellation now terminates the task's full agent process tree.
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops orphaned agent processes in pooled workers by running each task in its own process group and, on cancellation, killing that group and sweeping the runner’s PID namespace. Previously only `/kelos_entrypoint.sh` was terminated; descendants could survive and keep consuming CPU/memory.

- In `internal/workerrunner`, start tasks with a dedicated process group and override cancellation to `SIGKILL` the group.
- After cancellation, and only when the runner is PID 1, sweep `/proc`: reap adopted children, `SIGKILL` all other PIDs, repeat until only the runner remains or a 10s deadline; log survivors on timeout.
- Add deadline-based tests in `internal/workerrunner/runner_test.go` for process-group cancellation, sweep/reap convergence, fork-during-sweep, and skipping when not PID 1.
- Update `docs/reference.md` to state pooled task cancellation kills the full agent process tree and cleanup is best-effort (10s cap).

<sup>Written for commit fa57e2634298133be8f171510058f5e4c344ab02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

