### PR TITLE
Keep kelos logs -f open after empty streams

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1277,7 +1277,7 @@ The `kelos` CLI lets you manage the full lifecycle without writing YAML.
 | `kelos suspend taskspawner <name>` | Pause a TaskSpawner (stops polling, running tasks continue) |
 | `kelos resume taskspawner <name>` | Resume a paused TaskSpawner |
 
-`kelos logs <task-name> -f` waits while the task Pod is unscheduled, Pending, or initializing its target container, then streams logs once the container is available. Failed Tasks and non-transient container startup failures return an error instead of retrying indefinitely.
+`kelos logs <task-name> -f` waits while the task Pod is unscheduled, Pending, or initializing its target container, then streams logs once the container is available. If Kubernetes closes an empty agent log stream while the Task is still active, the command reconnects instead of reporting completion. Failed Tasks and non-transient container startup failures return an error instead of retrying indefinitely.
 
 ### `kelos install` Flags
 

--- a/internal/cli/logs.go
+++ b/internal/cli/logs.go
@@ -27,6 +27,11 @@ const (
 
 var errTaskLogSegmentNotFound = errors.New("task log segment not found")
 
+type bufferedReadCloser struct {
+	io.Reader
+	io.Closer
+}
+
 type logStreamRetryMode int
 
 const (
@@ -316,7 +321,37 @@ func openTaskLogStream(
 	for {
 		stream, err := open(ctx)
 		if err == nil {
-			return stream, nil
+			if !follow || container != kelos.AgentContainerName {
+				return stream, nil
+			}
+
+			reader := bufio.NewReader(stream)
+			if _, err := reader.Peek(1); err == nil {
+				return &bufferedReadCloser{Reader: reader, Closer: stream}, nil
+			} else if !errors.Is(err, io.EOF) {
+				_ = stream.Close()
+				return nil, fmt.Errorf("reading task %q logs: %w", taskName, err)
+			}
+
+			retry, retryErr := shouldRetryEmptyTaskLogStream(ctx, cl, namespace, taskName, podName, container)
+			if retryErr != nil {
+				_ = stream.Close()
+				return nil, retryErr
+			}
+			if !retry {
+				return &bufferedReadCloser{Reader: reader, Closer: stream}, nil
+			}
+
+			_ = stream.Close()
+			immediateRetryUsed = false
+			timer := time.NewTimer(retryInterval)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return nil, fmt.Errorf("streaming logs: %w", ctx.Err())
+			case <-timer.C:
+			}
+			continue
 		}
 		if !follow || !apierrors.IsBadRequest(err) {
 			return nil, fmt.Errorf("streaming logs: %w", err)
@@ -346,6 +381,71 @@ func openTaskLogStream(
 			return nil, fmt.Errorf("streaming logs: %w", ctx.Err())
 		case <-timer.C:
 		}
+	}
+}
+
+func shouldRetryEmptyTaskLogStream(ctx context.Context, cl client.Client, namespace, taskName, podName, container string) (bool, error) {
+	task := &kelos.Task{}
+	if err := cl.Get(ctx, client.ObjectKey{Name: taskName, Namespace: namespace}, task); err != nil {
+		return false, fmt.Errorf("getting task %q after its log stream closed: %w", taskName, err)
+	}
+	switch task.Status.Phase {
+	case kelos.TaskPhaseSucceeded:
+		return false, nil
+	case kelos.TaskPhaseFailed:
+		msg := "unknown error"
+		if task.Status.Message != "" {
+			msg = task.Status.Message
+		}
+		return false, fmt.Errorf("task %q failed before logs could be streamed: %s", taskName, msg)
+	}
+
+	pod := &corev1.Pod{}
+	if err := cl.Get(ctx, client.ObjectKey{Name: podName, Namespace: namespace}, pod); err != nil {
+		return false, fmt.Errorf("getting pod %q after task %q log stream closed: %w", podName, taskName, err)
+	}
+
+	statuses := append(pod.Status.InitContainerStatuses, pod.Status.ContainerStatuses...)
+	for _, status := range statuses {
+		if status.Name != container {
+			continue
+		}
+		switch {
+		case status.State.Running != nil:
+			return true, nil
+		case status.State.Terminated != nil:
+			return true, nil
+		case status.State.Waiting == nil:
+			return true, nil
+		}
+
+		switch status.State.Waiting.Reason {
+		case "", "PodInitializing", "ContainerCreating":
+			return true, nil
+		default:
+			return false, fmt.Errorf(
+				"container %q in pod %q cannot start while following task %q logs: %s",
+				container,
+				podName,
+				taskName,
+				status.State.Waiting.Reason,
+			)
+		}
+	}
+
+	switch pod.Status.Phase {
+	case corev1.PodSucceeded:
+		return true, nil
+	case corev1.PodFailed:
+		msg := "unknown error"
+		if pod.Status.Message != "" {
+			msg = pod.Status.Message
+		}
+		return false, fmt.Errorf("pod %q failed before task %q logs could be streamed: %s", podName, taskName, msg)
+	case corev1.PodUnknown:
+		return false, fmt.Errorf("pod %q entered phase %s while following task %q logs", podName, pod.Status.Phase, taskName)
+	default:
+		return true, nil
 	}
 }
 

--- a/internal/cli/logs_test.go
+++ b/internal/cli/logs_test.go
@@ -206,6 +206,237 @@ func TestOpenTaskLogStreamRetriesWhilePodIsStarting(t *testing.T) {
 	}
 }
 
+func TestOpenTaskLogStreamRetriesEmptyStreamWhileTaskIsPending(t *testing.T) {
+	task := &kelos.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: "task-1", Namespace: "default"},
+		Status:     kelos.TaskStatus{Phase: kelos.TaskPhasePending},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "task-pod", Namespace: "default"},
+		Status:     corev1.PodStatus{Phase: corev1.PodPending},
+	}
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(task, pod).Build()
+
+	attempts := 0
+	stream, err := openTaskLogStream(
+		context.Background(),
+		cl,
+		"default",
+		task.Name,
+		pod.Name,
+		"kelos-agent",
+		true,
+		0,
+		func(context.Context) (io.ReadCloser, error) {
+			attempts++
+			if attempts == 1 {
+				return io.NopCloser(strings.NewReader("")), nil
+			}
+			return io.NopCloser(strings.NewReader("task output")), nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("openTaskLogStream() error = %v", err)
+	}
+	defer stream.Close()
+
+	output, err := io.ReadAll(stream)
+	if err != nil {
+		t.Fatalf("reading stream: %v", err)
+	}
+	if string(output) != "task output" {
+		t.Fatalf("stream output = %q, want %q", output, "task output")
+	}
+	if attempts != 2 {
+		t.Fatalf("stream attempts = %d, want 2", attempts)
+	}
+}
+
+func TestOpenTaskLogStreamRetriesEmptyStreamUntilTaskBecomesTerminal(t *testing.T) {
+	task := &kelos.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: "task-1", Namespace: "default"},
+		Status:     kelos.TaskStatus{Phase: kelos.TaskPhaseRunning},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "task-pod", Namespace: "default"},
+		Spec:       corev1.PodSpec{NodeName: "worker-1"},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodSucceeded,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name: "kelos-agent",
+					State: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{ExitCode: 0},
+					},
+				},
+			},
+		},
+	}
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(task, pod).Build()
+
+	attempts := 0
+	stream, err := openTaskLogStream(
+		context.Background(),
+		cl,
+		"default",
+		task.Name,
+		pod.Name,
+		"kelos-agent",
+		true,
+		0,
+		func(ctx context.Context) (io.ReadCloser, error) {
+			attempts++
+			if attempts == 1 {
+				return io.NopCloser(strings.NewReader("")), nil
+			}
+			current := &kelos.Task{}
+			if err := cl.Get(ctx, client.ObjectKeyFromObject(task), current); err != nil {
+				return nil, err
+			}
+			current.Status.Phase = kelos.TaskPhaseSucceeded
+			if err := cl.Update(ctx, current); err != nil {
+				return nil, err
+			}
+			return io.NopCloser(strings.NewReader("")), nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("openTaskLogStream() error = %v", err)
+	}
+	defer stream.Close()
+
+	if attempts != 2 {
+		t.Fatalf("stream attempts = %d, want 2", attempts)
+	}
+}
+
+func TestOpenTaskLogStreamStopsWhenEmptyStreamHasTerminalTask(t *testing.T) {
+	task := &kelos.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: "task-1", Namespace: "default"},
+		Status:     kelos.TaskStatus{Phase: kelos.TaskPhaseSucceeded},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "task-pod", Namespace: "default"},
+		Status:     corev1.PodStatus{Phase: corev1.PodSucceeded},
+	}
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(task, pod).Build()
+
+	attempts := 0
+	stream, err := openTaskLogStream(
+		context.Background(),
+		cl,
+		"default",
+		task.Name,
+		pod.Name,
+		"kelos-agent",
+		true,
+		0,
+		func(context.Context) (io.ReadCloser, error) {
+			attempts++
+			return io.NopCloser(strings.NewReader("")), nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("openTaskLogStream() error = %v", err)
+	}
+	defer stream.Close()
+
+	output, err := io.ReadAll(stream)
+	if err != nil {
+		t.Fatalf("reading stream: %v", err)
+	}
+	if len(output) != 0 {
+		t.Fatalf("stream output = %q, want empty", output)
+	}
+	if attempts != 1 {
+		t.Fatalf("stream attempts = %d, want 1", attempts)
+	}
+}
+
+func TestOpenTaskLogStreamRejectsEmptyStreamForFailedTask(t *testing.T) {
+	task := &kelos.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: "task-1", Namespace: "default"},
+		Status: kelos.TaskStatus{
+			Phase:   kelos.TaskPhaseFailed,
+			Message: "pod could not start",
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "task-pod", Namespace: "default"},
+		Status:     corev1.PodStatus{Phase: corev1.PodFailed},
+	}
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(task, pod).Build()
+
+	attempts := 0
+	_, err := openTaskLogStream(
+		context.Background(),
+		cl,
+		"default",
+		task.Name,
+		pod.Name,
+		"kelos-agent",
+		true,
+		0,
+		func(context.Context) (io.ReadCloser, error) {
+			attempts++
+			return io.NopCloser(strings.NewReader("")), nil
+		},
+	)
+	wantErr := `task "task-1" failed before logs could be streamed: pod could not start`
+	if err == nil || err.Error() != wantErr {
+		t.Fatalf("openTaskLogStream() error = %v, want %q", err, wantErr)
+	}
+	if attempts != 1 {
+		t.Fatalf("stream attempts = %d, want 1", attempts)
+	}
+}
+
+func TestOpenTaskLogStreamRejectsEmptyStreamForContainerFailure(t *testing.T) {
+	task := &kelos.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: "task-1", Namespace: "default"},
+		Status:     kelos.TaskStatus{Phase: kelos.TaskPhasePending},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "task-pod", Namespace: "default"},
+		Spec:       corev1.PodSpec{NodeName: "worker-1"},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodPending,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name: "kelos-agent",
+					State: corev1.ContainerState{
+						Waiting: &corev1.ContainerStateWaiting{Reason: "ImagePullBackOff"},
+					},
+				},
+			},
+		},
+	}
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(task, pod).Build()
+
+	attempts := 0
+	_, err := openTaskLogStream(
+		context.Background(),
+		cl,
+		"default",
+		task.Name,
+		pod.Name,
+		"kelos-agent",
+		true,
+		0,
+		func(context.Context) (io.ReadCloser, error) {
+			attempts++
+			return io.NopCloser(strings.NewReader("")), nil
+		},
+	)
+	wantErr := `container "kelos-agent" in pod "task-pod" cannot start while following task "task-1" logs: ImagePullBackOff`
+	if err == nil || err.Error() != wantErr {
+		t.Fatalf("openTaskLogStream() error = %v, want %q", err, wantErr)
+	}
+	if attempts != 1 {
+		t.Fatalf("stream attempts = %d, want 1", attempts)
+	}
+}
+
 func TestOpenTaskLogStreamStopsForTerminalTask(t *testing.T) {
 	task := &kelos.Task{
 		ObjectMeta: metav1.ObjectMeta{Name: "task-1", Namespace: "default"},


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Kubernetes can successfully open an agent log stream and immediately return EOF while the Task and Pod are still Pending. The CLI previously treated that empty stream as successful completion, so `kelos logs <task> -f` could exit before the Task produced any output.

This change probes successful agent follow streams before returning them to the log parser. If a stream is empty, the CLI checks the current Task, Pod, and container state and reconnects while the Task remains active. Terminal Tasks end promptly, while failed Tasks and non-transient container startup failures return actionable errors. Non-empty streams continue through the existing parser without replaying output.

#### Which issue(s) this PR is related to:

Fixes #1653

#### Special notes for your reviewer:

The retry path applies only to empty agent follow streams. Init-container and non-follow log behavior remain unchanged.

Validation:

- `env -u CODEX_HOME -u CODEX_AUTH_JSON make test`
- `make verify`
- `make build`
- `git diff --check`

The E2E suite is left to PR CI as directed by the project guidance.

#### Does this PR introduce a user-facing change?

```release-note
`kelos logs -f` now reconnects when Kubernetes closes an empty agent log stream before the Task completes.
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep `kelos logs -f` open when Kubernetes returns an empty agent log stream so the CLI does not exit before Task output appears. Previously an empty stream meant success; now the CLI reconnects while the Task remains active and returns actionable errors for terminal or non-transient startup failures.

**Reviewer notes**
- Applies only to empty follow streams from the agent container; non-follow and init-container behavior is unchanged.
- Peeks one byte with a buffered reader and wraps the stream in a `bufferedReadCloser` to avoid replaying or dropping data when the stream is non-empty.
- Reconnect decisions come from `shouldRetryEmptyTaskLogStream(...)`, which inspects Task, Pod, and container state; it retries for active states and fails with clear messages for TaskFailed, container waiting reasons (e.g., ImagePullBackOff), or PodFailed/Unknown.
- Updates `docs/reference.md` to describe the reconnection behavior and adds tests for retry, terminal, and failure paths.

<sup>Written for commit 49b7b4af86a0eb98edba249161ce839e5642902f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1654?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

