### PR TITLE
Handle rotated CRD CA bundles during install

### DIFF
--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -4,7 +4,9 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"crypto/x509"
 	"encoding/base64"
+	"encoding/pem"
 	"fmt"
 	"io"
 	"os"
@@ -715,14 +717,67 @@ func crdConversionCABundleMatches(crd *unstructured.Unstructured, expectedCABund
 	if err != nil || !ok {
 		return false
 	}
-	switch v := caBundle.(type) {
-	case string:
-		return v == expectedCABundle
-	case []byte:
-		return string(v) == expectedCABundle || base64.StdEncoding.EncodeToString(v) == expectedCABundle
-	default:
+	injectedCertificates, ok := certificateBundle(caBundle)
+	if !ok {
 		return false
 	}
+	requiredCertificates, ok := certificateBundle(expectedCABundle)
+	if !ok {
+		return false
+	}
+
+	// CA injection can retain a retiring certificate during rotation.
+	injectedCertificateSet := make(map[string]struct{}, len(injectedCertificates))
+	for _, certificate := range injectedCertificates {
+		injectedCertificateSet[string(certificate.Raw)] = struct{}{}
+	}
+	for _, certificate := range requiredCertificates {
+		if _, ok := injectedCertificateSet[string(certificate.Raw)]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func certificateBundle(value interface{}) ([]*x509.Certificate, bool) {
+	var data []byte
+	switch v := value.(type) {
+	case string:
+		data = []byte(v)
+	case []byte:
+		data = v
+	default:
+		return nil, false
+	}
+
+	if certificates, ok := parsePEMCertificates(data); ok {
+		return certificates, true
+	}
+	decoded, err := base64.StdEncoding.DecodeString(string(data))
+	if err != nil {
+		return nil, false
+	}
+	return parsePEMCertificates(decoded)
+}
+
+func parsePEMCertificates(data []byte) ([]*x509.Certificate, bool) {
+	var certificates []*x509.Certificate
+	for len(bytes.TrimSpace(data)) > 0 {
+		block, rest := pem.Decode(data)
+		if block == nil {
+			return nil, false
+		}
+		data = rest
+		if block.Type != "CERTIFICATE" {
+			return nil, false
+		}
+		certificate, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return nil, false
+		}
+		certificates = append(certificates, certificate)
+	}
+	return certificates, len(certificates) > 0
 }
 
 func secretDataValue(secret *unstructured.Unstructured, key string) (string, bool) {

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -3,6 +3,12 @@ package cli
 import (
 	"bytes"
 	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"math/big"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -906,14 +912,16 @@ func TestRequireCertManager(t *testing.T) {
 }
 
 func TestInstallReadinessPredicates(t *testing.T) {
+	currentCA := testCertificatePEM(t, 1)
+	encodedCurrentCA := base64.StdEncoding.EncodeToString(currentCA)
 	secret := &unstructured.Unstructured{Object: map[string]interface{}{
-		"data": map[string]interface{}{"tls.crt": "crt", "tls.key": "key", "ca.crt": "current-ca"},
+		"data": map[string]interface{}{"tls.crt": "crt", "tls.key": "key", "ca.crt": encodedCurrentCA},
 	}}
 	if !secretHasTLSData(secret) {
 		t.Fatal("expected TLS secret data to be ready")
 	}
 	caBundle, ok := webhookCertificateCABundle(secret)
-	if !ok || caBundle != "current-ca" {
+	if !ok || caBundle != encodedCurrentCA {
 		t.Fatalf("expected current certificate CA bundle, got %q, %t", caBundle, ok)
 	}
 
@@ -951,14 +959,80 @@ func TestInstallReadinessPredicates(t *testing.T) {
 
 	crd := &unstructured.Unstructured{Object: map[string]interface{}{}}
 	_ = unstructured.SetNestedField(crd.Object, "Webhook", "spec", "conversion", "strategy")
-	_ = unstructured.SetNestedField(crd.Object, "current-ca", "spec", "conversion", "webhook", "clientConfig", "caBundle")
+	_ = unstructured.SetNestedField(crd.Object, encodedCurrentCA, "spec", "conversion", "webhook", "clientConfig", "caBundle")
 	if !crdConversionCABundleMatches(crd, caBundle) {
 		t.Fatal("expected CRD conversion CA bundle to match current certificate CA")
 	}
-	_ = unstructured.SetNestedField(crd.Object, "stale-ca", "spec", "conversion", "webhook", "clientConfig", "caBundle")
+	staleCA := testCertificatePEM(t, 2)
+	_ = unstructured.SetNestedField(crd.Object, base64.StdEncoding.EncodeToString(staleCA), "spec", "conversion", "webhook", "clientConfig", "caBundle")
 	if crdConversionCABundleMatches(crd, caBundle) {
 		t.Fatal("expected stale CRD conversion CA bundle to be rejected")
 	}
+}
+
+func TestCRDConversionCABundleMatchesRotationBundle(t *testing.T) {
+	currentCA := testCertificatePEM(t, 1)
+	staleCA := testCertificatePEM(t, 2)
+	rotationBundle := append(append([]byte{}, staleCA...), currentCA...)
+	expectedCABundle := base64.StdEncoding.EncodeToString(currentCA)
+
+	crd := &unstructured.Unstructured{Object: map[string]interface{}{}}
+	_ = unstructured.SetNestedField(crd.Object, "Webhook", "spec", "conversion", "strategy")
+	_ = unstructured.SetNestedField(crd.Object, base64.StdEncoding.EncodeToString(rotationBundle), "spec", "conversion", "webhook", "clientConfig", "caBundle")
+
+	if !crdConversionCABundleMatches(crd, expectedCABundle) {
+		t.Fatal("expected rotation bundle containing the current CA to match")
+	}
+
+	requiredChainCA := testCertificatePEM(t, 3)
+	requiredChain := append(append([]byte{}, currentCA...), requiredChainCA...)
+	if crdConversionCABundleMatches(crd, base64.StdEncoding.EncodeToString(requiredChain)) {
+		t.Fatal("expected bundle missing a required chain certificate to be rejected")
+	}
+	completeRotationBundle := append(append([]byte{}, rotationBundle...), requiredChainCA...)
+	_ = unstructured.SetNestedField(crd.Object, base64.StdEncoding.EncodeToString(completeRotationBundle), "spec", "conversion", "webhook", "clientConfig", "caBundle")
+	if !crdConversionCABundleMatches(crd, base64.StdEncoding.EncodeToString(requiredChain)) {
+		t.Fatal("expected bundle containing every required chain certificate to match")
+	}
+
+	nonCertificateBlock := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: []byte("not a key")})
+	malformedBundle := append(append([]byte{}, rotationBundle...), nonCertificateBlock...)
+	_ = unstructured.SetNestedField(crd.Object, base64.StdEncoding.EncodeToString(malformedBundle), "spec", "conversion", "webhook", "clientConfig", "caBundle")
+	if crdConversionCABundleMatches(crd, expectedCABundle) {
+		t.Fatal("expected bundle containing a non-certificate PEM block to be rejected")
+	}
+
+	rawBundleCRD := &unstructured.Unstructured{Object: map[string]interface{}{
+		"spec": map[string]interface{}{
+			"conversion": map[string]interface{}{
+				"strategy": "Webhook",
+				"webhook": map[string]interface{}{
+					"clientConfig": map[string]interface{}{"caBundle": rotationBundle},
+				},
+			},
+		},
+	}}
+	if !crdConversionCABundleMatches(rawBundleCRD, expectedCABundle) {
+		t.Fatal("expected raw PEM rotation bundle containing the current CA to match")
+	}
+
+	if crdConversionCABundleMatches(rawBundleCRD, base64.StdEncoding.EncodeToString([]byte("not a certificate"))) {
+		t.Fatal("expected malformed current CA bundle to be rejected")
+	}
+}
+
+func testCertificatePEM(t *testing.T, serialNumber int64) []byte {
+	t.Helper()
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generating test certificate key: %v", err)
+	}
+	template := &x509.Certificate{SerialNumber: big.NewInt(serialNumber)}
+	certificate, err := x509.CreateCertificate(rand.Reader, template, template, publicKey, privateKey)
+	if err != nil {
+		t.Fatalf("creating test certificate: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certificate})
 }
 
 func TestKelosCRDsExist(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

During certificate rotation, cert-manager's CA injector can retain both the retiring and current CA certificates in a CRD conversion webhook bundle. The installer compared that bundle byte-for-byte with the current CA from the webhook certificate Secret, so `kelos install` waited until its two-minute timeout even though the webhook was healthy.

This PR parses both PEM bundles and considers a conversion CRD ready when its bundle contains every certificate required by the Secret. Additional certificates retained for rotation safety are accepted, while malformed bundles and bundles missing the current CA remain rejected.

It also adds regression coverage for multi-certificate rotation bundles and the supported unstructured value representations.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Validation:

- `make verify`
- Focused installer tests through `make test TEST_FLAGS='-run "TestInstallReadinessPredicates|TestCRDConversionCABundleMatchesRotationBundle"'`
- The full `make test` target passes `internal/cli`; two unrelated `internal/controller` Codex entrypoint fixture tests fail because of the local Codex home contents.

#### Does this PR introduce a user-facing change?

```release-note
Fix `kelos install` timing out when cert-manager retains multiple CA certificates in CRD conversion bundles during certificate rotation.
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes kelos install timing out when CRD conversion CA bundles include rotated certificates. Previously the installer compared the CRD bundle byte-for-byte with the Secret CA; now it parses PEM bundles and considers the CRD ready when it contains all certificates from the Secret. Extra certificates are allowed; missing or malformed CA still fails.

- Updates crdConversionCABundleMatches to parse PEM from CRD and Secret, accept supersets, and compare by x509.Certificate.Raw; rejects non-certificate PEM blocks.
- Adds certificateBundle and parsePEMCertificates to handle string and []byte values and base64-encoded bundles.
- Extends tests for rotation bundles, required chain certificates, raw PEM values, and malformed inputs; no user-facing changes beyond fixing installer readiness.
- No migration required.

<sup>Written for commit 8514945a8c889fa2f235578d1cd39ada16e0551a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1656?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

