### PR TITLE
Remove pr-finish from self-development skills

### DIFF
--- a/internal/examples/self_development_test.go
+++ b/internal/examples/self_development_test.go
@@ -69,7 +69,13 @@ func TestSelfDevelopmentBaseAgentProvidesSharedInstructionsAndSkills(t *testing.
 	t.Parallel()
 
 	config := readAgentConfigFromDir(t, "self-development", "base-agent.yaml")
-	wantSkills := []kelos.SkillsShSpec{{Source: "gjkim42/kanon-repo"}}
+	wantSkills := []kelos.SkillsShSpec{
+		{Source: "gjkim42/kanon-repo", Skill: "api-review"},
+		{Source: "gjkim42/kanon-repo", Skill: "design-cleanup"},
+		{Source: "gjkim42/kanon-repo", Skill: "gjkim-instruction"},
+		{Source: "gjkim42/kanon-repo", Skill: "pre-session-end"},
+		{Source: "gjkim42/kanon-repo", Skill: "review-all"},
+	}
 	if !reflect.DeepEqual(config.Spec.Skills, wantSkills) {
 		t.Fatalf("base-agent skills = %v, want %v", config.Spec.Skills, wantSkills)
 	}

--- a/self-development/README.md
+++ b/self-development/README.md
@@ -26,7 +26,7 @@ Every self-development Task, TaskSpawner, Session, and SessionSpawner in this
 directory and its nested Agora, Kanon, and Open Actions directories references
 [`base-agent.yaml`](base-agent.yaml), which copies
 [`gjkim42/kanon-repo`'s `instructions/AGENTS.md`](https://github.com/gjkim42/kanon-repo/blob/main/instructions/AGENTS.md)
-and installs all skills from that repository through `spec.skills`.
+and installs its selected shared skills individually through `spec.skills`.
 Tasks and TaskSpawners add a second role-specific AgentConfig when they need
 local identity, conventions, or workflow instructions. The issue and PR
 pick-up SessionSpawners for Kelos, Agora, Kanon, and Open Actions, plus

--- a/self-development/base-agent.yaml
+++ b/self-development/base-agent.yaml
@@ -5,6 +5,15 @@ metadata:
 spec:
   skills:
     - source: gjkim42/kanon-repo
+      skill: api-review
+    - source: gjkim42/kanon-repo
+      skill: design-cleanup
+    - source: gjkim42/kanon-repo
+      skill: gjkim-instruction
+    - source: gjkim42/kanon-repo
+      skill: pre-session-end
+    - source: gjkim42/kanon-repo
+      skill: review-all
   agentsMD: |
     # AGENTS.md
 

--- a/self-development/kelos-config-update.yaml
+++ b/self-development/kelos-config-update.yaml
@@ -56,7 +56,7 @@ spec:
 
       Agent configuration includes:
       - `AGENTS.md` — project-level conventions and instructions for all agents
-      - `self-development/base-agent.yaml` — checked-in copy of `gjkim42/kanon-repo` instructions and shared skills
+      - `self-development/base-agent.yaml` — checked-in copy of `gjkim42/kanon-repo` instructions and selected shared skills
       - `self-development/agentconfig.yaml` — Kelos-specific AgentConfig used by general-purpose TaskSpawners
       - `self-development/*.yaml` — TaskSpawner and SessionSpawner prompt templates that guide each agent's behavior
 
@@ -84,7 +84,7 @@ spec:
          **Project-level changes** (affect all agents):
          - Update `AGENTS.md` if the feedback is about general project conventions
          - Update the applicable role-specific AgentConfig for shared TaskSpawner behavior
-         - Only update `self-development/base-agent.yaml` to synchronize changes from its upstream `gjkim42/kanon-repo` sources
+         - Only update `self-development/base-agent.yaml` to synchronize upstream instructions or its individually selected shared skills from `gjkim42/kanon-repo`
 
          **Task-specific changes** (affect a specific agent):
          - Update the relevant spawner prompt in `self-development/*.yaml`

--- a/self-development/kelos-self-update.yaml
+++ b/self-development/kelos-self-update.yaml
@@ -94,7 +94,7 @@ spec:
          - Check that resource requests/limits, models, TTLs, and other settings are appropriate
          - Verify that webhook repositories, events, labels, excludeLabels, and filters are correct and consistent
          - Ensure every root spawner references `base-agent` first, with role-specific AgentConfigs after it
-         - Ensure `base-agent.yaml` matches `gjkim42/kanon-repo`'s `instructions/AGENTS.md` and shared skills package
+         - Ensure `base-agent.yaml` matches `gjkim42/kanon-repo`'s `instructions/AGENTS.md` and lists each intended shared skill individually
          - Look for inconsistencies between spawners that should share the same configuration
 
       3. **Workflow Completeness**


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The shared self-development AgentConfig installed the entire
`gjkim42/kanon-repo` skills package, which also made `pr-finish` available to
every self-development agent.

This PR replaces the package-wide installation with an explicit allowlist of
the five intended shared skills, leaving out `pr-finish`. It also updates the
self-development documentation and updater prompts to preserve individual
skill selection, and updates the manifest test to enforce the allowlist.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Validation:

- `make verify`
- `make test TEST_FLAGS='-run TestSelfDevelopment'`

The full `make test` run reached two unrelated Codex entrypoint test failures:
`TestCodexEntrypointUsesPersistentSessionHome` and the Codex case of
`TestAgentEntrypointsPreserveSkillReferenceFiles`. The changed
self-development tests pass.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the package-wide install of `gjkim42/kanon-repo` skills with an explicit allowlist to remove `pr-finish` from self-development agents. Updated docs and tests to reflect and enforce individual skill selection.

- **Refactors**
  - `base-agent.yaml` now installs five skills explicitly: api-review, design-cleanup, gjkim-instruction, pre-session-end, review-all.
  - Updated README and updater prompts to reference selected shared skills instead of the full package.
  - Updated the self-development test to assert the exact allowlisted skills.

<sup>Written for commit 0839fbc7223937aeacc13a6a195e1fd1054ea280. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1632?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

