### PR TITLE
Allow API kind on pull requests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,10 +2,13 @@
 
 <!--
 Add one of the following kinds:
+/kind api
 /kind bug
 /kind cleanup
 /kind docs
 /kind feature
+
+Use /kind api for PRs that modify files under api/.
 -->
 
 #### What this PR does / why we need it:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,8 @@
 ## Pull Requests
 - **Always follow `.github/PULL_REQUEST_TEMPLATE.md`** when creating PRs.
 - Fill in every section of the template. Do not remove or skip sections — use "N/A" or "NONE" where appropriate.
-- Choose exactly one `/kind` label from: `bug`, `cleanup`, `docs`, `feature`.
+- Choose exactly one `/kind` label from: `api`, `bug`, `cleanup`, `docs`, `feature`.
+- PRs that modify files under `api/` must use `/kind api`.
 - If there is no associated issue, write "N/A" under the issue section.
 - If the PR does not introduce a user-facing change, write "NONE" in the `release-note` block.
 - If the PR introduces a new API field, CRD change, or user-facing feature, write a meaningful release note describing the change — do not write "NONE".

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,8 +106,9 @@ Every pull request must follow
 [the pull request template](.github/PULL_REQUEST_TEMPLATE.md):
 
 - Fill in every section; use `N/A` where appropriate.
-- Choose exactly one kind: `/kind bug`, `/kind cleanup`, `/kind docs`, or
-  `/kind feature`.
+- Choose exactly one kind: `/kind api`, `/kind bug`, `/kind cleanup`,
+  `/kind docs`, or `/kind feature`. Use `/kind api` for pull requests that
+  modify files under `api/`.
 - Link the associated issue, or write `N/A` if there is none.
 - Add a meaningful release note for a user-facing change. Write `NONE` in the
   `release-note` block when there is no user-facing change.


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Adds `/kind api` to the pull request template and contributor guidance. Pull requests that modify files under `api/` are now explicitly required to use the API kind.

This fixes the omission that prevented contributors and agents from selecting the existing `kind/api` label through the documented PR workflow.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Testing

- `make verify`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow PRs that modify `api/` to declare `/kind api`, making API changes explicit and unblocking label-based workflows. Previously the template omitted this kind; contributors and agents could not select it.

- Updates `.github/PULL_REQUEST_TEMPLATE.md`, `AGENTS.md`, and `CONTRIBUTING.md` to include `/kind api` and require it for changes under `api/`.
- No runtime or user-facing change; no release note.

<sup>Written for commit d4f30683b7b1eb5185dd2da86f29b9683f264dff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1651?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

