### PR TITLE
Accept the full SessionSpec in the Session create API

### DIFF
--- a/internal/consoleserver/server.go
+++ b/internal/consoleserver/server.go
@@ -152,13 +152,11 @@ type credentialOption struct {
 }
 
 type createSessionRequest struct {
-	Name                string                            `json:"name"`
-	Namespace           string                            `json:"namespace"`
-	Worker              kelos.WorkerSpec                  `json:"worker"`
-	InitialBranch       string                            `json:"initialBranch,omitempty"`
-	InitialPrompt       string                            `json:"initialPrompt,omitempty"`
-	Section             string                            `json:"section,omitempty"`
-	VolumeClaimTemplate *corev1.PersistentVolumeClaimSpec `json:"volumeClaimTemplate,omitempty"`
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+	Section   string `json:"section,omitempty"`
+
+	kelos.SessionSpec `json:",inline"`
 }
 
 type updateSessionSectionRequest struct {
@@ -926,12 +924,7 @@ func (s *Server) createSession(writer http.ResponseWriter, request *http.Request
 			Name:      payload.Name,
 			Namespace: payload.Namespace,
 		},
-		Spec: kelos.SessionSpec{
-			Worker:              payload.Worker,
-			InitialBranch:       payload.InitialBranch,
-			InitialPrompt:       payload.InitialPrompt,
-			VolumeClaimTemplate: payload.VolumeClaimTemplate,
-		},
+		Spec: payload.SessionSpec,
 	}
 	if section != "" {
 		session.Annotations = map[string]string{sessionSectionAnnotation: section}

--- a/internal/consoleserver/server_test.go
+++ b/internal/consoleserver/server_test.go
@@ -947,6 +947,119 @@ func TestSessionFormAPICreatesPersistentSession(t *testing.T) {
 	}
 }
 
+func TestSessionFormAPISetsIdlePolicy(t *testing.T) {
+	server := testServer(t)
+	payload := `{
+		"name":"idle-chat",
+		"namespace":"default",
+		"worker":{"type":"codex","credentials":{"type":"none"},"workspaceRef":{"name":"workspace"}},
+		"idlePolicy":{"suspendAfterSeconds":1800,"deleteAfterSeconds":604800}
+	}`
+	request := httptest.NewRequest(http.MethodPost, "/api/sessions", strings.NewReader(payload))
+	request.Header.Set("Authorization", "Bearer secret-token")
+	response := httptest.NewRecorder()
+	server.ServeHTTP(response, request)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("create status = %d body = %s", response.Code, response.Body.String())
+	}
+
+	var session kelos.Session
+	if err := server.client.Get(t.Context(), client.ObjectKey{Namespace: "default", Name: "idle-chat"}, &session); err != nil {
+		t.Fatal(err)
+	}
+	policy := session.Spec.IdlePolicy
+	if policy == nil {
+		t.Fatal("idlePolicy is nil")
+	}
+	if policy.SuspendAfterSeconds == nil || *policy.SuspendAfterSeconds != 1800 {
+		t.Fatalf("suspendAfterSeconds = %v, want 1800", policy.SuspendAfterSeconds)
+	}
+	if policy.DeleteAfterSeconds == nil || *policy.DeleteAfterSeconds != 604800 {
+		t.Fatalf("deleteAfterSeconds = %v, want 604800", policy.DeleteAfterSeconds)
+	}
+}
+
+func TestSessionFormAPIWithoutIdlePolicy(t *testing.T) {
+	server := testServer(t)
+	payload := `{
+		"name":"no-idle-chat",
+		"namespace":"default",
+		"worker":{"type":"codex","credentials":{"type":"none"},"workspaceRef":{"name":"workspace"}}
+	}`
+	request := httptest.NewRequest(http.MethodPost, "/api/sessions", strings.NewReader(payload))
+	request.Header.Set("Authorization", "Bearer secret-token")
+	response := httptest.NewRecorder()
+	server.ServeHTTP(response, request)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("create status = %d body = %s", response.Code, response.Body.String())
+	}
+
+	var session kelos.Session
+	if err := server.client.Get(t.Context(), client.ObjectKey{Namespace: "default", Name: "no-idle-chat"}, &session); err != nil {
+		t.Fatal(err)
+	}
+	if session.Spec.IdlePolicy != nil {
+		t.Fatalf("idlePolicy = %#v, want nil", session.Spec.IdlePolicy)
+	}
+}
+
+func TestSessionFormAPIPartialIdlePolicy(t *testing.T) {
+	server := testServer(t)
+	payload := `{
+		"name":"delete-only-chat",
+		"namespace":"default",
+		"worker":{"type":"codex","credentials":{"type":"none"},"workspaceRef":{"name":"workspace"}},
+		"idlePolicy":{"deleteAfterSeconds":3600}
+	}`
+	request := httptest.NewRequest(http.MethodPost, "/api/sessions", strings.NewReader(payload))
+	request.Header.Set("Authorization", "Bearer secret-token")
+	response := httptest.NewRecorder()
+	server.ServeHTTP(response, request)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("create status = %d body = %s", response.Code, response.Body.String())
+	}
+
+	var session kelos.Session
+	if err := server.client.Get(t.Context(), client.ObjectKey{Namespace: "default", Name: "delete-only-chat"}, &session); err != nil {
+		t.Fatal(err)
+	}
+	policy := session.Spec.IdlePolicy
+	if policy == nil {
+		t.Fatal("idlePolicy is nil")
+	}
+	if policy.SuspendAfterSeconds != nil {
+		t.Fatalf("suspendAfterSeconds = %v, want nil", *policy.SuspendAfterSeconds)
+	}
+	if policy.DeleteAfterSeconds == nil || *policy.DeleteAfterSeconds != 3600 {
+		t.Fatalf("deleteAfterSeconds = %v, want 3600", policy.DeleteAfterSeconds)
+	}
+}
+
+func TestSessionFormAPISetsSuspend(t *testing.T) {
+	server := testServer(t)
+	payload := `{
+		"name":"suspended-chat",
+		"namespace":"default",
+		"worker":{"type":"codex","credentials":{"type":"none"},"workspaceRef":{"name":"workspace"}},
+		"suspend":true
+	}`
+	request := httptest.NewRequest(http.MethodPost, "/api/sessions", strings.NewReader(payload))
+	request.Header.Set("Authorization", "Bearer secret-token")
+	response := httptest.NewRecorder()
+	server.ServeHTTP(response, request)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("create status = %d body = %s", response.Code, response.Body.String())
+	}
+
+	var session kelos.Session
+	if err := server.client.Get(t.Context(), client.ObjectKey{Namespace: "default", Name: "suspended-chat"}, &session); err != nil {
+		t.Fatal(err)
+	}
+	if session.Spec.Suspend == nil || !*session.Spec.Suspend {
+		t.Fatalf("suspend = %v, want true", session.Spec.Suspend)
+	}
+}
+
 func TestSessionYAMLApplyAPI(t *testing.T) {
 	server := testServer(t)
 	manifest := `apiVersion: kelos.dev/v1alpha2


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

`POST /api/sessions` mirrored a hand-maintained subset of `SessionSpec` in `createSessionRequest`,
so a spec field the CRD supports stayed unreachable through the create API until someone remembered
to add it here too. `Session.spec.idlePolicy` was one such field: `decodeJSON` uses
`DisallowUnknownFields`, so sending an `idlePolicy` key returned 400 rather than being silently
ignored, and clients had to fall back to the apply endpoint to configure idle suspension or
deletion.

`POST /api/sessions/apply` is not a substitute for callers that need this: it is an upsert and so
never returns 409, and clients rely on that 409 to detect and adopt orphaned Sessions.

This embeds `kelos.SessionSpec` in `createSessionRequest` rather than adding one more mirrored
field:

```go
type createSessionRequest struct {
	Name      string `json:"name"`
	Namespace string `json:"namespace"`
	Section   string `json:"section,omitempty"`

	kelos.SessionSpec `json:",inline"`
}
```

Anonymous embedding promotes the fields inline, so the request body is byte-identical to what
clients send today and the web UI keeps working unchanged, while spec fields added later are
carried without further edits here. `createSession` reduces to `Spec: payload.SessionSpec`.

`name` and `namespace` stay outside the embed because they are `ObjectMeta` rather than spec, and
`section` remains an annotation (`sessionSectionAnnotation`), not a spec field.

Behavior is otherwise unchanged:

- No default is applied — omitting `idlePolicy` still produces a Session with no idle policy.
- No handler-side validation was added. `Minimum=0` and the CEL rule
  (`suspendAfterSeconds < deleteAfterSeconds`) already live on `SessionIdlePolicy`.
- No API or codegen changes: `SessionSpec.IdlePolicy` and its deepcopy already exist.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Replaces #1655 because github is dumb and not showing a diff in commit.

This replaces the earlier single-field version of this change, per review feedback asking whether
the Session object could just be included here. Embedding the *spec* rather than a full `Session`
is what keeps the wire format flat — taking a whole `Session` (`apiVersion`/`kind`/`metadata`/
`spec`) would nest the payload, break existing clients, and overlap with `POST /api/sessions/apply`.

The request previously mirrored five of the six `SessionSpec` fields. The sixth is `Suspend`, so
this also newly accepts `suspend` at creation time — a deliberate widening, covered by a test.
Verified alongside it: `DisallowUnknownFields` still rejects unknown keys (400), and a nested
`{"spec": {...}}` body is rejected as an unknown field.

Tests cover a full `idlePolicy` round-trip, the omitted-field case (`spec.idlePolicy` stays nil), a
partial policy with only `deleteAfterSeconds`, and `suspend` at create.

No CEL-rejection test is included: the session server test harness builds its client with
`fake.NewClientBuilder()`, which does not evaluate CEL rules, so such an assertion would pass
vacuously regardless of the handler's behavior.

Out of scope: `createSession` maps both `IsAlreadyExists` and `IsInvalid` to 409, so an invalid idle
policy surfaces to the client as a conflict rather than a validation error. That conflation predates
this change and is untouched here.

#### Does this PR introduce a user-facing change?

```release-note
The session server create API (`POST /api/sessions`) now accepts the full Session spec, including `idlePolicy` and `suspend`, so clients can configure idle suspension and deletion when creating a Session.
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts the full `SessionSpec` in POST /api/sessions so clients can set idlePolicy and suspend at creation. Previously the create API mirrored a subset and rejected idlePolicy with 400, pushing callers to the upsert apply API that never returns 409.

- Request remains flat and backward compatible: fields from `kelos.SessionSpec` are inlined; name and namespace stay top-level; section remains an annotation.
- Behavior unchanged: no new defaults or handler-side validation; CRD/CEL rules still enforce constraints; unknown keys still return 400; a nested spec remains invalid.
- Tests cover idlePolicy round-trip, omitted and partial policy, and create-time suspend.
- No migration required; clients may start sending idlePolicy and suspend to POST /api/sessions.

<sup>Written for commit 1f1e1a8b1ebae7ffece69363e16b8059ed6f9952. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

