### PR TITLE
fix(slack): stop retrying replies rejected with cannot_reply_to_message

### DIFF
--- a/internal/reporting/slack.go
+++ b/internal/reporting/slack.go
@@ -3,6 +3,7 @@ package reporting
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"sync"
 	"unicode/utf8"
@@ -76,6 +77,27 @@ func (r *SlackReporter) UpdateMessage(ctx context.Context, channel, messageTS st
 		return fmt.Errorf("updating Slack message: %w", err)
 	}
 	return nil
+}
+
+// isPermanentSlackError reports whether err is a Slack API error that will
+// never succeed if retried, such as replying to a message Slack does not
+// allow replies to ("cannot_reply_to_message"). HTTP-level failures
+// (timeouts, 5xx) and rate limits are transient and remain retryable.
+//
+// slack-go returns SlackErrorResponse by value, with the API error code in
+// its Err field.
+//
+// The set is deliberately limited to cannot_reply_to_message. Other codes
+// that are arguably permanent (is_archived, channel_not_found, invalid_blocks,
+// msg_too_long) still retry, so suppressing them is a behavior change that
+// belongs in its own change with its own tests. Add them here when that
+// happens.
+func isPermanentSlackError(err error) bool {
+	var respErr slack.SlackErrorResponse
+	if !errors.As(err, &respErr) {
+		return false
+	}
+	return respErr.Err == "cannot_reply_to_message"
 }
 
 // contextBlock returns a context block displaying the task name.

--- a/internal/reporting/slack_test.go
+++ b/internal/reporting/slack_test.go
@@ -3,6 +3,8 @@ package reporting
 import (
 	"context"
 	"encoding/base64"
+	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -635,4 +637,29 @@ func assertContextContains(t *testing.T, block slack.Block, substr string) {
 		}
 	}
 	t.Errorf("context block does not contain %q", substr)
+}
+
+func TestIsPermanentSlackError(t *testing.T) {
+	cannotReply := slack.SlackErrorResponse{Err: "cannot_reply_to_message"}
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "cannot_reply_to_message", err: cannotReply, want: true},
+		{name: "wrapped cannot_reply_to_message", err: fmt.Errorf("posting Slack thread reply: %w", cannotReply), want: true},
+		{name: "rate limited stays retryable", err: slack.SlackErrorResponse{Err: "rate_limited"}, want: false},
+		{name: "other Slack API error", err: slack.SlackErrorResponse{Err: "is_archived"}, want: false},
+		{name: "HTTP status error", err: slack.StatusCodeError{Code: 500, Status: "server error"}, want: false},
+		{name: "non-Slack error", err: errors.New("boom"), want: false},
+		{name: "nil", err: nil, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isPermanentSlackError(tt.err); got != tt.want {
+				t.Errorf("isPermanentSlackError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
 }

--- a/internal/reporting/watcher.go
+++ b/internal/reporting/watcher.go
@@ -505,6 +505,18 @@ type SlackTaskReporter struct {
 	lastProgress map[types.UID]string         // taskUID -> last posted text
 	progressTS   map[types.UID]string         // taskUID -> message ts of the progress reply
 	activity     map[types.UID]*activityState // taskUID -> current activity indicator
+
+	// progressBlocked marks tasks whose thread permanently rejects replies.
+	// Like the maps above it is process-local, so a restart or a leader
+	// failover clears it: the phase annotation is durable and sends the task
+	// back through updateProgress, which posts once more against the rejected
+	// thread before re-blocking. The residue is one rejected API call and one
+	// log line per task per restart, and nothing reaches the thread because
+	// the post fails. Making it durable needs a new annotation plus a write on
+	// the reporting path, which is worth doing alongside progressTS — that one
+	// resets the same way and does post a duplicate progress message on
+	// restart — rather than for this flag alone.
+	progressBlocked map[types.UID]bool
 }
 
 // ReportTaskStatus checks a Task's current phase against its last reported
@@ -580,6 +592,17 @@ func (tr *SlackTaskReporter) ReportTaskStatus(ctx context.Context, task *kelos.T
 		log.Info("Posting Slack thread reply", "task", task.Name, "channel", channel, "phase", desiredPhase, "part", i+1, "total", len(msgs))
 		replyTS, err := tr.Reporter.PostThreadReply(ctx, channel, threadTS, msg)
 		if err != nil {
+			if isPermanentSlackError(err) {
+				// Slack will never accept a reply to this message (for
+				// example, the thread is closed). Mark the phase as reported
+				// anyway so the reporting cycle stops retrying every tick, and
+				// suppress progress posting too — the next cycle would otherwise
+				// read pod logs and post once more against the same thread
+				// before updateProgress sets the flag itself.
+				log.Error(err, "Not retrying Slack reply: permanent API error", "task", task.Name, "channel", channel, "threadTS", threadTS, "phase", desiredPhase, "part", i+1, "total", len(msgs))
+				tr.blockProgress(task.UID)
+				break
+			}
 			return fmt.Errorf("posting Slack reply for task %s (part %d/%d): %w", task.Name, i+1, len(msgs), err)
 		}
 		if i == 0 {
@@ -661,6 +684,12 @@ func (tr *SlackTaskReporter) updateProgress(ctx context.Context, task *kelos.Tas
 		return nil
 	}
 
+	// Slack permanently rejected a progress reply for this task, so skip the
+	// pod log read and the doomed post entirely.
+	if tr.isProgressBlocked(task.UID) {
+		return nil
+	}
+
 	log := ctrl.Log.WithName("slack-reporter")
 
 	podName := task.Status.PodName
@@ -708,7 +737,13 @@ func (tr *SlackTaskReporter) updateProgress(ctx context.Context, task *kelos.Tas
 	log.V(1).Info("Posting Slack progress update", "task", task.Name)
 	replyTS, err := tr.Reporter.PostThreadReply(ctx, channel, threadTS, msg)
 	if err != nil {
-		log.Error(err, "Failed to post Slack progress update", "task", task.Name)
+		log.Error(err, "Failed to post Slack progress update", "task", task.Name, "channel", channel, "threadTS", threadTS)
+		if isPermanentSlackError(err) {
+			// The thread will never accept a reply, for any snapshot — not
+			// just this one. Suppress progress posting for the task so later
+			// snapshots do not each retry against the rejected thread.
+			tr.blockProgress(task.UID)
+		}
 		return nil
 	}
 
@@ -746,6 +781,24 @@ func (tr *SlackTaskReporter) setLastProgress(uid types.UID, text string) {
 	tr.lastProgress[uid] = text
 }
 
+// blockProgress records that Slack permanently rejects progress replies for
+// a task, so no further snapshot is attempted for it.
+func (tr *SlackTaskReporter) blockProgress(uid types.UID) {
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	if tr.progressBlocked == nil {
+		tr.progressBlocked = make(map[types.UID]bool)
+	}
+	tr.progressBlocked[uid] = true
+}
+
+// isProgressBlocked reports whether progress posting is suppressed for a task.
+func (tr *SlackTaskReporter) isProgressBlocked(uid types.UID) bool {
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	return tr.progressBlocked[uid]
+}
+
 // getProgressTS returns the Slack message timestamp of the progress reply
 // for a task, or empty string if no progress has been posted yet.
 func (tr *SlackTaskReporter) getProgressTS(uid types.UID) string {
@@ -773,6 +826,7 @@ func (tr *SlackTaskReporter) clearProgressCache(uid types.UID) {
 	defer tr.mu.Unlock()
 	delete(tr.lastProgress, uid)
 	delete(tr.progressTS, uid)
+	delete(tr.progressBlocked, uid)
 }
 
 // SweepProgressCache removes entries for tasks that are no longer active.
@@ -796,6 +850,11 @@ func (tr *SlackTaskReporter) SweepProgressCache(activeUIDs map[types.UID]bool) {
 	for uid := range tr.activity {
 		if !activeUIDs[uid] {
 			delete(tr.activity, uid)
+		}
+	}
+	for uid := range tr.progressBlocked {
+		if !activeUIDs[uid] {
+			delete(tr.progressBlocked, uid)
 		}
 	}
 }

--- a/internal/reporting/watcher_test.go
+++ b/internal/reporting/watcher_test.go
@@ -3063,3 +3063,201 @@ func TestAppendActivityContext_DoesNotMutateBase(t *testing.T) {
 		t.Errorf("base message mutated: blocks went from %d to %d", originalBlockCount, len(baseMsg.Blocks))
 	}
 }
+
+func TestSlackTaskReporter_CannotReplyToMessageNotRetried(t *testing.T) {
+	task := &kelos.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-task",
+			Namespace: "default",
+			Annotations: map[string]string{
+				AnnotationSlackReporting: "enabled",
+				AnnotationSlackChannel:   "C123ABC",
+				AnnotationSlackThreadTS:  "1234567890.123456",
+			},
+		},
+		Spec: kelos.TaskSpec{
+			Type:   "claude-code",
+			Prompt: "test",
+			Credentials: &kelos.Credentials{
+				Type:      kelos.CredentialTypeOAuth,
+				SecretRef: &kelos.SecretReference{Name: "creds"},
+			},
+		},
+		Status: kelos.TaskStatus{
+			Phase:   kelos.TaskPhaseRunning,
+			PodName: "test-pod",
+		},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(task).Build()
+
+	attempts := 0
+	reporter := &fakeSlackReporter{
+		postFn: func(ctx context.Context, channel, threadTS string, msg SlackMessage) (string, error) {
+			attempts++
+			// slack-go surfaces API errors as a SlackErrorResponse value.
+			return "", slack.SlackErrorResponse{Err: "cannot_reply_to_message"}
+		},
+	}
+
+	// A ProgressReader and a pod are required for the second-cycle assertion
+	// below to mean anything: without them updateProgress returns at its
+	// ProgressReader/podName guards and the post count cannot grow no matter
+	// how the permanent error is handled. Production always wires one
+	// (cmd/kelos-slack-server/main.go).
+	tr := &SlackTaskReporter{
+		Client:         cl,
+		Reporter:       reporter,
+		ProgressReader: &fakeProgressReader{text: "Reading the changed files..."},
+	}
+
+	// A permanent Slack error must not wedge the task: the phase is still
+	// marked as reported so the 30s reporting cycle stops re-posting.
+	if err := tr.ReportTaskStatus(context.Background(), task); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if attempts != 1 {
+		t.Fatalf("expected exactly 1 post attempt, got %d", attempts)
+	}
+
+	var updated kelos.Task
+	if err := cl.Get(context.Background(), client.ObjectKeyFromObject(task), &updated); err != nil {
+		t.Fatalf("getting updated task: %v", err)
+	}
+	if updated.Annotations[AnnotationSlackReportPhase] != "accepted" {
+		t.Errorf("report phase = %q, want accepted so the cycle does not retry", updated.Annotations[AnnotationSlackReportPhase])
+	}
+
+	// The next cycle takes the progress path, which posts its own thread
+	// reply. It must not attempt that post either: the transition failure
+	// already proved the thread rejects every reply.
+	if err := tr.ReportTaskStatus(context.Background(), task); err != nil {
+		t.Fatalf("unexpected error on second cycle: %v", err)
+	}
+	if attempts != 1 {
+		t.Errorf("expected no additional post attempt on the next cycle, got %d total", attempts)
+	}
+}
+
+func TestSlackTaskReporter_TransientReplyErrorStillRetried(t *testing.T) {
+	task := &kelos.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-task",
+			Namespace: "default",
+			Annotations: map[string]string{
+				AnnotationSlackReporting: "enabled",
+				AnnotationSlackChannel:   "C123ABC",
+				AnnotationSlackThreadTS:  "1234567890.123456",
+			},
+		},
+		Spec: kelos.TaskSpec{
+			Type:   "claude-code",
+			Prompt: "test",
+			Credentials: &kelos.Credentials{
+				Type:      kelos.CredentialTypeOAuth,
+				SecretRef: &kelos.SecretReference{Name: "creds"},
+			},
+		},
+		Status: kelos.TaskStatus{
+			Phase: kelos.TaskPhasePending,
+		},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(task).Build()
+
+	reporter := &fakeSlackReporter{
+		postFn: func(ctx context.Context, channel, threadTS string, msg SlackMessage) (string, error) {
+			return "", errors.New("network timeout")
+		},
+	}
+
+	tr := &SlackTaskReporter{Client: cl, Reporter: reporter}
+
+	if err := tr.ReportTaskStatus(context.Background(), task); err == nil {
+		t.Fatal("expected error for transient failure")
+	}
+
+	var updated kelos.Task
+	if err := cl.Get(context.Background(), client.ObjectKeyFromObject(task), &updated); err != nil {
+		t.Fatalf("getting updated task: %v", err)
+	}
+	if updated.Annotations[AnnotationSlackReportPhase] != "" {
+		t.Errorf("report phase = %q, want unset so transient errors are retried", updated.Annotations[AnnotationSlackReportPhase])
+	}
+}
+
+func TestSlackTaskReporter_PermanentProgressErrorNotReattempted(t *testing.T) {
+	task := &kelos.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-task",
+			Namespace: "default",
+			UID:       "uid-124",
+			Annotations: map[string]string{
+				AnnotationSlackReporting:   "enabled",
+				AnnotationSlackChannel:     "C123ABC",
+				AnnotationSlackThreadTS:    "1234567890.123456",
+				AnnotationSlackReportPhase: "accepted",
+			},
+		},
+		Spec: kelos.TaskSpec{
+			Type:   "claude-code",
+			Prompt: "test",
+			Credentials: &kelos.Credentials{
+				Type:      kelos.CredentialTypeOAuth,
+				SecretRef: &kelos.SecretReference{Name: "creds"},
+			},
+		},
+		Status: kelos.TaskStatus{
+			Phase:   kelos.TaskPhaseRunning,
+			PodName: "test-pod",
+		},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(newTestScheme()).WithObjects(task).Build()
+
+	attempts := 0
+	reporter := &fakeSlackReporter{
+		postFn: func(ctx context.Context, channel, threadTS string, msg SlackMessage) (string, error) {
+			attempts++
+			return "", slack.SlackErrorResponse{Err: "cannot_reply_to_message"}
+		},
+	}
+
+	progress := &fakeProgressReader{text: "Searching through release tags..."}
+	tr := &SlackTaskReporter{
+		Client:         cl,
+		Reporter:       reporter,
+		ProgressReader: progress,
+	}
+
+	// First cycle: the permanent failure is logged and progress posting is
+	// blocked for the task. Suppression comes from the progressBlocked flag,
+	// not from snapshot text deduplication — setLastProgress is not reached
+	// on the error path.
+	if err := tr.ReportTaskStatus(context.Background(), task); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if attempts != 1 {
+		t.Fatalf("expected 1 post attempt, got %d", attempts)
+	}
+
+	// Second cycle with the same snapshot: no re-post attempt.
+	if err := tr.ReportTaskStatus(context.Background(), task); err != nil {
+		t.Fatalf("unexpected error on second cycle: %v", err)
+	}
+	if attempts != 1 {
+		t.Errorf("expected no additional post attempt on the next cycle, got %d total", attempts)
+	}
+
+	// A new, distinct snapshot must not retry either: the thread rejects
+	// every reply, not just the one that failed, so text deduplication alone
+	// would let each fresh snapshot post again.
+	progress.text = "Now running the test suite..."
+	if err := tr.ReportTaskStatus(context.Background(), task); err != nil {
+		t.Fatalf("unexpected error on third cycle: %v", err)
+	}
+	if attempts != 1 {
+		t.Errorf("expected no post attempt for a new snapshot, got %d total", attempts)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When Slack rejects a thread reply with `cannot_reply_to_message` (for example, when the thread is closed or the bot cannot reply to it), the `kelos-slack-server` reporting cycle currently retries the post forever. Because the failed post prevented the task's `kelos.dev/slack-report-phase` annotation from being persisted, the reporter re-posted on every 30s tick — observed in production as two self-triggered tasks wedged in the `accepted` phase with 198+ failed attempts in a single hour.

This PR treats `cannot_reply_to_message` as a permanent API error:

- **Phase transitions** (`ReportTaskStatus`): log the failure once and still persist the report phase, so the reporting cycle stops retrying that reply on every tick. HTTP-level failures (timeouts, 5xx, rate limits) keep the existing retry behavior.
- **Progress snapshots** (`updateProgress`): mark the snapshot as posted on a permanent error so it is not re-attempted every cycle.

The permanent-error detection is isolated in a small `isPermanentSlackError` helper, living alongside the other `SlackReporter` helpers in `internal/reporting/slack.go`, so the classification is easy to extend to other permanent Slack API errors later.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

- The new behavior is covered by unit tests:
  - `TestSlackTaskReporter_CannotReplyToMessageNotRetried` — permanent error: one attempt, phase annotation persisted, no further attempts on the next cycle.
  - `TestSlackTaskReporter_TransientReplyErrorStillRetried` — transient error: error surfaced, annotation not set, retry behavior unchanged.
  - `TestSlackTaskReporter_PermanentProgressErrorNotReattempted` — permanent error on a progress snapshot: single attempt, not re-attempted next cycle.
  - `TestIsPermanentSlackError` — classification of wrapped errors, other Slack API errors, HTTP status errors, and plain errors. Includes `rate_limited`, asserting rate limits stay transient and keep their existing retry behavior.
- `isPermanentSlackError` matches `slack.SlackErrorResponse` by value only. That is the shape slack-go v0.20.0 returns from `SlackResponse.Err()` (`misc.go:180`, `misc.go:195`), `Error()` has a value receiver, and no path in the library returns a pointer, so a `*SlackErrorResponse` branch would be unreachable.
- The permanent-error path uses `break` rather than an early return, so it falls through to the existing tail of `ReportTaskStatus`: `setActivityTarget` is skipped (`firstReplyTS` is empty), and terminal phases still reach `clearProgressCache`/`clearActivityState` before the phase is persisted.
- Verified: `go build ./...`, `go vet`, `gofmt`, and `go test ./internal/reporting/` all pass. The new tests fail against the pre-fix code. The repo-wide failures (`internal/controller` entrypoint tests, `test/e2e`, `test/integration`) are pre-existing environment issues (kubebuilder envtest binaries and a git sandbox limitation) that fail identically without this change.
- `make test-integration` requires envtest binaries not available in the sandbox environment.

#### Does this PR introduce a user-facing change?

```release-note
Slack task reports that Slack permanently rejects with cannot_reply_to_message are no longer retried on every reporting cycle, preventing repeated duplicate posts.
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop retrying Slack thread replies rejected with cannot_reply_to_message by classifying them as permanent API errors. This prevents 30s retry loops, wedged tasks, and duplicate posts by persisting the report phase and suppressing progress posts.

- Adds `isPermanentSlackError` that matches `slack.SlackErrorResponse.Err == "cannot_reply_to_message"`; HTTP failures and rate limits remain retryable.
- Phase transitions: on permanent error, log once with channel and thread timestamp, persist `kelos.dev/slack-report-phase`, and set a per-task progress block so the next cycle does not attempt progress posts.
- Progress updates: if blocked, return before reading pod logs; on permanent error, set the block and log channel and thread timestamp on failures.
- The progress block is in-memory: a restart/leader failover may trigger one extra rejected post before re-blocking; it clears via `clearProgressCache` and is swept in `SweepProgressCache`.
- Unit tests cover permanent vs transient paths, progress suppression, and error classification. No config or migration changes.

<sup>Written for commit b84f50d7a2f7632fe3d045a5b825dbcdad46166f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

