### PR TITLE
Enable prompt drafts before sessions are ready

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -303,7 +303,9 @@ Less important status-bar items are omitted as the terminal narrows. The
 model is the same runtime-reported value persisted in
 `status.model`. Web chat is served by the optional shared
 `kelos-session-server`; it shows the same live runtime details beneath its
-composer. It shows connection status separately from working, waiting-for-input,
+composer. The composer accepts prompt drafts while a selected Session is still
+Pending and enables sending after the runtime connects. It shows connection
+status separately from working, waiting-for-input,
 and interrupting progress, including elapsed time for active work, and adds the
 duration to its separator after a completed turn. Duration labels are omitted
 from retained history that does not contain event timestamps and from turns

--- a/internal/sessionserver/testdata/session_history_test.js
+++ b/internal/sessionserver/testdata/session_history_test.js
@@ -142,6 +142,7 @@ let interruptRequests;
 let socketConnections;
 let progressTimers;
 let toasts;
+let closeSocketRequests;
 
 global.window = {
   clearInterval: (timer) => progressTimers.delete(timer),
@@ -172,9 +173,19 @@ function resetHarness() {
     progressElapsed: new TestNode('span'),
     runtimeStatus: new TestNode('div'),
     sidebar: new TestNode('aside'),
+    displayNameButton: new TestNode('button'),
+    resetButton: new TestNode('button'),
+    deleteButton: new TestNode('button'),
+    conversationTab: new TestNode('button'),
+    changesTab: new TestNode('button'),
+    title: new TestNode('h1'),
+    meta: new TestNode('div'),
+    connection: new TestNode('div'),
     welcome: null,
   };
+  elements.connection.append(new TestNode('span'), new TestNode('span'));
   global.state = {
+    sessions: [],
     selected: null,
     currentView: null,
     sessionViews: new Map(),
@@ -208,10 +219,13 @@ function resetHarness() {
     runtimeRecoveryActive: false,
     pinHistoryToBottom: false,
     fileChangesDirty: false,
+    namespace: 'default',
+    namespaceGeneration: 0,
   };
   bottomAnchors = 0;
   interruptRequests = 0;
   socketConnections = 0;
+  closeSocketRequests = 0;
   progressTimers = new Map();
   toasts = [];
 }
@@ -223,10 +237,16 @@ global.renderMessageMarkdown = (element, text) => { element.textContent = text |
 global.providerInitials = () => 'A';
 global.savePromptDraft = () => {};
 global.restorePromptDraft = () => {};
-global.closeSocket = () => {};
+global.closeSocket = () => {
+  closeSocketRequests++;
+  state.socket = null;
+};
 global.setActiveView = () => {};
 global.renderSessions = () => {};
 global.renderHeader = () => {};
+global.renderSectionOptions = () => {};
+global.renderSelectedSessionSection = () => {};
+global.createPullRequestLink = () => null;
 global.resizeComposer = () => {};
 global.scheduleBottomAnchor = () => { bottomAnchors++; };
 global.connectSocket = () => { socketConnections++; };
@@ -252,9 +272,15 @@ function applicationSlice(start, end) {
 
 vm.runInThisContext(applicationSlice('function sessionKey', 'function savePromptDraft'), {filename: 'app.js'});
 vm.runInThisContext(applicationSlice('function savePromptDraft', 'function providerLabel'), {filename: 'app.js'});
+vm.runInThisContext(applicationSlice('function providerLabel', 'function parseSessionTimestamp'), {filename: 'app.js'});
 vm.runInThisContext(applicationSlice('function parseSessionTimestamp', 'function safeHTTPURL'), {filename: 'app.js'});
 vm.runInThisContext(applicationSlice('function selectSession', 'function renderHeader'), {filename: 'app.js'});
+vm.runInThisContext(applicationSlice('async function loadSessions', 'async function loadConfig'), {filename: 'app.js'});
 vm.runInThisContext(applicationSlice('function usesTouchComposer', 'function closeSocket'), {filename: 'app.js'});
+const renderSessionHeader = vm.runInThisContext(
+  `(() => {${applicationSlice('function renderHeader', 'function usesTouchComposer')} return renderHeader;})()`,
+  {filename: 'app.js'},
+);
 vm.runInThisContext(applicationSlice('function ensureConversation', 'function trimURLSuffix'), {filename: 'app.js'});
 vm.runInThisContext(applicationSlice('function completedAssistantText', 'function handleEvent'), {filename: 'app.js'});
 vm.runInThisContext(applicationSlice('function handleEvent', 'function renderUser'), {filename: 'app.js'});
@@ -394,6 +420,50 @@ function testComposerLabelsPendingSubmission() {
   elements.input.value = '/goal pause';
   updateComposerAction();
   assert.equal(elements.composerHint.textContent, 'Enter to run goal command · Shift+Enter for a new line · !COMMAND · /goal');
+}
+
+function testPendingSessionComposerAllowsDraft() {
+  resetHarness();
+  const session = {namespace: 'default', name: 'one', uid: 'uid-one', provider: 'codex', phase: 'Pending'};
+  state.selected = session;
+
+  renderSessionHeader();
+
+  assert.equal(elements.input.disabled, false);
+  assert.equal(elements.attachFiles.disabled, false);
+  assert.equal(elements.send.disabled, true);
+  elements.input.value = 'Start by reviewing the failing tests';
+  savePromptDraft(session);
+  assert.equal(state.promptDrafts.get(sessionKey(session)), 'Start by reviewing the failing tests');
+}
+
+function testFailedSessionComposerRejectsDraft() {
+  resetHarness();
+  state.selected = {namespace: 'default', name: 'one', uid: 'uid-one', provider: 'codex', phase: 'Failed'};
+
+  renderSessionHeader();
+
+  assert.equal(elements.input.disabled, true);
+  assert.equal(elements.attachFiles.disabled, true);
+  assert.equal(elements.send.disabled, true);
+}
+
+async function testReadySessionDisconnectsWhenItBecomesPending() {
+  resetHarness();
+  const session = {namespace: 'default', name: 'one', uid: 'uid-one', provider: 'codex', phase: 'Ready'};
+  state.selected = session;
+  state.sessions = [session];
+  state.socket = {readyState: WebSocket.OPEN};
+  global.api = async () => [{...session, phase: 'Pending'}];
+  global.renderHeader = renderSessionHeader;
+
+  await loadSessions({quiet: true});
+
+  assert.equal(closeSocketRequests, 1);
+  assert.equal(state.socket, null);
+  assert.equal(state.selected.phase, 'Pending');
+  assert.equal(elements.input.disabled, false);
+  assert.equal(elements.send.disabled, true);
 }
 
 async function testComposerIgnoresReentrantSubmission() {
@@ -901,6 +971,8 @@ testSessionViewReset();
 testSessionProgressLifecycle();
 testComposerInterruptsWhileInputIsDisabled();
 testComposerLabelsPendingSubmission();
+testPendingSessionComposerAllowsDraft();
+testFailedSessionComposerRejectsDraft();
 testSessionProgressSurvivesCachedViewSwitch();
 testSessionProgressElapsedFormatting();
 testRuntimeStatusLifecycle();
@@ -926,7 +998,8 @@ testUserAttachmentRendering();
 testPendingMessageEditing();
 testPendingMessageRemoval();
 testPendingMessageSurvivesCompletedHistoryReplay();
-testComposerIgnoresReentrantSubmission()
+testReadySessionDisconnectsWhenItBecomesPending()
+  .then(testComposerIgnoresReentrantSubmission)
   .then(() => process.stdout.write('Session history tests passed\n'))
   .catch(error => {
     process.stderr.write(`${error.stack}\n`);

--- a/internal/sessionserver/web/app.js
+++ b/internal/sessionserver/web/app.js
@@ -1048,9 +1048,10 @@ async function loadSessions({quiet = false} = {}) {
         } else {
           const beganReset = !state.selected.resetting && current.resetting;
           const becameReady = (state.selected.phase !== 'Ready' || state.selected.resetting) && current.phase === 'Ready' && !current.resetting;
+          const becameNotReady = state.selected.phase === 'Ready' && current.phase !== 'Ready';
           state.selected = current;
+          if (beganReset || becameNotReady) closeSocket();
           if (beganReset) {
-            closeSocket();
             resetCurrentSessionView();
           }
           renderHeader();
@@ -1591,7 +1592,7 @@ function renderHeader() {
     setComposer(false);
   } else if (session.phase !== 'Ready') {
     setConnection(session.phase === 'Failed' ? 'error' : 'connecting', session.phase || 'Pending');
-    setComposer(false);
+    setComposer(!session.phase || session.phase === 'Pending');
   }
   renderRuntimeStatus();
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Enable the web composer for newly created and Pending Sessions so users can prepare a prompt and attachments during startup. Sending remains disabled until the Session WebSocket connects. Failed and Suspended Sessions keep the composer disabled.

The composer readiness gate previously disabled both drafting and sending, even though sending already has its own connection guard. This change allows the per-Session draft support to work during startup while preserving the connection guard.

When a Ready Session becomes non-Ready, the web client now closes its stale WebSocket before rendering the new state. This prevents an open connection from leaving Send enabled during Pod replacement or another readiness transition.

Add browser behavior coverage for Pending and Failed Sessions, the Ready-to-Pending transition, and per-Session draft persistence. Document when drafting and sending become available.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Validation:

- `make verify`
- `make test TEST_FLAGS='-run TestApplicationSessionHistoryBehavior'`

An earlier full `make test` run passed the changed Session server coverage but reported two failures outside this diff: `TestCodexEntrypointUsesPersistentSessionHome` and the Codex case of `TestAgentEntrypointsPreserveSkillReferenceFiles`.

#### Does this PR introduce a user-facing change?

```release-note
Allow users to prepare prompt and attachment drafts in the Session web chat while the Session runtime starts.
```
