### PR TITLE
Reduce Session GitHub API usage

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -234,10 +234,13 @@ the Session resource and is visible through the Kubernetes API.
 | `status.pullRequest.checks.completed` | Number of GitHub checks that have completed | Output |
 | `status.pullRequest.checks.total` | Total number of GitHub checks reported for the pull request | Output |
 
-The Session runtime refreshes pull request and GitHub check status automatically.
-The Session web application's sidebar and selected Session header show the
-aggregate check state and pending progress. `status.pullRequest.checks` is
-omitted when GitHub reports no checks for the pull request.
+The Session runtime refreshes pull request and GitHub check status at startup,
+after each turn, every 30 seconds while checks are pending or the pull request
+is queued, and every five minutes otherwise. The Session web application's
+sidebar and selected Session header show the aggregate check state and pending
+progress. `status.pullRequest.checks` is omitted when GitHub reports no checks
+for the pull request. Failed GitHub refreshes use exponential retry delays from
+one minute up to 15 minutes.
 
 The web creation dialog can generate a new Session from an existing Session in
 the active namespace. This copies the complete `Session.spec` into an editable

--- a/internal/sessionruntime/server.go
+++ b/internal/sessionruntime/server.go
@@ -23,21 +23,26 @@ import (
 
 	"k8s.io/apimachinery/pkg/types"
 
+	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
 	"github.com/kelos-dev/kelos/internal/sessionupdate"
 	clientv1alpha2 "github.com/kelos-dev/kelos/pkg/generated/clientset/versioned/typed/api/v1alpha2"
 )
 
 const (
-	DefaultSocketPath                   = "/tmp/kelos-session/runtime.sock"
-	DefaultStateDir                     = "/workspace/.kelos/session"
-	DefaultWorkingDir                   = "/workspace/repo"
-	journalFileName                     = "events.jsonl"
-	activityPublishedFile               = "activity-published"
-	initializedFile                     = "initialized"
-	defaultInterruptTimeout             = 10 * time.Second
-	shellCommandWaitDelay               = 250 * time.Millisecond
-	defaultSessionStatusPublishInterval = 30 * time.Second
-	defaultSessionStatusRetryInterval   = 2 * time.Second
+	DefaultSocketPath                           = "/tmp/kelos-session/runtime.sock"
+	DefaultStateDir                             = "/workspace/.kelos/session"
+	DefaultWorkingDir                           = "/workspace/repo"
+	journalFileName                             = "events.jsonl"
+	activityPublishedFile                       = "activity-published"
+	initializedFile                             = "initialized"
+	defaultInterruptTimeout                     = 10 * time.Second
+	shellCommandWaitDelay                       = 250 * time.Millisecond
+	defaultSessionStatusPublishInterval         = 30 * time.Second
+	defaultSessionStatusRetryInterval           = 2 * time.Second
+	defaultWorkspaceStatusRefreshInterval       = 5 * time.Minute
+	defaultActiveWorkspaceStatusRefreshInterval = 30 * time.Second
+	defaultWorkspaceStatusRetryInterval         = time.Minute
+	defaultWorkspaceStatusMaxRetryInterval      = 15 * time.Minute
 )
 
 // Config configures the resident Session runtime.
@@ -67,9 +72,8 @@ type turnRequest struct {
 }
 
 type sessionStatusPublishRequest struct {
-	active                       bool
-	waitingForInput              bool
-	refreshWorkspaceAfterPublish bool
+	active          bool
+	waitingForInput bool
 	// settledTurnID is the completed-turn high-water mark captured when this
 	// request was enqueued. It becomes the persisted activity mark only after an
 	// idle (active == false) publication of this request succeeds, so a stale
@@ -136,37 +140,47 @@ type Server struct {
 	runtimeStatusSubscribers    map[int]chan RuntimeStatus
 	nextRuntimeStatusSubscriber int
 
-	inputMu                      sync.Mutex
-	pendingInputs                map[string]*pendingInput
-	nextInputID                  atomic.Int64
-	refreshWorkspaceStatus       func(context.Context) error
-	publishSessionStatus         func(context.Context, bool, bool) error
-	workspaceStatusRefreshes     chan struct{}
-	sessionStatusMu              sync.Mutex
-	sessionStatusPublishQueue    []sessionStatusPublishRequest
-	sessionStatusPublishWakeups  chan struct{}
-	sessionStatusPublishInterval time.Duration
-	sessionStatusRetryInterval   time.Duration
+	inputMu                              sync.Mutex
+	pendingInputs                        map[string]*pendingInput
+	nextInputID                          atomic.Int64
+	refreshWorkspaceStatus               func(context.Context, bool) (WorkspaceStatus, error)
+	publishSessionStatus                 func(context.Context, bool, bool) error
+	workspaceStatusMu                    sync.Mutex
+	workspaceStatusForceDiscovery        bool
+	workspaceStatusRefreshes             chan struct{}
+	workspaceStatusRefreshInterval       time.Duration
+	activeWorkspaceStatusRefreshInterval time.Duration
+	workspaceStatusRetryInterval         time.Duration
+	workspaceStatusMaxRetryInterval      time.Duration
+	sessionStatusMu                      sync.Mutex
+	sessionStatusPublishQueue            []sessionStatusPublishRequest
+	sessionStatusPublishWakeups          chan struct{}
+	sessionStatusPublishInterval         time.Duration
+	sessionStatusRetryInterval           time.Duration
 }
 
 // NewServer constructs a Session server around injected provider and journal implementations.
 func NewServer(config Config, journal *Journal, provider Provider) *Server {
 	server := &Server{
-		config:                       config,
-		journal:                      journal,
-		provider:                     provider,
-		appendMessage:                journal.Append,
-		turns:                        make(chan turnRequest, 1),
-		updateReport:                 make(chan struct{}, 1),
-		runtimeStatus:                newRuntimeStatus(config),
-		runtimeStatusSubscribers:     map[int]chan RuntimeStatus{},
-		pendingInputs:                map[string]*pendingInput{},
-		workspaceStatusRefreshes:     make(chan struct{}, 1),
-		sessionStatusPublishWakeups:  make(chan struct{}, 1),
-		providerStop:                 make(chan struct{}),
-		interruptTimeout:             defaultInterruptTimeout,
-		sessionStatusPublishInterval: defaultSessionStatusPublishInterval,
-		sessionStatusRetryInterval:   defaultSessionStatusRetryInterval,
+		config:                               config,
+		journal:                              journal,
+		provider:                             provider,
+		appendMessage:                        journal.Append,
+		turns:                                make(chan turnRequest, 1),
+		updateReport:                         make(chan struct{}, 1),
+		runtimeStatus:                        newRuntimeStatus(config),
+		runtimeStatusSubscribers:             map[int]chan RuntimeStatus{},
+		pendingInputs:                        map[string]*pendingInput{},
+		workspaceStatusRefreshes:             make(chan struct{}, 1),
+		sessionStatusPublishWakeups:          make(chan struct{}, 1),
+		providerStop:                         make(chan struct{}),
+		interruptTimeout:                     defaultInterruptTimeout,
+		workspaceStatusRefreshInterval:       defaultWorkspaceStatusRefreshInterval,
+		activeWorkspaceStatusRefreshInterval: defaultActiveWorkspaceStatusRefreshInterval,
+		workspaceStatusRetryInterval:         defaultWorkspaceStatusRetryInterval,
+		workspaceStatusMaxRetryInterval:      defaultWorkspaceStatusMaxRetryInterval,
+		sessionStatusPublishInterval:         defaultSessionStatusPublishInterval,
+		sessionStatusRetryInterval:           defaultSessionStatusRetryInterval,
 	}
 	if config.StateDir != "" {
 		server.activityMarkerPath = filepath.Join(config.StateDir, activityPublishedFile)
@@ -230,10 +244,10 @@ func Run(ctx context.Context, config Config) error {
 			return readWorkspaceStatus(ctx, realWorkspaceStatusRunner{}, config.StateDir, config.WorkingDir)
 		})
 	}
-	server.refreshWorkspaceStatus = func(ctx context.Context) error {
-		status, err := refreshWorkspaceStatus(ctx, config.StateDir, config.WorkingDir, config.Environment)
+	server.refreshWorkspaceStatus = func(ctx context.Context, forceDiscovery bool) (WorkspaceStatus, error) {
+		status, err := refreshWorkspaceStatus(ctx, config.StateDir, config.WorkingDir, config.Environment, forceDiscovery)
 		server.updateWorkspaceRuntimeStatus(status)
-		return err
+		return status, err
 	}
 	if config.PublishSessionStatus != nil {
 		server.publishSessionStatus = publishSessionStatus
@@ -373,7 +387,7 @@ func (s *Server) Serve(ctx context.Context) error {
 	if s.publishSessionStatus != nil {
 		go s.runSessionStatusPublishes(serveCtx)
 	}
-	s.requestWorkspaceStatusRefresh()
+	s.requestWorkspaceStatusRefresh(true)
 	s.requestSessionStatusPublish()
 	go func() {
 		select {
@@ -464,44 +478,88 @@ func (s *Server) runTurns(ctx context.Context) {
 	}
 }
 
-func (s *Server) requestWorkspaceStatusRefresh() {
+func (s *Server) requestWorkspaceStatusRefresh(forceDiscovery bool) {
 	if s.refreshWorkspaceStatus == nil {
 		return
+	}
+	s.workspaceStatusMu.Lock()
+	if forceDiscovery {
+		s.workspaceStatusForceDiscovery = true
 	}
 	select {
 	case s.workspaceStatusRefreshes <- struct{}{}:
 	default:
 	}
+	s.workspaceStatusMu.Unlock()
 }
 
 func (s *Server) runWorkspaceStatusRefreshes(ctx context.Context) {
+	if s.refreshWorkspaceStatus == nil {
+		return
+	}
+	timer := time.NewTimer(s.workspaceStatusRefreshInterval)
+	defer timer.Stop()
+	retryDelay := s.workspaceStatusRetryInterval
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-s.workspaceStatusRefreshes:
-			err := s.refreshWorkspaceStatus(ctx)
-			s.requestSessionStatusPublishAfterWorkspaceRefresh()
-			if err != nil {
-				log.Printf("Unable to refresh Session workspace status error=%v", err)
+		case <-timer.C:
+		}
+		if !timer.Stop() {
+			select {
+			case <-timer.C:
+			default:
 			}
 		}
+		s.workspaceStatusMu.Lock()
+		forceDiscovery := s.workspaceStatusForceDiscovery
+		s.workspaceStatusForceDiscovery = false
+		select {
+		case <-s.workspaceStatusRefreshes:
+		default:
+		}
+		s.workspaceStatusMu.Unlock()
+
+		status, err := s.refreshWorkspaceStatus(ctx, forceDiscovery)
+		s.requestSessionStatusPublishAfterWorkspaceRefresh()
+		next := s.workspaceStatusRefreshDelay(status)
+		if err != nil {
+			log.Printf("Unable to refresh Session workspace status error=%v", err)
+			next = retryDelay
+			retryDelay = min(retryDelay*2, s.workspaceStatusMaxRetryInterval)
+		} else {
+			retryDelay = s.workspaceStatusRetryInterval
+		}
+		timer.Reset(next)
 	}
 }
 
+func (s *Server) workspaceStatusRefreshDelay(status WorkspaceStatus) time.Duration {
+	if status.PullRequest == nil {
+		return s.workspaceStatusRefreshInterval
+	}
+	if status.PullRequest.State == kelos.SessionPullRequestStateQueued ||
+		(status.PullRequest.Checks != nil && status.PullRequest.Checks.State == kelos.SessionPullRequestChecksStatePending) {
+		return s.activeWorkspaceStatusRefreshInterval
+	}
+	return s.workspaceStatusRefreshInterval
+}
+
 func (s *Server) requestSessionStatusPublish() {
-	s.queueSessionStatusPublish(false, false)
+	s.queueSessionStatusPublish(false)
 }
 
 func (s *Server) requestSessionStatusPublishAfterWorkspaceRefresh() {
-	s.queueSessionStatusPublish(true, false)
+	s.queueSessionStatusPublish(true)
 }
 
 func (s *Server) requestPeriodicSessionStatusPublish() {
-	s.queueSessionStatusPublish(true, true)
+	s.queueSessionStatusPublish(true)
 }
 
-func (s *Server) queueSessionStatusPublish(force, refreshWorkspaceAfterPublish bool) {
+func (s *Server) queueSessionStatusPublish(force bool) {
 	if s.publishSessionStatus == nil {
 		return
 	}
@@ -515,10 +573,9 @@ func (s *Server) queueSessionStatusPublish(force, refreshWorkspaceAfterPublish b
 		s.sessionStatusPublishQueue[len(s.sessionStatusPublishQueue)-1].waitingForInput != waitingForInput
 	if queued {
 		s.sessionStatusPublishQueue = append(s.sessionStatusPublishQueue, sessionStatusPublishRequest{
-			active:                       active,
-			waitingForInput:              waitingForInput,
-			refreshWorkspaceAfterPublish: refreshWorkspaceAfterPublish,
-			settledTurnID:                settledTurnID,
+			active:          active,
+			waitingForInput: waitingForInput,
+			settledTurnID:   settledTurnID,
 		})
 	}
 	s.sessionStatusMu.Unlock()
@@ -692,9 +749,6 @@ func (s *Server) runSessionStatusPublishes(ctx context.Context) {
 		} else {
 			s.completeSessionStatusPublish()
 			s.recordSettledActivity(request)
-			if request.refreshWorkspaceAfterPublish {
-				s.requestWorkspaceStatusRefresh()
-			}
 			// A drain report may have been withheld until in-flight activity was
 			// durably published; re-evaluate now that the queue has advanced.
 			if s.drainReportPending() {
@@ -720,7 +774,7 @@ func (s *Server) runSessionStatusPublishes(ctx context.Context) {
 }
 
 func (s *Server) runTurn(ctx context.Context, turn turnRequest) {
-	defer s.requestWorkspaceStatusRefresh()
+	defer s.requestWorkspaceStatusRefresh(true)
 	turnCtx, cancelTurn := context.WithCancelCause(ctx)
 	turnDone := make(chan struct{})
 	command := turn.command

--- a/internal/sessionruntime/server_test.go
+++ b/internal/sessionruntime/server_test.go
@@ -474,13 +474,16 @@ func TestRunTurnQueuesWorkspaceStatusRefresh(t *testing.T) {
 	server := NewServer(Config{}, journal, &fakeProvider{})
 	refreshStarted := make(chan struct{})
 	releaseRefresh := make(chan struct{})
-	server.refreshWorkspaceStatus = func(ctx context.Context) error {
+	server.refreshWorkspaceStatus = func(ctx context.Context, forceDiscovery bool) (WorkspaceStatus, error) {
+		if !forceDiscovery {
+			t.Error("turn completion did not force pull request discovery")
+		}
 		close(refreshStarted)
 		select {
 		case <-releaseRefresh:
-			return nil
+			return WorkspaceStatus{}, nil
 		case <-ctx.Done():
-			return ctx.Err()
+			return WorkspaceStatus{}, ctx.Err()
 		}
 	}
 	ctx, cancel := context.WithCancel(context.Background())
@@ -868,9 +871,9 @@ func TestServerQueuesStatusPublicationAfterWorkspaceRefresh(t *testing.T) {
 	defer journal.Close()
 	server := NewServer(Config{}, journal, &fakeProvider{})
 	refreshed := make(chan struct{})
-	server.refreshWorkspaceStatus = func(context.Context) error {
+	server.refreshWorkspaceStatus = func(context.Context, bool) (WorkspaceStatus, error) {
 		close(refreshed)
-		return nil
+		return WorkspaceStatus{}, nil
 	}
 	server.publishSessionStatus = func(context.Context, bool, bool) error { return nil }
 	ctx, cancel := context.WithCancel(context.Background())
@@ -883,7 +886,7 @@ func TestServerQueuesStatusPublicationAfterWorkspaceRefresh(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("initial Session status publication was not requested")
 	}
-	server.requestWorkspaceStatusRefresh()
+	server.requestWorkspaceStatusRefresh(true)
 	select {
 	case <-refreshed:
 	case <-time.After(time.Second):
@@ -971,22 +974,105 @@ func TestServerRetriesSessionStatusPublicationInOrder(t *testing.T) {
 	assertActivity(t, activity, false)
 }
 
-func TestServerRefreshesWorkspaceStatusAfterPeriodicPublication(t *testing.T) {
+func TestServerRefreshesWorkspaceStatusPeriodically(t *testing.T) {
 	journal := NewJournal()
 	defer journal.Close()
 	server := NewServer(Config{}, journal, &fakeProvider{})
-	server.sessionStatusRetryInterval = time.Hour
+	server.workspaceStatusRefreshInterval = 10 * time.Millisecond
+	refreshed := make(chan bool, 1)
+	server.refreshWorkspaceStatus = func(_ context.Context, forceDiscovery bool) (WorkspaceStatus, error) {
+		select {
+		case refreshed <- forceDiscovery:
+		default:
+		}
+		return WorkspaceStatus{}, nil
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go server.runWorkspaceStatusRefreshes(ctx)
+
+	select {
+	case forceDiscovery := <-refreshed:
+		if forceDiscovery {
+			t.Fatal("periodic workspace status refresh forced pull request discovery")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("workspace status was not refreshed periodically")
+	}
+}
+
+func TestPeriodicSessionStatusPublicationDoesNotRefreshWorkspace(t *testing.T) {
+	journal := NewJournal()
+	defer journal.Close()
+	server := NewServer(Config{}, journal, &fakeProvider{})
 	server.sessionStatusPublishInterval = 10 * time.Millisecond
-	server.publishSessionStatus = func(context.Context, bool, bool) error { return nil }
-	server.refreshWorkspaceStatus = func(context.Context) error { return nil }
+	published := make(chan struct{}, 1)
+	server.publishSessionStatus = func(context.Context, bool, bool) error {
+		published <- struct{}{}
+		return nil
+	}
+	server.refreshWorkspaceStatus = func(context.Context, bool) (WorkspaceStatus, error) {
+		t.Fatal("periodic Session status publication refreshed workspace status")
+		return WorkspaceStatus{}, nil
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go server.runSessionStatusPublishes(ctx)
 
 	select {
-	case <-server.workspaceStatusRefreshes:
+	case <-published:
 	case <-time.After(time.Second):
-		t.Fatal("periodic workspace status publication did not request a refresh")
+		t.Fatal("Session status was not published periodically")
+	}
+	select {
+	case <-server.workspaceStatusRefreshes:
+		t.Fatal("periodic Session status publication queued a workspace refresh")
+	default:
+	}
+}
+
+func TestWorkspaceStatusRefreshDelay(t *testing.T) {
+	server := NewServer(Config{}, NewJournal(), &fakeProvider{})
+	t.Cleanup(server.journal.Close)
+	server.workspaceStatusRefreshInterval = 5 * time.Minute
+	server.activeWorkspaceStatusRefreshInterval = 30 * time.Second
+
+	tests := []struct {
+		name   string
+		status WorkspaceStatus
+		want   time.Duration
+	}{
+		{name: "no pull request", want: 5 * time.Minute},
+		{
+			name: "queued pull request",
+			status: WorkspaceStatus{PullRequest: &kelos.SessionPullRequest{
+				State: kelos.SessionPullRequestStateQueued,
+			}},
+			want: 30 * time.Second,
+		},
+		{
+			name: "pending checks",
+			status: WorkspaceStatus{PullRequest: &kelos.SessionPullRequest{
+				State:  kelos.SessionPullRequestStateOpen,
+				Checks: &kelos.SessionPullRequestChecks{State: kelos.SessionPullRequestChecksStatePending, Total: 1},
+			}},
+			want: 30 * time.Second,
+		},
+		{
+			name: "successful checks",
+			status: WorkspaceStatus{PullRequest: &kelos.SessionPullRequest{
+				State:  kelos.SessionPullRequestStateOpen,
+				Checks: &kelos.SessionPullRequestChecks{State: kelos.SessionPullRequestChecksStateSuccess, Completed: 1, Total: 1},
+			}},
+			want: 5 * time.Minute,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := server.workspaceStatusRefreshDelay(tt.status); got != tt.want {
+				t.Fatalf("workspaceStatusRefreshDelay() = %s, want %s", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/sessionruntime/workspace_status.go
+++ b/internal/sessionruntime/workspace_status.go
@@ -6,11 +6,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -20,7 +20,7 @@ import (
 const (
 	workspaceStatusFileName       = "workspace-status.json"
 	workspaceStatusCommandTimeout = 5 * time.Second
-	pullRequestMergeQueueQuery    = `query($id:ID!){node(id:$id){... on PullRequest{mergeQueueEntry{headCommit{statusCheckRollup{contexts(first:100){nodes{__typename ... on CheckRun{status conclusion} ... on StatusContext{state}}}}}}}}}`
+	pullRequestStatusQuery        = `query($owner:String!,$repo:String!,$number:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$number){url state isDraft commits(last:1){nodes{commit{statusCheckRollup{contexts(first:100){nodes{__typename ... on CheckRun{status conclusion} ... on StatusContext{state}}}}}}} mergeQueueEntry{headCommit{statusCheckRollup{contexts(first:100){nodes{__typename ... on CheckRun{status conclusion} ... on StatusContext{state}}}}}}}}}`
 )
 
 // WorkspaceStatus describes the git work currently visible in a Session.
@@ -40,14 +40,36 @@ type githubStatusCheck struct {
 	State      string `json:"state"`
 }
 
+type githubRepository struct {
+	Host  string
+	Owner string
+	Name  string
+}
+
+type githubStatusCheckRollup struct {
+	Contexts struct {
+		Nodes []githubStatusCheck `json:"nodes"`
+	} `json:"contexts"`
+}
+
+type githubCommit struct {
+	StatusCheckRollup *githubStatusCheckRollup `json:"statusCheckRollup"`
+}
+
 type githubMergeQueueEntry struct {
-	HeadCommit *struct {
-		StatusCheckRollup *struct {
-			Contexts struct {
-				Nodes []githubStatusCheck `json:"nodes"`
-			} `json:"contexts"`
-		} `json:"statusCheckRollup"`
-	} `json:"headCommit"`
+	HeadCommit *githubCommit `json:"headCommit"`
+}
+
+type githubPullRequestStatus struct {
+	URL     string `json:"url"`
+	State   string `json:"state"`
+	IsDraft bool   `json:"isDraft"`
+	Commits struct {
+		Nodes []struct {
+			Commit githubCommit `json:"commit"`
+		} `json:"nodes"`
+	} `json:"commits"`
+	MergeQueueEntry *githubMergeQueueEntry `json:"mergeQueueEntry"`
 }
 
 type realWorkspaceStatusRunner struct{}
@@ -62,6 +84,10 @@ func (realWorkspaceStatusRunner) run(ctx context.Context, workingDir, name strin
 }
 
 func captureWorkspaceStatus(ctx context.Context, runner workspaceStatusRunner, workingDir string, environment []string) (WorkspaceStatus, error) {
+	return captureWorkspaceStatusFromPrevious(ctx, runner, workingDir, environment, WorkspaceStatus{}, true)
+}
+
+func captureWorkspaceStatusFromPrevious(ctx context.Context, runner workspaceStatusRunner, workingDir string, environment []string, previous WorkspaceStatus, forceDiscovery bool) (WorkspaceStatus, error) {
 	isGitWorkspace, err := isGitWorkspace(ctx, runner, workingDir)
 	if err != nil {
 		return WorkspaceStatus{}, err
@@ -77,17 +103,28 @@ func captureWorkspaceStatus(ctx context.Context, runner workspaceStatusRunner, w
 		return WorkspaceStatus{}, nil
 	}
 	status := WorkspaceStatus{Branch: branch}
-	headOwner, err := repositoryOwner(ctx, runner, workingDir, branch)
+	if !forceDiscovery && branch == previous.Branch && reusablePullRequest(previous.PullRequest) {
+		status.PullRequest, err = readPullRequestStatus(ctx, runner, workingDir, previous.PullRequest.URL)
+		if err != nil {
+			status.PullRequest = previous.PullRequest
+		}
+		return status, err
+	}
+	repository, headOwner, err := repositoryContext(ctx, runner, workingDir, branch)
 	if err != nil {
 		return status, err
 	}
-	status.PullRequest, err = findPullRequest(ctx, runner, workingDir, branch, "", headOwner)
+	status.PullRequest, err = findPullRequest(ctx, runner, workingDir, branch, repository, headOwner)
 	if err != nil {
 		return status, err
 	}
 	if status.PullRequest == nil {
 		if upstreamRepo := environmentValue(environment, "KELOS_UPSTREAM_REPO"); upstreamRepo != "" {
-			status.PullRequest, err = findPullRequest(ctx, runner, workingDir, branch, upstreamRepo, headOwner)
+			repository, parseErr := repositoryFromName(repository.Host, upstreamRepo)
+			if parseErr != nil {
+				return status, parseErr
+			}
+			status.PullRequest, err = findPullRequest(ctx, runner, workingDir, branch, repository, headOwner)
 			if err != nil {
 				return status, err
 			}
@@ -96,47 +133,67 @@ func captureWorkspaceStatus(ctx context.Context, runner workspaceStatusRunner, w
 	return status, nil
 }
 
-func repositoryOwner(ctx context.Context, runner workspaceStatusRunner, workingDir, branch string) (string, error) {
+func reusablePullRequest(pullRequest *kelos.SessionPullRequest) bool {
+	return pullRequest != nil && pullRequest.State != kelos.SessionPullRequestStateMerged && pullRequest.State != kelos.SessionPullRequestStateClosed
+}
+
+func repositoryContext(ctx context.Context, runner workspaceStatusRunner, workingDir, branch string) (githubRepository, string, error) {
 	remote, err := runner.run(ctx, workingDir, "git", "for-each-ref", "--format=%(push:remotename)", "refs/heads/"+branch)
 	if err != nil {
-		return "", fmt.Errorf("reading Session branch push remote: %w", err)
+		return githubRepository{}, "", fmt.Errorf("reading Session branch push remote: %w", err)
 	}
 	if remote == "" {
 		remote = "origin"
 	}
-	remoteURL, err := runner.run(ctx, workingDir, "git", "remote", "get-url", "--push", remote)
+	remoteURL, err := runner.run(ctx, workingDir, "git", "remote", "get-url", remote)
 	if err != nil {
-		return "", fmt.Errorf("reading Session branch push URL: %w", err)
+		return githubRepository{}, "", fmt.Errorf("reading Session repository URL: %w", err)
 	}
-	owner, err := repositoryOwnerFromRemoteURL(remoteURL)
+	repository, err := repositoryFromRemoteURL(remoteURL)
 	if err != nil {
-		return "", fmt.Errorf("identifying Session branch push repository: %w", err)
+		return githubRepository{}, "", fmt.Errorf("identifying Session repository: %w", err)
 	}
-	return owner, nil
+	remoteURL, err = runner.run(ctx, workingDir, "git", "remote", "get-url", "--push", remote)
+	if err != nil {
+		return githubRepository{}, "", fmt.Errorf("reading Session branch push URL: %w", err)
+	}
+	pushRepository, err := repositoryFromRemoteURL(remoteURL)
+	if err != nil {
+		return githubRepository{}, "", fmt.Errorf("identifying Session branch push repository: %w", err)
+	}
+	return repository, pushRepository.Owner, nil
 }
 
-func repositoryOwnerFromRemoteURL(remoteURL string) (string, error) {
+func repositoryFromRemoteURL(remoteURL string) (githubRepository, error) {
 	repositoryPath := remoteURL
+	host := ""
 	parsed, err := url.Parse(remoteURL)
 	if err == nil && parsed.Scheme != "" {
 		repositoryPath = parsed.Path
+		host = parsed.Hostname()
 	} else if prefix, path, ok := strings.Cut(remoteURL, ":"); ok && strings.Contains(prefix, "@") {
 		repositoryPath = path
+		host = strings.TrimPrefix(prefix, "git@")
 	}
 	repositoryPath = strings.Trim(strings.TrimSuffix(repositoryPath, ".git"), "/")
 	parts := strings.Split(repositoryPath, "/")
-	if len(parts) < 2 || parts[len(parts)-2] == "" || parts[len(parts)-1] == "" {
-		return "", fmt.Errorf("invalid remote URL %q", remoteURL)
+	if host == "" || len(parts) < 2 || parts[len(parts)-2] == "" || parts[len(parts)-1] == "" {
+		return githubRepository{}, fmt.Errorf("invalid remote URL %q", remoteURL)
 	}
-	return parts[len(parts)-2], nil
+	return githubRepository{Host: host, Owner: parts[len(parts)-2], Name: parts[len(parts)-1]}, nil
 }
 
-func findPullRequest(ctx context.Context, runner workspaceStatusRunner, workingDir, branch, repo, headOwner string) (*kelos.SessionPullRequest, error) {
-	args := []string{"pr", "list", "--head", branch, "--state", "all", "--json", "id,url,headRepositoryOwner,state,isDraft,statusCheckRollup", "--limit", "100"}
-	if repo != "" {
-		args = append(args, "--repo", repo)
+func repositoryFromName(host, name string) (githubRepository, error) {
+	parts := strings.Split(strings.Trim(name, "/"), "/")
+	if host == "" || len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return githubRepository{}, fmt.Errorf("invalid GitHub repository %q", name)
 	}
-	output, err := runner.run(ctx, workingDir, "gh", args...)
+	return githubRepository{Host: host, Owner: parts[0], Name: parts[1]}, nil
+}
+
+func findPullRequest(ctx context.Context, runner workspaceStatusRunner, workingDir, branch string, repository githubRepository, headOwner string) (*kelos.SessionPullRequest, error) {
+	endpoint := fmt.Sprintf("repos/%s/%s/pulls", repository.Owner, repository.Name)
+	output, err := runner.run(ctx, workingDir, "gh", "api", "--hostname", repository.Host, "--method", "GET", endpoint, "-f", "state=all", "-f", "head="+headOwner+":"+branch, "-F", "per_page=1")
 	if err != nil {
 		return nil, fmt.Errorf("listing pull requests: %w", err)
 	}
@@ -144,61 +201,95 @@ func findPullRequest(ctx context.Context, runner workspaceStatusRunner, workingD
 		return nil, nil
 	}
 	var pullRequests []struct {
-		ID                  string `json:"id"`
-		URL                 string `json:"url"`
-		State               string `json:"state"`
-		IsDraft             bool   `json:"isDraft"`
-		HeadRepositoryOwner struct {
-			Login string `json:"login"`
-		} `json:"headRepositoryOwner"`
-		StatusCheckRollup []githubStatusCheck `json:"statusCheckRollup"`
+		URL      string  `json:"html_url"`
+		State    string  `json:"state"`
+		Draft    bool    `json:"draft"`
+		MergedAt *string `json:"merged_at"`
 	}
 	if err := json.Unmarshal([]byte(output), &pullRequests); err != nil {
 		return nil, fmt.Errorf("decoding pull requests: %w", err)
 	}
-	for _, pullRequest := range pullRequests {
-		if strings.EqualFold(pullRequest.HeadRepositoryOwner.Login, headOwner) {
-			state, err := sessionPullRequestState(pullRequest.State, pullRequest.IsDraft)
-			if err != nil {
-				return nil, err
-			}
-			checks := pullRequest.StatusCheckRollup
-			mergeQueueEntry, err := findPullRequestMergeQueueEntry(ctx, runner, workingDir, pullRequest.ID)
-			if err != nil {
-				log.Printf("Unable to read pull request merge queue, using pull request checks error=%v", err)
-			} else if mergeQueueEntry != nil {
-				state = kelos.SessionPullRequestStateQueued
-				checks = nil
-				if mergeQueueEntry.HeadCommit != nil && mergeQueueEntry.HeadCommit.StatusCheckRollup != nil {
-					checks = mergeQueueEntry.HeadCommit.StatusCheckRollup.Contexts.Nodes
-				}
-			}
-			return &kelos.SessionPullRequest{
-				URL:    pullRequest.URL,
-				State:  state,
-				Checks: sessionPullRequestChecks(checks),
-			}, nil
-		}
+	if len(pullRequests) == 0 {
+		return nil, nil
 	}
-	return nil, nil
+	pullRequest := pullRequests[0]
+	state := strings.ToUpper(pullRequest.State)
+	if pullRequest.MergedAt != nil {
+		state = "MERGED"
+	}
+	fallbackState, err := sessionPullRequestState(state, pullRequest.Draft)
+	if err != nil {
+		return nil, err
+	}
+	fallback := &kelos.SessionPullRequest{URL: pullRequest.URL, State: fallbackState}
+	status, err := readPullRequestStatus(ctx, runner, workingDir, pullRequest.URL)
+	if err != nil {
+		return fallback, err
+	}
+	return status, nil
 }
 
-func findPullRequestMergeQueueEntry(ctx context.Context, runner workspaceStatusRunner, workingDir, pullRequestID string) (*githubMergeQueueEntry, error) {
-	output, err := runner.run(ctx, workingDir, "gh", "api", "graphql", "-F", "id="+pullRequestID, "-f", "query="+pullRequestMergeQueueQuery)
+func readPullRequestStatus(ctx context.Context, runner workspaceStatusRunner, workingDir, pullRequestURL string) (*kelos.SessionPullRequest, error) {
+	repository, number, err := pullRequestCoordinatesFromURL(pullRequestURL)
 	if err != nil {
-		return nil, fmt.Errorf("reading pull request merge queue: %w", err)
+		return nil, err
+	}
+	output, err := runner.run(ctx, workingDir, "gh", "api", "--hostname", repository.Host, "graphql", "-f", "owner="+repository.Owner, "-f", "repo="+repository.Name, "-F", "number="+strconv.Itoa(number), "-f", "query="+pullRequestStatusQuery)
+	if err != nil {
+		return nil, fmt.Errorf("reading pull request status: %w", err)
 	}
 	var response struct {
 		Data struct {
-			Node struct {
-				MergeQueueEntry *githubMergeQueueEntry `json:"mergeQueueEntry"`
-			} `json:"node"`
+			Repository struct {
+				PullRequest *githubPullRequestStatus `json:"pullRequest"`
+			} `json:"repository"`
 		} `json:"data"`
 	}
 	if err := json.Unmarshal([]byte(output), &response); err != nil {
-		return nil, fmt.Errorf("decoding pull request merge queue: %w", err)
+		return nil, fmt.Errorf("decoding pull request status: %w", err)
 	}
-	return response.Data.Node.MergeQueueEntry, nil
+	pullRequest := response.Data.Repository.PullRequest
+	if pullRequest == nil {
+		return nil, fmt.Errorf("pull request %s not found", pullRequestURL)
+	}
+	state, err := sessionPullRequestState(pullRequest.State, pullRequest.IsDraft)
+	if err != nil {
+		return nil, err
+	}
+	var checks []githubStatusCheck
+	if len(pullRequest.Commits.Nodes) > 0 {
+		if rollup := pullRequest.Commits.Nodes[0].Commit.StatusCheckRollup; rollup != nil {
+			checks = rollup.Contexts.Nodes
+		}
+	}
+	if pullRequest.MergeQueueEntry != nil {
+		state = kelos.SessionPullRequestStateQueued
+		checks = nil
+		if pullRequest.MergeQueueEntry.HeadCommit != nil && pullRequest.MergeQueueEntry.HeadCommit.StatusCheckRollup != nil {
+			checks = pullRequest.MergeQueueEntry.HeadCommit.StatusCheckRollup.Contexts.Nodes
+		}
+	}
+	return &kelos.SessionPullRequest{
+		URL:    pullRequest.URL,
+		State:  state,
+		Checks: sessionPullRequestChecks(checks),
+	}, nil
+}
+
+func pullRequestCoordinatesFromURL(pullRequestURL string) (githubRepository, int, error) {
+	parsed, err := url.Parse(pullRequestURL)
+	if err != nil || parsed.Hostname() == "" {
+		return githubRepository{}, 0, fmt.Errorf("invalid pull request URL %q", pullRequestURL)
+	}
+	parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	if len(parts) != 4 || parts[2] != "pull" {
+		return githubRepository{}, 0, fmt.Errorf("invalid pull request URL %q", pullRequestURL)
+	}
+	number, err := strconv.Atoi(parts[3])
+	if err != nil || number < 1 {
+		return githubRepository{}, 0, fmt.Errorf("invalid pull request URL %q", pullRequestURL)
+	}
+	return githubRepository{Host: parsed.Hostname(), Owner: parts[0], Name: parts[1]}, number, nil
 }
 
 func sessionPullRequestChecks(checks []githubStatusCheck) *kelos.SessionPullRequestChecks {
@@ -279,22 +370,26 @@ func environmentValue(environment []string, name string) string {
 	return ""
 }
 
-func refreshWorkspaceStatus(ctx context.Context, stateDir, workingDir string, environment []string) (WorkspaceStatus, error) {
-	return refreshWorkspaceStatusWithRunner(ctx, realWorkspaceStatusRunner{}, stateDir, workingDir, environment)
+func refreshWorkspaceStatus(ctx context.Context, stateDir, workingDir string, environment []string, forceDiscovery bool) (WorkspaceStatus, error) {
+	return refreshWorkspaceStatusWithRunner(ctx, realWorkspaceStatusRunner{}, stateDir, workingDir, environment, forceDiscovery)
 }
 
-func refreshWorkspaceStatusWithRunner(ctx context.Context, runner workspaceStatusRunner, stateDir, workingDir string, environment []string) (WorkspaceStatus, error) {
+func refreshWorkspaceStatusWithRunner(ctx context.Context, runner workspaceStatusRunner, stateDir, workingDir string, environment []string, forceDiscovery bool) (WorkspaceStatus, error) {
 	previous, err := readRecordedWorkspaceStatus(stateDir)
 	if err != nil {
 		return WorkspaceStatus{}, err
 	}
-	status, captureErr := captureWorkspaceStatus(ctx, runner, workingDir, environment)
+	status, captureErr := captureWorkspaceStatusFromPrevious(ctx, runner, workingDir, environment, previous, forceDiscovery)
 	if captureErr != nil {
 		if status.Branch == "" {
 			return previous, captureErr
 		}
 		if status.Branch == previous.Branch {
-			status.PullRequest = previous.PullRequest
+			if status.PullRequest == nil {
+				status.PullRequest = previous.PullRequest
+			} else if previous.PullRequest != nil && status.PullRequest.URL == previous.PullRequest.URL && status.PullRequest.Checks == nil {
+				status.PullRequest.Checks = previous.PullRequest.Checks
+			}
 		}
 	}
 	if err := writeWorkspaceStatus(stateDir, status); err != nil {

--- a/internal/sessionruntime/workspace_status_test.go
+++ b/internal/sessionruntime/workspace_status_test.go
@@ -30,17 +30,36 @@ func (r fakeWorkspaceStatusRunner) run(_ context.Context, workingDir, name strin
 	return result.output, result.err
 }
 
+func workspaceStatusCommands(branch, remote, fetchURL, pushURL string) map[string]workspaceStatusResult {
+	if remote == "" {
+		remote = "origin"
+	}
+	return map[string]workspaceStatusResult{
+		"/repo: git rev-parse --is-inside-work-tree":                               {output: "true"},
+		"/repo: git branch --show-current":                                         {output: branch},
+		"/repo: git for-each-ref --format=%(push:remotename) refs/heads/" + branch: {output: remote},
+		"/repo: git remote get-url " + remote:                                      {output: fetchURL},
+		"/repo: git remote get-url --push " + remote:                               {output: pushURL},
+	}
+}
+
+func pullRequestDiscoveryCommand(repository, head string) string {
+	return "/repo: gh api --hostname github.com --method GET repos/" + repository + "/pulls -f state=all -f head=" + head + " -F per_page=1"
+}
+
+func pullRequestStatusCommand(owner, repository, number string) string {
+	return "/repo: gh api --hostname github.com graphql -f owner=" + owner + " -f repo=" + repository + " -F number=" + number + " -f query=" + pullRequestStatusQuery
+}
+
 func TestCaptureWorkspaceStatus(t *testing.T) {
-	runner := fakeWorkspaceStatusRunner{commands: map[string]workspaceStatusResult{
-		"/repo: git rev-parse --is-inside-work-tree":                                    {output: "true"},
-		"/repo: git branch --show-current":                                              {output: "feature/status"},
-		"/repo: git for-each-ref --format=%(push:remotename) refs/heads/feature/status": {output: ""},
-		"/repo: git remote get-url --push origin":                                       {output: "https://github.com/kelos-dev/kelos.git"},
-		"/repo: gh pr list --head feature/status --state all --json id,url,headRepositoryOwner,state,isDraft,statusCheckRollup --limit 100": {
-			output: `[{"id":"PR_42","url":"https://github.com/kelos-dev/kelos/pull/42","state":"OPEN","isDraft":false,"headRepositoryOwner":{"login":"kelos-dev"},"statusCheckRollup":[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"},{"__typename":"CheckRun","status":"IN_PROGRESS","conclusion":""},{"__typename":"StatusContext","state":"SUCCESS"}]}]`,
-		},
-		"/repo: gh api graphql -F id=PR_42 -f query=" + pullRequestMergeQueueQuery: {output: `{"data":{"node":{"mergeQueueEntry":null}}}`},
-	}}
+	commands := workspaceStatusCommands("feature/status", "origin", "https://github.com/kelos-dev/kelos.git", "https://github.com/kelos-dev/kelos.git")
+	commands[pullRequestDiscoveryCommand("kelos-dev/kelos", "kelos-dev:feature/status")] = workspaceStatusResult{
+		output: `[{"html_url":"https://github.com/kelos-dev/kelos/pull/42","state":"open","draft":false,"merged_at":null}]`,
+	}
+	commands[pullRequestStatusCommand("kelos-dev", "kelos", "42")] = workspaceStatusResult{
+		output: `{"data":{"repository":{"pullRequest":{"url":"https://github.com/kelos-dev/kelos/pull/42","state":"OPEN","isDraft":false,"commits":{"nodes":[{"commit":{"statusCheckRollup":{"contexts":{"nodes":[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"},{"__typename":"CheckRun","status":"IN_PROGRESS","conclusion":""},{"__typename":"StatusContext","state":"SUCCESS"}]}}}}]},"mergeQueueEntry":null}}}}`,
+	}
+	runner := fakeWorkspaceStatusRunner{commands: commands}
 
 	got, err := captureWorkspaceStatus(context.Background(), runner, "/repo", nil)
 	if err != nil {
@@ -64,18 +83,14 @@ func TestCaptureWorkspaceStatus(t *testing.T) {
 }
 
 func TestCaptureWorkspaceStatusUsesMergeQueueChecks(t *testing.T) {
-	runner := fakeWorkspaceStatusRunner{commands: map[string]workspaceStatusResult{
-		"/repo: git rev-parse --is-inside-work-tree":                                    {output: "true"},
-		"/repo: git branch --show-current":                                              {output: "feature/status"},
-		"/repo: git for-each-ref --format=%(push:remotename) refs/heads/feature/status": {output: ""},
-		"/repo: git remote get-url --push origin":                                       {output: "https://github.com/kelos-dev/kelos.git"},
-		"/repo: gh pr list --head feature/status --state all --json id,url,headRepositoryOwner,state,isDraft,statusCheckRollup --limit 100": {
-			output: `[{"id":"PR_42","url":"https://github.com/kelos-dev/kelos/pull/42","state":"OPEN","isDraft":false,"headRepositoryOwner":{"login":"kelos-dev"},"statusCheckRollup":[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}]}]`,
-		},
-		"/repo: gh api graphql -F id=PR_42 -f query=" + pullRequestMergeQueueQuery: {
-			output: `{"data":{"node":{"mergeQueueEntry":{"headCommit":{"statusCheckRollup":{"contexts":{"nodes":[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"},{"__typename":"CheckRun","status":"IN_PROGRESS","conclusion":""}]}}}}}}}`,
-		},
-	}}
+	commands := workspaceStatusCommands("feature/status", "origin", "https://github.com/kelos-dev/kelos.git", "https://github.com/kelos-dev/kelos.git")
+	commands[pullRequestDiscoveryCommand("kelos-dev/kelos", "kelos-dev:feature/status")] = workspaceStatusResult{
+		output: `[{"html_url":"https://github.com/kelos-dev/kelos/pull/42","state":"open","draft":false,"merged_at":null}]`,
+	}
+	commands[pullRequestStatusCommand("kelos-dev", "kelos", "42")] = workspaceStatusResult{
+		output: `{"data":{"repository":{"pullRequest":{"url":"https://github.com/kelos-dev/kelos/pull/42","state":"OPEN","isDraft":false,"commits":{"nodes":[{"commit":{"statusCheckRollup":{"contexts":{"nodes":[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}]}}}}]},"mergeQueueEntry":{"headCommit":{"statusCheckRollup":{"contexts":{"nodes":[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"},{"__typename":"CheckRun","status":"IN_PROGRESS","conclusion":""}]}}}}}}}}`,
+	}
+	runner := fakeWorkspaceStatusRunner{commands: commands}
 
 	got, err := captureWorkspaceStatus(context.Background(), runner, "/repo", nil)
 	if err != nil {
@@ -98,32 +113,23 @@ func TestCaptureWorkspaceStatusUsesMergeQueueChecks(t *testing.T) {
 	}
 }
 
-func TestCaptureWorkspaceStatusUsesPullRequestChecksOnMergeQueueLookupError(t *testing.T) {
-	runner := fakeWorkspaceStatusRunner{commands: map[string]workspaceStatusResult{
-		"/repo: git rev-parse --is-inside-work-tree":                                    {output: "true"},
-		"/repo: git branch --show-current":                                              {output: "feature/status"},
-		"/repo: git for-each-ref --format=%(push:remotename) refs/heads/feature/status": {output: ""},
-		"/repo: git remote get-url --push origin":                                       {output: "https://github.com/kelos-dev/kelos.git"},
-		"/repo: gh pr list --head feature/status --state all --json id,url,headRepositoryOwner,state,isDraft,statusCheckRollup --limit 100": {
-			output: `[{"id":"PR_42","url":"https://github.com/kelos-dev/kelos/pull/42","state":"OPEN","isDraft":false,"headRepositoryOwner":{"login":"kelos-dev"},"statusCheckRollup":[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}]}]`,
-		},
-		"/repo: gh api graphql -F id=PR_42 -f query=" + pullRequestMergeQueueQuery: {err: errors.New("merge queue unavailable")},
-	}}
+func TestCaptureWorkspaceStatusReturnsDiscoveredPullRequestOnStatusLookupError(t *testing.T) {
+	commands := workspaceStatusCommands("feature/status", "origin", "https://github.com/kelos-dev/kelos.git", "https://github.com/kelos-dev/kelos.git")
+	commands[pullRequestDiscoveryCommand("kelos-dev/kelos", "kelos-dev:feature/status")] = workspaceStatusResult{
+		output: `[{"html_url":"https://github.com/kelos-dev/kelos/pull/42","state":"open","draft":false,"merged_at":null}]`,
+	}
+	commands[pullRequestStatusCommand("kelos-dev", "kelos", "42")] = workspaceStatusResult{err: errors.New("status unavailable")}
+	runner := fakeWorkspaceStatusRunner{commands: commands}
 
 	got, err := captureWorkspaceStatus(context.Background(), runner, "/repo", nil)
-	if err != nil {
-		t.Fatal(err)
+	if err == nil {
+		t.Fatal("captureWorkspaceStatus() error = nil, want status lookup error")
 	}
 	want := WorkspaceStatus{
 		Branch: "feature/status",
 		PullRequest: &kelos.SessionPullRequest{
 			URL:   "https://github.com/kelos-dev/kelos/pull/42",
 			State: kelos.SessionPullRequestStateOpen,
-			Checks: &kelos.SessionPullRequestChecks{
-				State:     kelos.SessionPullRequestChecksStateSuccess,
-				Completed: 1,
-				Total:     1,
-			},
 		},
 	}
 	if !reflect.DeepEqual(got, want) {
@@ -132,16 +138,14 @@ func TestCaptureWorkspaceStatusUsesPullRequestChecksOnMergeQueueLookupError(t *t
 }
 
 func TestCaptureWorkspaceStatusUsesBranchPushRemote(t *testing.T) {
-	runner := fakeWorkspaceStatusRunner{commands: map[string]workspaceStatusResult{
-		"/repo: git rev-parse --is-inside-work-tree":                                    {output: "true"},
-		"/repo: git branch --show-current":                                              {output: "feature/status"},
-		"/repo: git for-each-ref --format=%(push:remotename) refs/heads/feature/status": {output: "fork"},
-		"/repo: git remote get-url --push fork":                                         {output: "git@github.com:gjkim/kelos.git"},
-		"/repo: gh pr list --head feature/status --state all --json id,url,headRepositoryOwner,state,isDraft,statusCheckRollup --limit 100": {
-			output: `[{"id":"PR_42","url":"https://github.com/kelos-dev/kelos/pull/42","state":"OPEN","isDraft":false,"headRepositoryOwner":{"login":"gjkim"}}]`,
-		},
-		"/repo: gh api graphql -F id=PR_42 -f query=" + pullRequestMergeQueueQuery: {output: `{"data":{"node":{"mergeQueueEntry":null}}}`},
-	}}
+	commands := workspaceStatusCommands("feature/status", "fork", "https://github.com/kelos-dev/kelos.git", "git@github.com:gjkim/kelos.git")
+	commands[pullRequestDiscoveryCommand("kelos-dev/kelos", "gjkim:feature/status")] = workspaceStatusResult{
+		output: `[{"html_url":"https://github.com/kelos-dev/kelos/pull/42","state":"open","draft":false,"merged_at":null}]`,
+	}
+	commands[pullRequestStatusCommand("kelos-dev", "kelos", "42")] = workspaceStatusResult{
+		output: `{"data":{"repository":{"pullRequest":{"url":"https://github.com/kelos-dev/kelos/pull/42","state":"OPEN","isDraft":false,"commits":{"nodes":[]},"mergeQueueEntry":null}}}}`,
+	}
+	runner := fakeWorkspaceStatusRunner{commands: commands}
 
 	got, err := captureWorkspaceStatus(context.Background(), runner, "/repo", nil)
 	if err != nil {
@@ -176,19 +180,15 @@ func TestCaptureWorkspaceStatusWithoutGitRepository(t *testing.T) {
 }
 
 func TestCaptureWorkspaceStatusUsesUpstreamRepository(t *testing.T) {
-	runner := fakeWorkspaceStatusRunner{commands: map[string]workspaceStatusResult{
-		"/repo: git rev-parse --is-inside-work-tree":                                    {output: "true"},
-		"/repo: git branch --show-current":                                              {output: "feature/status"},
-		"/repo: git for-each-ref --format=%(push:remotename) refs/heads/feature/status": {output: "origin"},
-		"/repo: git remote get-url --push origin":                                       {output: "git@github.com:gjkim/kelos.git"},
-		"/repo: gh pr list --head feature/status --state all --json id,url,headRepositoryOwner,state,isDraft,statusCheckRollup --limit 100": {
-			output: "[]",
-		},
-		"/repo: gh pr list --head feature/status --state all --json id,url,headRepositoryOwner,state,isDraft,statusCheckRollup --limit 100 --repo kelos-dev/kelos": {
-			output: `[{"id":"PR_41","url":"https://github.com/kelos-dev/kelos/pull/41","state":"OPEN","isDraft":false,"headRepositoryOwner":{"login":"another-fork"}},{"id":"PR_42","url":"https://github.com/kelos-dev/kelos/pull/42","state":"OPEN","isDraft":true,"headRepositoryOwner":{"login":"gjkim"}}]`,
-		},
-		"/repo: gh api graphql -F id=PR_42 -f query=" + pullRequestMergeQueueQuery: {output: `{"data":{"node":{"mergeQueueEntry":null}}}`},
-	}}
+	commands := workspaceStatusCommands("feature/status", "origin", "git@github.com:gjkim/kelos.git", "git@github.com:gjkim/kelos.git")
+	commands[pullRequestDiscoveryCommand("gjkim/kelos", "gjkim:feature/status")] = workspaceStatusResult{output: "[]"}
+	commands[pullRequestDiscoveryCommand("kelos-dev/kelos", "gjkim:feature/status")] = workspaceStatusResult{
+		output: `[{"html_url":"https://github.com/kelos-dev/kelos/pull/42","state":"open","draft":true,"merged_at":null}]`,
+	}
+	commands[pullRequestStatusCommand("kelos-dev", "kelos", "42")] = workspaceStatusResult{
+		output: `{"data":{"repository":{"pullRequest":{"url":"https://github.com/kelos-dev/kelos/pull/42","state":"OPEN","isDraft":true,"commits":{"nodes":[]},"mergeQueueEntry":null}}}}`,
+	}
+	runner := fakeWorkspaceStatusRunner{commands: commands}
 
 	got, err := captureWorkspaceStatus(context.Background(), runner, "/repo", []string{"KELOS_UPSTREAM_REPO=kelos-dev/kelos"})
 	if err != nil {
@@ -222,10 +222,10 @@ func TestRefreshWorkspaceStatusPreservesPullRequestOnLookupError(t *testing.T) {
 		"/repo: git rev-parse --is-inside-work-tree":                                    {output: "true"},
 		"/repo: git branch --show-current":                                              {output: "feature/status"},
 		"/repo: git for-each-ref --format=%(push:remotename) refs/heads/feature/status": {output: "origin"},
-		"/repo: git remote get-url --push origin":                                       {err: errors.New("temporary git failure")},
+		"/repo: git remote get-url origin":                                              {err: errors.New("temporary git failure")},
 	}}
 
-	_, err := refreshWorkspaceStatusWithRunner(context.Background(), runner, stateDir, "/repo", nil)
+	_, err := refreshWorkspaceStatusWithRunner(context.Background(), runner, stateDir, "/repo", nil, true)
 	if err == nil {
 		t.Fatal("refreshWorkspaceStatusWithRunner() error = nil, want GitHub failure")
 	}
@@ -254,7 +254,7 @@ func TestRefreshWorkspaceStatusReturnsRecordedStatusOnGitError(t *testing.T) {
 		"/repo: git rev-parse --is-inside-work-tree": {err: errors.New("temporary git failure")},
 	}}
 
-	got, err := refreshWorkspaceStatusWithRunner(context.Background(), runner, stateDir, "/repo", nil)
+	got, err := refreshWorkspaceStatusWithRunner(context.Background(), runner, stateDir, "/repo", nil, true)
 	if err == nil {
 		t.Fatal("refreshWorkspaceStatusWithRunner() error = nil, want Git failure")
 	}
@@ -281,17 +281,11 @@ func TestRefreshWorkspaceStatusClearsPullRequestAfterSuccessfulLookup(t *testing
 	}); err != nil {
 		t.Fatal(err)
 	}
-	runner := fakeWorkspaceStatusRunner{commands: map[string]workspaceStatusResult{
-		"/repo: git rev-parse --is-inside-work-tree":                                    {output: "true"},
-		"/repo: git branch --show-current":                                              {output: "feature/status"},
-		"/repo: git for-each-ref --format=%(push:remotename) refs/heads/feature/status": {output: "origin"},
-		"/repo: git remote get-url --push origin":                                       {output: "https://github.com/kelos-dev/kelos.git"},
-		"/repo: gh pr list --head feature/status --state all --json id,url,headRepositoryOwner,state,isDraft,statusCheckRollup --limit 100": {
-			output: "[]",
-		},
-	}}
+	commands := workspaceStatusCommands("feature/status", "origin", "https://github.com/kelos-dev/kelos.git", "https://github.com/kelos-dev/kelos.git")
+	commands[pullRequestDiscoveryCommand("kelos-dev/kelos", "kelos-dev:feature/status")] = workspaceStatusResult{output: "[]"}
+	runner := fakeWorkspaceStatusRunner{commands: commands}
 
-	if _, err := refreshWorkspaceStatusWithRunner(context.Background(), runner, stateDir, "/repo", nil); err != nil {
+	if _, err := refreshWorkspaceStatusWithRunner(context.Background(), runner, stateDir, "/repo", nil, false); err != nil {
 		t.Fatal(err)
 	}
 	got, err := readRecordedWorkspaceStatus(stateDir)
@@ -301,6 +295,46 @@ func TestRefreshWorkspaceStatusClearsPullRequestAfterSuccessfulLookup(t *testing
 	want := WorkspaceStatus{Branch: "feature/status"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("recorded workspace status = %#v, want %#v", got, want)
+	}
+}
+
+func TestRefreshWorkspaceStatusUsesCachedPullRequest(t *testing.T) {
+	stateDir := t.TempDir()
+	if err := writeWorkspaceStatus(stateDir, WorkspaceStatus{
+		Branch: "feature/status",
+		PullRequest: &kelos.SessionPullRequest{
+			URL:   "https://github.com/kelos-dev/kelos/pull/42",
+			State: kelos.SessionPullRequestStateOpen,
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	runner := fakeWorkspaceStatusRunner{commands: map[string]workspaceStatusResult{
+		"/repo: git rev-parse --is-inside-work-tree": {output: "true"},
+		"/repo: git branch --show-current":           {output: "feature/status"},
+		pullRequestStatusCommand("kelos-dev", "kelos", "42"): {
+			output: `{"data":{"repository":{"pullRequest":{"url":"https://github.com/kelos-dev/kelos/pull/42","state":"OPEN","isDraft":false,"commits":{"nodes":[{"commit":{"statusCheckRollup":{"contexts":{"nodes":[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"}]}}}}]},"mergeQueueEntry":null}}}}`,
+		},
+	}}
+
+	got, err := refreshWorkspaceStatusWithRunner(context.Background(), runner, stateDir, "/repo", nil, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := WorkspaceStatus{
+		Branch: "feature/status",
+		PullRequest: &kelos.SessionPullRequest{
+			URL:   "https://github.com/kelos-dev/kelos/pull/42",
+			State: kelos.SessionPullRequestStateOpen,
+			Checks: &kelos.SessionPullRequestChecks{
+				State:     kelos.SessionPullRequestChecksStateSuccess,
+				Completed: 1,
+				Total:     1,
+			},
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("refreshWorkspaceStatusWithRunner() = %#v, want %#v", got, want)
 	}
 }
 
@@ -386,28 +420,44 @@ func TestSessionPullRequestChecks(t *testing.T) {
 	}
 }
 
-func TestRepositoryOwnerFromRemoteURL(t *testing.T) {
+func TestRepositoryFromRemoteURL(t *testing.T) {
 	tests := []struct {
 		name      string
 		remoteURL string
-		want      string
+		want      githubRepository
 		wantError bool
 	}{
-		{name: "HTTPS", remoteURL: "https://github.com/kelos-dev/kelos.git", want: "kelos-dev"},
-		{name: "SSH", remoteURL: "git@github.com:gjkim/kelos.git", want: "gjkim"},
-		{name: "SSH URL", remoteURL: "ssh://git@github.example.com/team/kelos.git", want: "team"},
+		{name: "HTTPS", remoteURL: "https://github.com/kelos-dev/kelos.git", want: githubRepository{Host: "github.com", Owner: "kelos-dev", Name: "kelos"}},
+		{name: "SSH", remoteURL: "git@github.com:gjkim/kelos.git", want: githubRepository{Host: "github.com", Owner: "gjkim", Name: "kelos"}},
+		{name: "SSH URL", remoteURL: "ssh://git@github.example.com/team/kelos.git", want: githubRepository{Host: "github.example.com", Owner: "team", Name: "kelos"}},
 		{name: "invalid", remoteURL: "kelos", wantError: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := repositoryOwnerFromRemoteURL(tt.remoteURL)
+			got, err := repositoryFromRemoteURL(tt.remoteURL)
 			if (err != nil) != tt.wantError {
-				t.Fatalf("repositoryOwnerFromRemoteURL() error = %v, wantError %t", err, tt.wantError)
+				t.Fatalf("repositoryFromRemoteURL() error = %v, wantError %t", err, tt.wantError)
 			}
-			if got != tt.want {
-				t.Fatalf("repositoryOwnerFromRemoteURL() = %q, want %q", got, tt.want)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("repositoryFromRemoteURL() = %#v, want %#v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestPullRequestCoordinatesFromURL(t *testing.T) {
+	repository, number, err := pullRequestCoordinatesFromURL("https://github.example.com/team/kelos/pull/42")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := (githubRepository{Host: "github.example.com", Owner: "team", Name: "kelos"}); !reflect.DeepEqual(repository, want) {
+		t.Fatalf("pullRequestCoordinatesFromURL() repository = %#v, want %#v", repository, want)
+	}
+	if number != 42 {
+		t.Fatalf("pullRequestCoordinatesFromURL() number = %d, want 42", number)
+	}
+	if _, _, err := pullRequestCoordinatesFromURL("https://github.com/team/kelos/issues/42"); err == nil {
+		t.Fatal("pullRequestCoordinatesFromURL() error = nil, want invalid URL error")
 	}
 }
 

--- a/test/e2e/fixtures/fake-gh.sh
+++ b/test/e2e/fixtures/fake-gh.sh
@@ -1,9 +1,19 @@
 #!/bin/sh
 set -eu
 
-if [ "$#" -lt 2 ] || [ "$1" != "pr" ] || [ "$2" != "list" ]; then
-  echo "Unsupported gh command: $*" >&2
-  exit 2
+if [ "$#" -eq 12 ] && [ "$1" = "api" ] && [ "$2" = "--hostname" ] && [ "$3" = "github.com" ] && [ "$4" = "--method" ] && [ "$5" = "GET" ] && [ "$6" = "repos/kelos-dev/kelos/pulls" ] && [ "$7" = "-f" ] && [ "$8" = "state=all" ] && [ "$9" = "-f" ] && [ "${10}" = "head=kelos-dev:agent/session-status" ] && [ "${11}" = "-F" ] && [ "${12}" = "per_page=1" ]; then
+  printf '%s\n' '[{"html_url":"https://github.com/kelos-dev/kelos/pull/42","state":"open","draft":false,"merged_at":null}]'
+  exit 0
 fi
 
-printf '%s\n' '[{"url":"https://github.com/kelos-dev/kelos/pull/42","state":"OPEN","isDraft":false,"headRepositoryOwner":{"login":"kelos-dev"},"statusCheckRollup":[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"},{"__typename":"CheckRun","status":"IN_PROGRESS","conclusion":""},{"__typename":"StatusContext","state":"SUCCESS"}]}]'
+if [ "$#" -eq 12 ] && [ "$1" = "api" ] && [ "$2" = "--hostname" ] && [ "$3" = "github.com" ] && [ "$4" = "graphql" ] && [ "$5" = "-f" ] && [ "$6" = "owner=kelos-dev" ] && [ "$7" = "-f" ] && [ "$8" = "repo=kelos" ] && [ "$9" = "-F" ] && [ "${10}" = "number=42" ] && [ "${11}" = "-f" ]; then
+  case "${12}" in
+    query=*commits*mergeQueueEntry*)
+      printf '%s\n' '{"data":{"repository":{"pullRequest":{"url":"https://github.com/kelos-dev/kelos/pull/42","state":"OPEN","isDraft":false,"commits":{"nodes":[{"commit":{"statusCheckRollup":{"contexts":{"nodes":[{"__typename":"CheckRun","status":"COMPLETED","conclusion":"SUCCESS"},{"__typename":"CheckRun","status":"IN_PROGRESS","conclusion":""},{"__typename":"StatusContext","state":"SUCCESS"}]}}}}]},"mergeQueueEntry":null}}}}'
+      exit 0
+      ;;
+  esac
+fi
+
+echo "Unsupported gh command: $*" >&2
+exit 2


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Session pull request status refreshes were tied to the 30-second activity heartbeat. Each refresh rediscovered the branch pull request with a broad GraphQL query and then made a second GraphQL query for merge-queue state, quickly consuming shared GitHub API quota when several Sessions ran concurrently.

This change:

- discovers pull requests with the REST API's owner-qualified head filter;
- reuses the recorded pull request URL and refreshes state, checks, and merge-queue data in one GraphQL query;
- polls pending or queued pull requests every 30 seconds and stable states every five minutes;
- backs off failed refreshes from one minute to 15 minutes;
- keeps immediate refreshes at startup and after turns.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

The first `make test` run inherited Codex host variables and failed two unrelated entrypoint fixture tests. Running the suite with `CODEX_AUTH_JSON`, `CODEX_HOME`, and `KELOS_PLUGIN_DIR` unset passed. `make verify` also passed with those host variables unset.

#### Does this PR introduce a user-facing change?

```release-note
Session pull request status refreshes now use fewer GitHub API requests and back off when checks are stable or GitHub requests fail.
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce Session GitHub API usage by discovering pull requests once via REST and refreshing status with a single GraphQL query. Previously every 30-second heartbeat rediscovered PRs and ran a separate merge-queue query; now discovery is cached, refresh cadence adapts to PR state, and failures back off to avoid quota exhaustion.

- Discover the PR via `gh api` REST using the repository host from the git remote and an owner-qualified head; refresh PR state, checks, and merge-queue in one GraphQL `repository(owner,name).pullRequest(number)` call.
- Refresh cadence: 30s while checks are pending or the PR is queued; 5m otherwise. Failed refreshes back off from 1m up to 15m. Startup and post-turn refreshes remain immediate.
- Cache and reuse the discovered PR URL between refreshes; periodic workspace refresh reads status without forcing rediscovery. Rediscovery is forced only at startup or after a turn. Preserve last-known checks when a status lookup fails.
- Periodic Session status publication no longer triggers a workspace refresh. `docs/reference.md` documents polling and backoff, and e2e `test/e2e/fixtures/fake-gh.sh` emulates the new `gh api` REST and GraphQL calls.

<sup>Written for commit 80e81398170c018eacd0feef410e6b456934ee24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1652?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

