### PR TITLE
Add Session server resume action

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -452,11 +452,11 @@ field is omitted, the workspace uses `emptyDir`, which is primarily useful for
 development because its history and changes do not survive Pod replacement.
 
 Set `spec.suspend` to `true` to suspend a Session without deleting it, then set
-it back to `false` to resume. A suspended Session rejects web connection
-attempts and the terminal client waits for it to resume. Configured persistent
-workspace and conversation data remain available across suspension. An
-`emptyDir` workspace is deleted with the scaled-down Pod and starts empty after
-resuming.
+it back to `false` or use the Resume action in the shared web client to resume.
+A suspended Session rejects web connection attempts and the terminal client
+waits for it to resume. Configured persistent workspace and conversation data
+remain available across suspension. An `emptyDir` workspace is deleted with the
+scaled-down Pod and starts empty after resuming.
 
 Reset a Session with `kelos session reset NAME` or the reset action in the
 shared web client's Session-row overflow menu. The same menu can rename or

--- a/internal/sessionserver/server.go
+++ b/internal/sessionserver/server.go
@@ -125,6 +125,7 @@ type sessionSummary struct {
 	PullRequest     *kelos.SessionPullRequest `json:"pullRequest,omitempty"`
 	Section         string                    `json:"section,omitempty"`
 	Resetting       bool                      `json:"resetting,omitempty"`
+	UserSuspended   bool                      `json:"userSuspended,omitempty"`
 	IdleSuspended   bool                      `json:"idleSuspended,omitempty"`
 }
 
@@ -666,9 +667,47 @@ func (s *Server) resumeSession(writer http.ResponseWriter, request *http.Request
 		writeError(writer, status, err.Error())
 		return
 	}
-	if session.Status.Phase == kelos.SessionPhaseSuspended && !sessionsuspend.IsIdlePolicySuspended(session) {
-		writeError(writer, http.StatusConflict, fmt.Sprintf("Session %q is suspended by user request", name))
-		return
+	if session.Spec.Suspend != nil && *session.Spec.Suspend {
+		original := session.DeepCopy()
+		suspend := false
+		session.Spec.Suspend = &suspend
+		if err := s.client.Patch(
+			request.Context(),
+			session,
+			client.MergeFromWithOptions(original, client.MergeFromWithOptimisticLock{}),
+		); err != nil {
+			status := http.StatusInternalServerError
+			switch {
+			case apierrors.IsNotFound(err):
+				status = http.StatusNotFound
+			case apierrors.IsInvalid(err):
+				status = http.StatusBadRequest
+			case apierrors.IsForbidden(err):
+				status = http.StatusForbidden
+			case apierrors.IsConflict(err):
+				status = http.StatusConflict
+			}
+			writeError(writer, status, fmt.Sprintf("resuming Session %q: %v", name, err))
+			return
+		}
+		session, _, err = sessionsuspend.RequestResume(
+			request.Context(),
+			s.client,
+			client.ObjectKey{Namespace: namespace, Name: name},
+		)
+		if err != nil {
+			status := http.StatusInternalServerError
+			switch {
+			case apierrors.IsNotFound(err):
+				status = http.StatusNotFound
+			case apierrors.IsForbidden(err):
+				status = http.StatusForbidden
+			case apierrors.IsConflict(err):
+				status = http.StatusConflict
+			}
+			writeError(writer, status, err.Error())
+			return
+		}
 	}
 	writeJSON(writer, http.StatusAccepted, summarize(session))
 }
@@ -810,6 +849,7 @@ func summarize(session *kelos.Session) sessionSummary {
 		PullRequest:    session.Status.PullRequest,
 		Section:        session.Annotations[sessionSectionAnnotation],
 		Resetting:      session.Annotations[sessionreset.RequestAnnotation] != "",
+		UserSuspended:  session.Spec.Suspend != nil && *session.Spec.Suspend,
 		IdleSuspended:  sessionsuspend.IsIdlePolicySuspended(session),
 	}
 	if !session.CreationTimestamp.IsZero() {

--- a/internal/sessionserver/server_test.go
+++ b/internal/sessionserver/server_test.go
@@ -209,6 +209,19 @@ func TestSessionSummaryReportsIdleSuspension(t *testing.T) {
 	if !summary.IdleSuspended {
 		t.Fatal("Session summary idleSuspended = false, want true")
 	}
+	if summary.UserSuspended {
+		t.Fatal("Session summary userSuspended = true for idle suspension")
+	}
+}
+
+func TestSessionSummaryReportsUserSuspension(t *testing.T) {
+	summary := summarize(&kelos.Session{Spec: kelos.SessionSpec{Suspend: ptr.To(true)}})
+	if !summary.UserSuspended {
+		t.Fatal("Session summary userSuspended = false, want true")
+	}
+	if summary.IdleSuspended {
+		t.Fatal("Session summary idleSuspended = true for user suspension")
+	}
 }
 
 func TestSessionJavaScriptResumesIdleSuspension(t *testing.T) {
@@ -220,10 +233,33 @@ func TestSessionJavaScriptResumesIdleSuspension(t *testing.T) {
 	for _, expected := range []string{
 		"selectSession(session, true)",
 		"if (resumeIdle && session.idleSuspended) resumeIdleSession(session);",
-		"/resume`, {method: 'POST'}",
+		"await requestSessionResume(session);",
 	} {
 		if !strings.Contains(javascript, expected) {
 			t.Errorf("Session JavaScript is missing idle resume behavior %q", expected)
+		}
+	}
+}
+
+func TestSessionPageOffersUserSuspensionResume(t *testing.T) {
+	index, err := webFiles.ReadFile("web/index.html")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if expected := `id="resume-session" aria-label="Resume session"`; !strings.Contains(string(index), expected) {
+		t.Errorf("Session page is missing resume control %q", expected)
+	}
+
+	source, err := webFiles.ReadFile("web/app.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, expected := range []string{
+		"elements.resumeButton.hidden = !session?.userSuspended;",
+		"elements.resumeButton.addEventListener('click', resumeSelectedSession);",
+	} {
+		if !strings.Contains(string(source), expected) {
+			t.Errorf("Session JavaScript is missing user suspension resume behavior %q", expected)
 		}
 	}
 }
@@ -400,6 +436,17 @@ func TestApplicationDisplayNameBehavior(t *testing.T) {
 	command := exec.Command(node, "testdata/display_name_test.js")
 	if output, err := command.CombinedOutput(); err != nil {
 		t.Fatalf("running display name tests: %v\n%s", err, output)
+	}
+}
+
+func TestApplicationSessionResumeBehavior(t *testing.T) {
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("Node.js is not installed")
+	}
+	command := exec.Command(node, "testdata/session_resume_test.js")
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("running Session resume tests: %v\n%s", err, output)
 	}
 }
 
@@ -768,6 +815,7 @@ func TestSessionUIAdaptsToPhoneViewport(t *testing.T) {
 		"dynamic viewport height":    `height: 100dvh`,
 		"landscape phone breakpoint": `(max-height: 500px) and (pointer: coarse)`,
 		"two-row phone header":       `grid-template-areas: "menu heading reset delete" "tabs tabs connection connection"`,
+		"phone header resume slot":   `.conversation-header:has(#resume-session:not([hidden])) { grid-template-areas: "menu heading resume reset delete"`,
 		"48-pixel touch targets":     `.icon-button { width: 48px; height: 48px; }`,
 		"phone safe-area padding":    `env(safe-area-inset-bottom)`,
 		"non-zooming form fields":    `.composer textarea, .pending-message-input, .yaml-panel textarea, .form-grid input`,
@@ -1008,6 +1056,99 @@ func TestSessionResumeAPIRequestsIdleResume(t *testing.T) {
 	}
 	if !sessionsuspend.ResumeRequested(&updated) {
 		t.Fatalf("resume endpoint did not record a wake request: %#v", updated.Annotations)
+	}
+}
+
+func TestSessionResumeAPIUnsuspendsUserSuspendedSession(t *testing.T) {
+	server := testServer(t)
+	session := &kelos.Session{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "chat",
+			Namespace:   "team-a",
+			Annotations: map[string]string{"owner": "platform"},
+		},
+		Spec: kelos.SessionSpec{
+			Worker: kelos.WorkerSpec{
+				Type:        "codex",
+				Model:       "gpt-5",
+				Credentials: &kelos.Credentials{Type: kelos.CredentialTypeNone},
+			},
+			Suspend: ptr.To(true),
+		},
+		Status: kelos.SessionStatus{Phase: kelos.SessionPhaseSuspended},
+	}
+	if err := server.client.Create(t.Context(), session); err != nil {
+		t.Fatal(err)
+	}
+
+	request := httptest.NewRequest(http.MethodPost, "/api/sessions/team-a/chat/resume", nil)
+	request.Header.Set("Authorization", "Bearer secret-token")
+	response := httptest.NewRecorder()
+	server.ServeHTTP(response, request)
+	if response.Code != http.StatusAccepted {
+		t.Fatalf("resume status = %d body = %s", response.Code, response.Body.String())
+	}
+	var summary sessionSummary
+	if err := json.Unmarshal(response.Body.Bytes(), &summary); err != nil {
+		t.Fatal(err)
+	}
+	if summary.UserSuspended {
+		t.Fatal("resume response userSuspended = true, want false")
+	}
+
+	var updated kelos.Session
+	if err := server.client.Get(t.Context(), client.ObjectKeyFromObject(session), &updated); err != nil {
+		t.Fatal(err)
+	}
+	if updated.Spec.Suspend == nil || *updated.Spec.Suspend {
+		t.Fatalf("resumed Session suspend = %v, want false", updated.Spec.Suspend)
+	}
+	if updated.Spec.Worker.Model != "gpt-5" || updated.Annotations["owner"] != "platform" {
+		t.Fatalf("resumed Session lost unrelated fields: %#v", updated)
+	}
+}
+
+func TestSessionResumeAPIRequestsIdleResumeAfterUserSuspension(t *testing.T) {
+	server := testServer(t)
+	session := &kelos.Session{
+		ObjectMeta: metav1.ObjectMeta{Name: "chat", Namespace: "team-a"},
+		Spec: kelos.SessionSpec{
+			Worker: kelos.WorkerSpec{
+				Type:        "codex",
+				Credentials: &kelos.Credentials{Type: kelos.CredentialTypeNone},
+			},
+			Suspend: ptr.To(true),
+		},
+		Status: kelos.SessionStatus{
+			Phase: kelos.SessionPhaseSuspended,
+			Conditions: []metav1.Condition{{
+				Type:   kelos.SessionConditionReady,
+				Status: metav1.ConditionFalse,
+				Reason: sessionsuspend.IdlePolicyReason,
+			}},
+		},
+	}
+	if err := server.client.Create(t.Context(), session); err != nil {
+		t.Fatal(err)
+	}
+
+	request := httptest.NewRequest(http.MethodPost, "/api/sessions/team-a/chat/resume", nil)
+	request.Header.Set("Authorization", "Bearer secret-token")
+	response := httptest.NewRecorder()
+	server.ServeHTTP(response, request)
+	if response.Code != http.StatusAccepted {
+		t.Fatalf("resume status = %d body = %s", response.Code, response.Body.String())
+	}
+
+	var updated kelos.Session
+	if err := server.client.Get(t.Context(), client.ObjectKeyFromObject(session), &updated); err != nil {
+		t.Fatal(err)
+	}
+	if updated.Spec.Suspend == nil || *updated.Spec.Suspend {
+		t.Fatalf("resumed Session suspend = %v, want false", updated.Spec.Suspend)
+	}
+	if !sessionsuspend.ResumeRequested(&updated) {
+		t.Fatalf("resume endpoint did not record an idle wake request: %#v", updated.Annotations)
 	}
 }
 

--- a/internal/sessionserver/testdata/section_chooser_test.js
+++ b/internal/sessionserver/testdata/section_chooser_test.js
@@ -449,7 +449,7 @@ async function testInlineNewSectionSubmission() {
   global.showToast = () => {};
 
   vm.runInThisContext(
-    applicationSlice("elements.sectionChoice.addEventListener", "elements.deleteButton.addEventListener"),
+    applicationSlice("elements.sectionChoice.addEventListener", "elements.resumeButton.addEventListener"),
     {filename: 'app.js'},
   );
   renderSelectedSessionSection(session);

--- a/internal/sessionserver/testdata/session_actions_test.js
+++ b/internal/sessionserver/testdata/session_actions_test.js
@@ -114,7 +114,7 @@ function applicationSlice(start, end) {
 
 vm.runInThisContext(applicationSlice('function sessionKey', 'function sessionViewKey'), {filename: 'app.js'});
 vm.runInThisContext(applicationSlice('function createSessionListItem', 'function sectionLabel'), {filename: 'app.js'});
-vm.runInThisContext(applicationSlice('async function deleteSession', 'elements.deleteButton.addEventListener'), {filename: 'app.js'});
+vm.runInThisContext(applicationSlice('async function deleteSession', 'elements.resumeButton.addEventListener'), {filename: 'app.js'});
 
 global.sessionDisplayStatus = () => 'Ready';
 global.createSessionTimestamp = () => null;

--- a/internal/sessionserver/testdata/session_history_test.js
+++ b/internal/sessionserver/testdata/session_history_test.js
@@ -174,6 +174,7 @@ function resetHarness() {
     runtimeStatus: new TestNode('div'),
     sidebar: new TestNode('aside'),
     displayNameButton: new TestNode('button'),
+    resumeButton: new TestNode('button'),
     resetButton: new TestNode('button'),
     deleteButton: new TestNode('button'),
     conversationTab: new TestNode('button'),
@@ -221,6 +222,7 @@ function resetHarness() {
     fileChangesDirty: false,
     namespace: 'default',
     namespaceGeneration: 0,
+    sessionListGeneration: 0,
   };
   bottomAnchors = 0;
   interruptRequests = 0;

--- a/internal/sessionserver/testdata/session_resume_test.js
+++ b/internal/sessionserver/testdata/session_resume_test.js
@@ -1,0 +1,92 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const application = fs.readFileSync(path.join(__dirname, '..', 'web', 'app.js'), 'utf8');
+
+function applicationSlice(start, end) {
+  const startIndex = application.indexOf(start);
+  const endIndex = application.indexOf(end, startIndex);
+  assert.notEqual(startIndex, -1, `${start} not found`);
+  assert.notEqual(endIndex, -1, `${end} not found`);
+  return application.slice(startIndex, endIndex);
+}
+
+vm.runInThisContext(applicationSlice('async function requestSessionResume', 'function createWelcome'), {filename: 'app.js'});
+vm.runInThisContext(applicationSlice('async function loadSessions', 'async function loadConfig'), {filename: 'app.js'});
+
+async function testUserSuspendedSessionResume() {
+  const session = {namespace: 'team-a', name: 'chat', phase: 'Suspended', userSuspended: true};
+  global.state = {
+    namespaceGeneration: 4,
+    sessionListGeneration: 0,
+    sessions: [session],
+    selected: session,
+    resumingSession: false,
+  };
+  global.sessionKey = value => `${value.namespace}/${value.name}`;
+  let request;
+  let sessionsRendered = 0;
+  const headerStates = [];
+  const toasts = [];
+  global.api = async (requestPath, options) => {
+    request = {path: requestPath, options};
+    return {...session, userSuspended: false};
+  };
+  global.renderSessions = () => { sessionsRendered++; };
+  global.renderHeader = () => {
+    headerStates.push({
+      resumingSession: state.resumingSession,
+      userSuspended: state.selected.userSuspended,
+    });
+  };
+  global.showToast = message => { toasts.push(message); };
+
+  await resumeSelectedSession();
+
+  assert.equal(request.path, '/api/sessions/team-a/chat/resume');
+  assert.deepEqual(request.options, {method: 'POST'});
+  assert.equal(state.sessions[0].userSuspended, false);
+  assert.equal(state.selected.userSuspended, false);
+  assert.equal(state.resumingSession, false);
+  assert.equal(sessionsRendered, 1);
+  assert.deepEqual(headerStates[headerStates.length - 1], {
+    resumingSession: false,
+    userSuspended: false,
+  });
+  assert.deepEqual(toasts, ['Session resume requested']);
+}
+
+async function testResumeIgnoresOlderSessionList() {
+  const suspended = {namespace: 'team-a', name: 'chat', phase: 'Suspended', userSuspended: true};
+  const resumed = {...suspended, userSuspended: false};
+  global.state = {
+    namespace: 'team-a',
+    namespaceGeneration: 4,
+    sessionListGeneration: 0,
+    sessions: [suspended],
+    selected: suspended,
+  };
+  let resolveList;
+  global.api = async (requestPath) => {
+    if (requestPath.startsWith('/api/sessions?')) {
+      return new Promise(resolve => { resolveList = resolve; });
+    }
+    return resumed;
+  };
+  global.renderSessions = () => {};
+  global.renderHeader = () => {};
+
+  const loading = loadSessions();
+  await requestSessionResume(suspended);
+  resolveList([suspended]);
+  await loading;
+
+  assert.equal(state.sessions[0].userSuspended, false);
+  assert.equal(state.selected.userSuspended, false);
+}
+
+testUserSuspendedSessionResume().then(testResumeIgnoresOlderSessionList).then(() => {
+  process.stdout.write('Session resume tests passed\n');
+});

--- a/internal/sessionserver/web/app.js
+++ b/internal/sessionserver/web/app.js
@@ -69,6 +69,7 @@ const elements = {
   persistentVolume: document.querySelector('#volume-claim-enabled'),
   volumeClaimFields: document.querySelector('#volume-claim-fields'),
   createButton: document.querySelector('#create-session'),
+  resumeButton: document.querySelector('#resume-session'),
   resetButton: document.querySelector('#reset-session'),
   deleteButton: document.querySelector('#delete-session'),
   sidebar: document.querySelector('#sidebar'),
@@ -120,12 +121,14 @@ const state = {
   defaultNamespace: 'default',
   namespace: 'default',
   namespaceGeneration: 0,
+  sessionListGeneration: 0,
   options: {credentials: [], workspaces: [], agentConfigs: [], sessions: []},
   selectedAgentConfigs: [],
   creationMode: 'form',
   sourceGeneration: 0,
   sourceLoading: false,
   creatingSession: false,
+  resumingSession: false,
   sourceStorageClassNamePresent: false,
   loadedSource: null,
   displayNameSaving: false,
@@ -1153,9 +1156,10 @@ function resetSectionSelection() {
 async function loadSessions({quiet = false} = {}) {
   const namespace = state.namespace;
   const generation = state.namespaceGeneration;
+  const listGeneration = ++state.sessionListGeneration;
   try {
     const sessions = await api(`/api/sessions?namespace=${encodeURIComponent(namespace)}`);
-    if (generation !== state.namespaceGeneration) return;
+    if (generation !== state.namespaceGeneration || listGeneration !== state.sessionListGeneration) return;
     state.sessions = sessions;
     renderSectionOptions();
     if (state.selected) {
@@ -1183,7 +1187,7 @@ async function loadSessions({quiet = false} = {}) {
     }
     renderSessions();
   } catch (error) {
-    if (!quiet && generation === state.namespaceGeneration) showToast(error.message);
+    if (!quiet && generation === state.namespaceGeneration && listGeneration === state.sessionListGeneration) showToast(error.message);
   }
 }
 
@@ -1646,10 +1650,40 @@ function selectSession(session, resumeIdle = false) {
 
 async function resumeIdleSession(session) {
   try {
-    await api(`/api/sessions/${encodeURIComponent(session.namespace)}/${encodeURIComponent(session.name)}/resume`, {method: 'POST'});
-    await loadSessions({quiet: true});
+    await requestSessionResume(session);
   } catch (error) {
     showToast(error.message);
+  }
+}
+
+async function requestSessionResume(session) {
+  const generation = state.namespaceGeneration;
+  const updated = await api(
+    `/api/sessions/${encodeURIComponent(session.namespace)}/${encodeURIComponent(session.name)}/resume`,
+    {method: 'POST'},
+  );
+  if (generation !== state.namespaceGeneration) return updated;
+  state.sessionListGeneration += 1;
+  state.sessions = state.sessions.map(item => sessionKey(item) === sessionKey(updated) ? updated : item);
+  if (state.selected && sessionKey(state.selected) === sessionKey(updated)) state.selected = updated;
+  renderSessions();
+  renderHeader();
+  return updated;
+}
+
+async function resumeSelectedSession() {
+  const session = state.selected;
+  if (!session?.userSuspended || state.resumingSession) return;
+  state.resumingSession = true;
+  renderHeader();
+  try {
+    await requestSessionResume(session);
+    showToast('Session resume requested');
+  } catch (error) {
+    showToast(error.message);
+  } finally {
+    state.resumingSession = false;
+    renderHeader();
   }
 }
 
@@ -1669,6 +1703,8 @@ function renderHeader() {
   elements.displayNameButton.hidden = !session;
   elements.displayNameButton.disabled = !session;
   renderSelectedSessionSection(session);
+  elements.resumeButton.hidden = !session?.userSuspended;
+  elements.resumeButton.disabled = !session?.userSuspended || state.resumingSession;
   elements.resetButton.disabled = !session || session.resetting;
   elements.deleteButton.disabled = !session;
   elements.conversationTab.disabled = !session;
@@ -4039,6 +4075,7 @@ async function resetSession(session) {
   }
 }
 
+elements.resumeButton.addEventListener('click', resumeSelectedSession);
 elements.deleteButton.addEventListener('click', () => deleteSession(state.selected));
 elements.resetButton.addEventListener('click', () => resetSession(state.selected));
 elements.sessionActionRename.addEventListener('click', () => {

--- a/internal/sessionserver/web/index.html
+++ b/internal/sessionserver/web/index.html
@@ -64,6 +64,7 @@
             <button id="changes-tab" type="button" role="tab" aria-selected="false" aria-controls="changes-view" tabindex="-1" disabled>Changes <span id="changes-count">0</span></button>
           </div>
           <span class="connection-pill" id="connection-pill" data-state="idle"><span></span>Not connected</span>
+          <button class="icon-button" id="resume-session" aria-label="Resume session" title="Resume session" disabled hidden>▶</button>
           <button class="icon-button danger" id="reset-session" aria-label="Reset session" title="Reset session" disabled>↺</button>
           <button class="icon-button danger" id="delete-session" aria-label="Delete session" title="Delete session" disabled>⌫</button>
         </div>

--- a/internal/sessionserver/web/styles.css
+++ b/internal/sessionserver/web/styles.css
@@ -149,6 +149,7 @@ button { color: inherit; }
 .connection-pill[data-state="error"] span { background: #c45555; }
 @keyframes pulse { 50% { opacity: .35; } }
 .icon-button { width: 35px; height: 35px; display: grid; place-items: center; border: 1px solid var(--line); border-radius: 10px; background: var(--card); cursor: pointer; }
+.icon-button[hidden] { display: none; }
 .icon-button:hover { border-color: #c5ccc6; }
 .icon-button:disabled { opacity: .38; cursor: default; }
 .icon-button.danger:not(:disabled):hover { color: var(--danger); border-color: rgba(167,63,63,.3); background: #fff6f6; }
@@ -390,10 +391,12 @@ button { color: inherit; }
   .brand-row .mobile-only { margin-left: auto; }
   .conversation { height: 100%; height: 100dvh; }
   .conversation-header { display: grid; grid-template-areas: "menu heading reset delete" "tabs tabs connection connection"; grid-template-columns: 48px minmax(0, 1fr) 48px 48px; gap: 8px 10px; padding: calc(8px + env(safe-area-inset-top)) calc(10px + env(safe-area-inset-right)) 9px calc(10px + env(safe-area-inset-left)); }
+  .conversation-header:has(#resume-session:not([hidden])) { grid-template-areas: "menu heading resume reset delete" "tabs tabs connection connection connection"; grid-template-columns: 48px minmax(0, 1fr) 48px 48px 48px; }
   #open-sidebar { grid-area: menu; }
   .session-heading { grid-area: heading; }
   .header-actions { display: contents; }
   .view-tabs { grid-area: tabs; width: fit-content; }
+  #resume-session { grid-area: resume; }
   #reset-session { grid-area: reset; }
   #delete-session { grid-area: delete; }
   .connection-pill { grid-area: connection; width: 48px; height: 48px; max-width: 48px; justify-content: center; justify-self: end; overflow: hidden; padding: 0; color: transparent; font-size: 0; gap: 0; }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds a Resume action to the Session server for Sessions suspended through `spec.suspend`.

The existing resume endpoint only handled idle-policy suspension and returned a conflict for explicitly suspended Sessions, leaving the web client without a way to resume them. This change makes the endpoint set `spec.suspend` to `false`, reports explicit suspension separately in Session summaries, and shows a Resume control when applicable. Idle-policy resume behavior remains unchanged.

Backend and browser tests cover the new resume path and confirm unrelated Session fields are preserved.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Validation:

- `make verify`
- `env -u CODEX_AUTH_JSON -u KELOS_PLUGIN_DIR -u CODEX_HOME make test`

The environment variables are unset for the test command because the agent container otherwise leaks its live Codex configuration into entrypoint fixture tests.

#### Does this PR introduce a user-facing change?

```release-note
Add a Resume action to the Session web interface for explicitly suspended Sessions.
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Resume action for Sessions explicitly suspended via spec.suspend and exposes it in the web client. Previously, POST /api/sessions/:ns/:name/resume handled only idle-policy suspension and returned 409 for user-suspended Sessions; it now clears spec.suspend, requests an idle wake when applicable, and returns 202 with an updated summary.

- Server: Resume clears spec.suspend when set, preserves unrelated fields, requests an idle wake if the Session was also idle-suspended, and responds 202 with sessionSummary. sessionSummary now reports userSuspended and idleSuspended. Clients that relied on 409 for user-suspended Sessions must handle 202 instead.
- UI: Adds a Resume button shown only when userSuspended and disabled while resuming. Clicking requests resume, updates the selected/listed Session state immediately, prevents stale list overwrites via sessionListGeneration, and shows “Session resume requested”. Includes mobile header layout and hidden-icon styling updates.
- Docs/Tests: Reference docs note the web Resume action. Backend tests cover unsuspending, idle-wake annotation, summary flags, and field preservation. Node-based browser tests verify UI wiring and ignoring older session lists; idle-policy resume behavior remains unchanged.

<sup>Written for commit 8f0b40168b674b4a00158dc660fcfd11591568a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1662?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

