### PR TITLE
Add per-session actions menu to session server

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -342,9 +342,10 @@ exact value is also available to assistive technology. A Session waiting for a
 user response is labeled **Waiting for input** in the sidebar and header, with a
 distinct red indicator in the sidebar.
 
-Use **Rename** beside the selected Session's title to set a display name for the
-web chat. The display name appears in the sidebar, conversation header, and web
-runtime status without changing the Session's Kubernetes resource name. An empty
+Use **Rename** beside the selected Session's title or in a Session row's overflow
+menu to set a display name for the web chat. The display name appears in the
+sidebar, conversation header, and web runtime status without changing the
+Session's Kubernetes resource name. An empty
 display name restores the resource name. Display names are stored in the
 `kelos.dev/session-display-name` annotation, so Session manifests can set the
 same annotation directly. Values are trimmed and limited to 64 characters when
@@ -456,8 +457,10 @@ workspace and conversation data remain available across suspension. An
 resuming.
 
 Reset a Session with `kelos session reset NAME` or the reset action in the
-shared web client. Reset preserves the Session resource and its immutable spec
-fields but permanently deletes retained conversation history and workspace changes.
+shared web client's Session-row overflow menu. The same menu can rename or
+delete that Session without selecting it first. Reset preserves the Session
+resource and its immutable spec fields but permanently deletes retained
+conversation history and workspace changes.
 The controller stops the Session Pod before deleting its PersistentVolumeClaim,
 then creates a fresh claim and replacement Pod. An `emptyDir` Session resets by
 replacing only its Pod. Workspace initialization and

--- a/internal/sessionserver/server_test.go
+++ b/internal/sessionserver/server_test.go
@@ -414,6 +414,17 @@ func TestApplicationInputRequestBehavior(t *testing.T) {
 	}
 }
 
+func TestApplicationSessionActionsBehavior(t *testing.T) {
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("Node.js is not installed")
+	}
+	command := exec.Command(node, "testdata/session_actions_test.js")
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("running Session actions tests: %v\n%s", err, output)
+	}
+}
+
 func TestSessionFormAPICreatesPersistentSession(t *testing.T) {
 	server := testServer(t)
 	payload := `{
@@ -660,10 +671,11 @@ func TestSessionResetControlWarnsAndUsesResetEndpoint(t *testing.T) {
 		t.Fatal(err)
 	}
 	for description, expected := range map[string]string{
-		"destructive warning":       "This permanently deletes its conversation history and all workspace changes.",
-		"reset API request":         "/reset`, {method: 'POST'}",
-		"reset history clearing":    "resetCurrentSessionView();\n    discardSessionView(session);",
-		"reset connection blocking": "state.selected.resetting",
+		"destructive warning":        "This permanently deletes its conversation history and all workspace changes.",
+		"reset API request":          "/reset`, {method: 'POST'}",
+		"reset history clearing":     "resetCurrentSessionView();",
+		"reset cached view clearing": "discardSessionView(session);",
+		"reset connection blocking":  "state.selected.resetting",
 	} {
 		if !strings.Contains(string(javascript), expected) {
 			t.Errorf("Session reset control is missing %s: %s", description, expected)
@@ -683,7 +695,7 @@ func TestSessionComposerKeepsDraftsPerSession(t *testing.T) {
 		"Session selection save":  "function selectSession(session, resumeIdle = false) {\n  savePromptDraft(state.selected);",
 		"Session draft restore":   `state.promptDrafts.get(sessionKey(session))`,
 		"prompt submission clear": "state.socket.send(JSON.stringify({type: 'message', text, attachmentIds: attachments.map(attachment => attachment.id)}));\n    clearPromptDraft(session);",
-		"Session deletion clear":  "selectSession(null);\n    clearPromptDraft(session);",
+		"Session deletion clear":  "{method: 'DELETE'});\n    discardSessionView(session);\n    clearPromptDraft(session);\n    clearAttachmentDraft(session);",
 		"composer input save":     "elements.input.addEventListener('input', () => {\n  savePromptDraft(state.selected);",
 	} {
 		if !strings.Contains(string(source), expected) {

--- a/internal/sessionserver/testdata/session_actions_test.js
+++ b/internal/sessionserver/testdata/session_actions_test.js
@@ -1,0 +1,338 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+class TestNode {
+  constructor(tag, bounds = {top: 20, right: 260, bottom: 52, width: 32, height: 32}) {
+    this.tag = tag;
+    this.bounds = bounds;
+    this.children = [];
+    this.listeners = new Map();
+    this.attributes = new Map();
+    this.classes = new Set();
+    this.dataset = {};
+    this.style = {};
+    this.hidden = false;
+    this.disabled = false;
+    this.draggable = false;
+    this._text = '';
+  }
+
+  append(...nodes) {
+    this.children.push(...nodes);
+  }
+
+  replaceChildren(...nodes) {
+    this.children = [...nodes];
+  }
+
+  querySelectorAll(selector) {
+    assert.ok(selector.startsWith('.'), `Unsupported selector: ${selector}`);
+    const className = selector.slice(1);
+    const matches = [];
+    for (const child of this.children) {
+      if (child.classes?.has(className)) matches.push(child);
+      matches.push(...(child.querySelectorAll?.(selector) || []));
+    }
+    return matches;
+  }
+
+  addEventListener(type, listener) {
+    const listeners = this.listeners.get(type) || [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  async dispatch(type, event = {}) {
+    for (const listener of this.listeners.get(type) || []) await listener(event);
+  }
+
+  setAttribute(name, value) {
+    this.attributes.set(name, String(value));
+  }
+
+  removeAttribute(name) {
+    this.attributes.delete(name);
+  }
+
+  getBoundingClientRect() {
+    return this.bounds;
+  }
+
+  focus() {
+    global.document.activeElement = this;
+  }
+
+  contains(target) {
+    return this === target || this.children.some(child => child.contains?.(target));
+  }
+
+  set className(value) {
+    this.classes = new Set(String(value).split(/\s+/).filter(Boolean));
+  }
+
+  get className() {
+    return [...this.classes].join(' ');
+  }
+
+  get classList() {
+    return {add: (...names) => names.forEach(name => this.classes.add(name))};
+  }
+
+  set textContent(value) {
+    this._text = String(value);
+    this.children = [];
+  }
+
+  get textContent() {
+    return this.children.length ? this.children.map(child => child.textContent).join('') : this._text;
+  }
+}
+
+global.document = {
+  activeElement: null,
+  createElement: tag => new TestNode(tag),
+};
+global.window = {
+  confirm: () => true,
+  innerHeight: 800,
+  innerWidth: 400,
+};
+
+const application = fs.readFileSync(path.join(__dirname, '..', 'web', 'app.js'), 'utf8');
+const index = fs.readFileSync(path.join(__dirname, '..', 'web', 'index.html'), 'utf8');
+const styles = fs.readFileSync(path.join(__dirname, '..', 'web', 'styles.css'), 'utf8');
+
+function applicationSlice(start, end) {
+  const startIndex = application.indexOf(start);
+  const endIndex = application.indexOf(end, startIndex);
+  assert.notEqual(startIndex, -1, `${start} not found`);
+  assert.notEqual(endIndex, -1, `${end} not found`);
+  return application.slice(startIndex, endIndex);
+}
+
+vm.runInThisContext(applicationSlice('function sessionKey', 'function sessionViewKey'), {filename: 'app.js'});
+vm.runInThisContext(applicationSlice('function createSessionListItem', 'function sectionLabel'), {filename: 'app.js'});
+vm.runInThisContext(applicationSlice('async function deleteSession', 'elements.deleteButton.addEventListener'), {filename: 'app.js'});
+
+global.sessionDisplayStatus = () => 'Ready';
+global.createSessionTimestamp = () => null;
+global.providerLabel = provider => provider;
+global.createPullRequestLink = () => null;
+global.configureSessionDrag = () => {};
+global.selectSession = () => {};
+
+function resetHarness() {
+  global.elements = {
+    list: new TestNode('div'),
+    sessionActionsMenu: new TestNode('div', {top: 0, right: 0, bottom: 0, width: 176, height: 120}),
+    sessionActionRename: new TestNode('button'),
+    sessionActionReset: new TestNode('button'),
+    newSessionButton: new TestNode('button'),
+  };
+  elements.sessionActionsMenu.append(elements.sessionActionRename, elements.sessionActionReset);
+  elements.sessionActionsMenu.hidden = true;
+  document.activeElement = null;
+  global.state = {
+    sessions: [],
+    selected: null,
+    currentView: null,
+    sessionActionKey: '',
+    sessionActionTrigger: null,
+    sectionAssignments: new Set(),
+  };
+}
+
+async function testEverySessionRowHasActionsMenu() {
+  resetHarness();
+  const session = {namespace: 'default', name: 'review', provider: 'codex'};
+  state.sessions = [session];
+
+  const item = createSessionListItem(session);
+  const actions = item.children.find(child => child.className === 'session-item-actions');
+
+  assert.ok(actions);
+  assert.equal(actions.textContent, '…');
+  assert.equal(actions.attributes.get('aria-label'), 'Actions for review');
+  assert.equal(actions.attributes.get('aria-haspopup'), 'menu');
+  assert.equal(actions.attributes.get('aria-expanded'), 'false');
+
+  let stopped = false;
+  await actions.dispatch('click', {stopPropagation: () => { stopped = true; }});
+  assert.equal(stopped, true);
+  assert.equal(state.sessionActionKey, 'default/review');
+  assert.equal(elements.sessionActionsMenu.hidden, false);
+  assert.equal(actions.attributes.get('aria-expanded'), 'true');
+  assert.equal(document.activeElement, elements.sessionActionRename);
+
+  await actions.dispatch('click', {stopPropagation() {}});
+  assert.equal(elements.sessionActionsMenu.hidden, true);
+  assert.equal(actions.attributes.get('aria-expanded'), 'false');
+  assert.equal(document.activeElement, actions);
+}
+
+function testOpenMenuSurvivesSessionRefresh() {
+  resetHarness();
+  const session = {namespace: 'default', name: 'review', provider: 'codex'};
+  state.sessions = [session];
+  const firstItem = createSessionListItem(session);
+  openSessionActionsMenu(session, firstItem.children[1]);
+
+  const refreshed = {...session, displayName: 'Review CI', resetting: true};
+  state.sessions = [refreshed];
+  state.sessionActionTrigger = null;
+  const refreshedItem = createSessionListItem(refreshed);
+  syncSessionActionsMenu();
+
+  const refreshedActions = refreshedItem.children[1];
+  assert.equal(elements.sessionActionsMenu.hidden, false);
+  assert.equal(elements.sessionActionsMenu.attributes.get('aria-label'), 'Actions for Review CI');
+  assert.equal(elements.sessionActionReset.disabled, true);
+  assert.equal(refreshedActions.attributes.get('aria-expanded'), 'true');
+}
+
+async function testActionsCanTargetAnUnselectedSession() {
+  resetHarness();
+  const selected = {namespace: 'default', name: 'selected'};
+  const target = {namespace: 'team-a', name: 'target'};
+  state.sessions = [selected, target];
+  state.selected = selected;
+  state.sessionActionKey = sessionKey(target);
+  assert.equal(sessionActionsTarget(), target);
+
+  const requests = [];
+  const discarded = [];
+  const clearedDrafts = [];
+  const clearedAttachments = [];
+  let selectionChanges = 0;
+  global.api = async (requestPath, options) => {
+    requests.push({path: requestPath, options});
+    return {...target, resetting: true};
+  };
+  global.discardSessionView = session => discarded.push(sessionKey(session));
+  global.clearPromptDraft = session => clearedDrafts.push(sessionKey(session));
+  global.clearAttachmentDraft = session => clearedAttachments.push(sessionKey(session));
+  global.selectSession = () => { selectionChanges++; };
+  global.loadSessions = async () => {};
+  global.showToast = () => {};
+  global.closeSocket = () => {};
+  global.resetCurrentSessionView = () => {};
+
+  await resetSession(target);
+  await deleteSession(target);
+
+  assert.deepEqual(requests.map(request => request.path), [
+    '/api/sessions/team-a/target/reset',
+    '/api/sessions/team-a/target',
+  ]);
+  assert.equal(requests[0].options.method, 'POST');
+  assert.equal(requests[1].options.method, 'DELETE');
+  assert.deepEqual(discarded, ['team-a/target', 'team-a/target']);
+  assert.deepEqual(clearedDrafts, ['team-a/target', 'team-a/target']);
+  assert.deepEqual(clearedAttachments, ['team-a/target', 'team-a/target']);
+  assert.equal(selectionChanges, 0);
+  assert.equal(state.selected, selected);
+}
+
+async function testActionsUpdateTheSelectedSession() {
+  resetHarness();
+  const target = {namespace: 'team-a', name: 'target'};
+  const resetting = {...target, resetting: true};
+  state.sessions = [target];
+  state.selected = target;
+  state.currentView = {historyLoaded: true};
+
+  const selections = [];
+  let socketCloses = 0;
+  let viewResets = 0;
+  global.api = async requestPath => requestPath.endsWith('/reset') ? resetting : null;
+  global.discardSessionView = () => {};
+  global.clearPromptDraft = () => {};
+  global.clearAttachmentDraft = () => {};
+  global.selectSession = session => selections.push(session);
+  global.loadSessions = async () => {};
+  global.showToast = () => {};
+  global.closeSocket = () => { socketCloses++; };
+  global.resetCurrentSessionView = () => { viewResets++; };
+
+  await resetSession(target);
+  await deleteSession(target);
+
+  assert.equal(socketCloses, 1);
+  assert.equal(viewResets, 1);
+  assert.equal(state.currentView, null);
+  assert.deepEqual(selections, [resetting, null]);
+}
+
+async function testKeyboardActionsRestoreFocusAfterRefresh() {
+  resetHarness();
+  const target = {namespace: 'team-a', name: 'target', provider: 'codex'};
+  const neighbor = {namespace: 'team-a', name: 'neighbor', provider: 'codex'};
+  const render = sessions => {
+    state.sessions = sessions;
+    elements.list.replaceChildren(...sessions.map(session => createSessionListItem(session)));
+  };
+
+  render([target, neighbor]);
+  const originalAction = elements.list.querySelectorAll('.session-item-actions')[0];
+  openSessionActionsMenu(target, originalAction);
+  await runSessionMenuAction({detail: 0}, async session => render([{...session, resetting: true}, neighbor]));
+
+  const refreshedActions = elements.list.querySelectorAll('.session-item-actions');
+  assert.notEqual(refreshedActions[0], originalAction);
+  assert.equal(document.activeElement, refreshedActions[0]);
+
+  openSessionActionsMenu(state.sessions[0], refreshedActions[0]);
+  await runSessionMenuAction({detail: 0}, async () => render([neighbor]));
+  assert.equal(document.activeElement, elements.list.querySelectorAll('.session-item-actions')[0]);
+}
+
+async function testKeyboardActionRestoresFocusAfterRequestFailure() {
+  resetHarness();
+  const target = {namespace: 'team-a', name: 'target', provider: 'codex'};
+  state.sessions = [target];
+  elements.list.append(createSessionListItem(target));
+  const action = elements.list.querySelectorAll('.session-item-actions')[0];
+  openSessionActionsMenu(target, action);
+
+  global.api = async () => { throw new Error('request failed'); };
+  global.showToast = () => {};
+  await runSessionMenuAction({detail: 0}, resetSession);
+
+  assert.equal(document.activeElement, action);
+}
+
+function testMenuClosesWhenFocusLeaves() {
+  resetHarness();
+  const target = {namespace: 'team-a', name: 'target', provider: 'codex'};
+  state.sessions = [target];
+  const action = createSessionListItem(target).children[1];
+  openSessionActionsMenu(target, action);
+
+  handleSessionActionsFocusOut({relatedTarget: elements.sessionActionReset});
+  assert.equal(elements.sessionActionsMenu.hidden, false);
+
+  handleSessionActionsFocusOut({relatedTarget: new TestNode('button')});
+  assert.equal(elements.sessionActionsMenu.hidden, true);
+}
+
+assert.match(index, /id="session-actions-menu" role="menu"/);
+assert.match(index, /id="session-action-rename"[^>]+role="menuitem"/);
+assert.match(index, /id="session-action-reset"[^>]+role="menuitem"/);
+assert.match(index, /id="session-action-delete"[^>]+role="menuitem"/);
+assert.match(styles, /\.session-actions-menu button:focus-visible \{[^}]*outline: 2px solid var\(--accent-2\)/);
+assert.match(application, /sessionActionsMenu\.addEventListener\('focusout'/);
+
+testEverySessionRowHasActionsMenu()
+  .then(() => {
+    testOpenMenuSurvivesSessionRefresh();
+    return testActionsCanTargetAnUnselectedSession();
+  })
+  .then(() => testActionsUpdateTheSelectedSession())
+  .then(() => testKeyboardActionsRestoreFocusAfterRefresh())
+  .then(() => testKeyboardActionRestoresFocusAfterRequestFailure())
+  .then(() => {
+    testMenuClosesWhenFocusLeaves();
+    process.stdout.write('Session actions tests passed\n');
+  });

--- a/internal/sessionserver/web/app.js
+++ b/internal/sessionserver/web/app.js
@@ -9,6 +9,11 @@ const elements = {
   displayNameInput: document.querySelector('#session-display-name-input'),
   displayNameDialogError: document.querySelector('#display-name-dialog-error'),
   saveDisplayNameButton: document.querySelector('#save-session-display-name'),
+  sessionActionsMenu: document.querySelector('#session-actions-menu'),
+  sessionActionRename: document.querySelector('#session-action-rename'),
+  sessionActionReset: document.querySelector('#session-action-reset'),
+  sessionActionDelete: document.querySelector('#session-action-delete'),
+  newSessionButton: document.querySelector('#new-session'),
   sectionSelect: document.querySelector('#session-section-select'),
   sectionCustom: document.querySelector('#session-section-custom'),
   sectionForm: document.querySelector('#session-section-form'),
@@ -124,6 +129,9 @@ const state = {
   sourceStorageClassNamePresent: false,
   loadedSource: null,
   displayNameSaving: false,
+  displayNameSession: null,
+  sessionActionKey: '',
+  sessionActionTrigger: null,
   sectionSaving: false,
   sectionAssignments: new Set(),
   sectionOrders: new Map(),
@@ -626,18 +634,21 @@ function createPullRequestLink(pullRequest, className) {
 }
 
 function renderSessions() {
+  if (state.sessionActionKey) state.sessionActionTrigger = null;
   elements.list.replaceChildren();
   if (!state.sessions.length) {
     const empty = document.createElement('div');
     empty.className = 'sidebar-empty';
     empty.textContent = `No Sessions in ${state.namespace}.`;
     elements.list.append(empty);
+    syncSessionActionsMenu();
     return;
   }
 
   const sections = orderedSessionSections();
   if (!sections.length) {
     for (const session of state.sessions) elements.list.append(createSessionListItem(session));
+    syncSessionActionsMenu();
     return;
   }
 
@@ -691,6 +702,7 @@ function renderSessions() {
     configureSectionDrag(group, heading, title, section);
     elements.list.append(group);
   }
+  syncSessionActionsMenu();
 }
 
 function createSessionListItem(session, draggable = false) {
@@ -743,6 +755,23 @@ function createSessionListItem(session, draggable = false) {
   button.append(dot, text);
   button.addEventListener('click', () => selectSession(session, true));
   item.append(button);
+  const actions = document.createElement('button');
+  actions.className = 'session-item-actions';
+  actions.type = 'button';
+  actions.textContent = '…';
+  actions.title = `Actions for ${sessionDisplayName(session)}`;
+  actions.setAttribute('aria-label', actions.title);
+  actions.setAttribute('aria-haspopup', 'menu');
+  actions.setAttribute('aria-controls', 'session-actions-menu');
+  actions.setAttribute('aria-expanded', 'false');
+  actions.dataset.sessionKey = key;
+  actions.draggable = false;
+  actions.addEventListener('click', event => {
+    event.stopPropagation();
+    toggleSessionActionsMenu(session, actions);
+  });
+  item.append(actions);
+  if (state.sessionActionKey === key) state.sessionActionTrigger = actions;
   const link = createPullRequestLink(session.pullRequest, 'session-item-pull-request');
   if (link) {
     item.classList.add('has-pull-request');
@@ -751,6 +780,96 @@ function createSessionListItem(session, draggable = false) {
   }
   if (item.draggable) configureSessionDrag(item, session);
   return item;
+}
+
+function sessionActionsTarget() {
+  return state.sessions.find(session => sessionKey(session) === state.sessionActionKey) || null;
+}
+
+function sessionActionButtons() {
+  return Array.from(elements.list.querySelectorAll('.session-item-actions'));
+}
+
+function restoreSessionActionFocus(session, fallbackIndex) {
+  const buttons = sessionActionButtons();
+  const target = buttons.find(button => button.dataset.sessionKey === sessionKey(session));
+  const fallback = buttons[Math.min(Math.max(fallbackIndex, 0), buttons.length - 1)];
+  (target || fallback || elements.newSessionButton).focus();
+}
+
+async function runSessionMenuAction(event, action) {
+  const session = sessionActionsTarget();
+  if (!session) return;
+  const restoreFocus = event.detail === 0;
+  const fallbackIndex = sessionActionButtons().indexOf(state.sessionActionTrigger);
+  closeSessionActionsMenu();
+  await action(session);
+  if (restoreFocus) restoreSessionActionFocus(session, fallbackIndex);
+}
+
+function positionSessionActionsMenu(trigger) {
+  const triggerBounds = trigger.getBoundingClientRect();
+  const menuBounds = elements.sessionActionsMenu.getBoundingClientRect();
+  const margin = 8;
+  const gap = 4;
+  const left = Math.max(margin, Math.min(
+    triggerBounds.right - menuBounds.width,
+    window.innerWidth - menuBounds.width - margin,
+  ));
+  let top = triggerBounds.bottom + gap;
+  if (top + menuBounds.height > window.innerHeight - margin) {
+    top = Math.max(margin, triggerBounds.top - menuBounds.height - gap);
+  }
+  elements.sessionActionsMenu.style.left = `${left}px`;
+  elements.sessionActionsMenu.style.top = `${top}px`;
+}
+
+function closeSessionActionsMenu(restoreFocus = false) {
+  const trigger = state.sessionActionTrigger;
+  if (trigger) trigger.setAttribute('aria-expanded', 'false');
+  elements.sessionActionsMenu.hidden = true;
+  elements.sessionActionsMenu.removeAttribute('aria-label');
+  state.sessionActionKey = '';
+  state.sessionActionTrigger = null;
+  if (restoreFocus && trigger) trigger.focus();
+}
+
+function openSessionActionsMenu(session, trigger) {
+  closeSessionActionsMenu();
+  state.sessionActionKey = sessionKey(session);
+  state.sessionActionTrigger = trigger;
+  trigger.setAttribute('aria-expanded', 'true');
+  elements.sessionActionReset.disabled = session.resetting;
+  elements.sessionActionsMenu.setAttribute('aria-label', `Actions for ${sessionDisplayName(session)}`);
+  elements.sessionActionsMenu.hidden = false;
+  positionSessionActionsMenu(trigger);
+  elements.sessionActionRename.focus();
+}
+
+function toggleSessionActionsMenu(session, trigger) {
+  if (!elements.sessionActionsMenu.hidden && state.sessionActionKey === sessionKey(session)) {
+    closeSessionActionsMenu(true);
+    return;
+  }
+  openSessionActionsMenu(session, trigger);
+}
+
+function syncSessionActionsMenu() {
+  if (!state.sessionActionKey) return;
+  const session = sessionActionsTarget();
+  if (!session || !state.sessionActionTrigger) {
+    closeSessionActionsMenu();
+    return;
+  }
+  state.sessionActionTrigger.setAttribute('aria-expanded', 'true');
+  elements.sessionActionReset.disabled = session.resetting;
+  elements.sessionActionsMenu.setAttribute('aria-label', `Actions for ${sessionDisplayName(session)}`);
+  positionSessionActionsMenu(state.sessionActionTrigger);
+}
+
+function handleSessionActionsFocusOut(event) {
+  if (elements.sessionActionsMenu.contains(event.relatedTarget) || state.sessionActionTrigger?.contains(event.relatedTarget)) return;
+  closeSessionActionsMenu();
 }
 
 function sectionLabel(section) {
@@ -3592,7 +3711,7 @@ async function openDialog() {
   window.setTimeout(() => (state.creationMode === 'yaml' ? elements.yaml : elements.form.elements.name).focus(), 0);
 }
 
-document.querySelector('#new-session').addEventListener('click', openDialog);
+elements.newSessionButton.addEventListener('click', openDialog);
 document.querySelector('#welcome-new').addEventListener('click', openDialog);
 document.querySelectorAll('.close-dialog').forEach(button => button.addEventListener('click', () => elements.dialog.close()));
 elements.namespaceForm.addEventListener('submit', async event => {
@@ -3729,9 +3848,9 @@ elements.form.addEventListener('submit', async event => {
   }
 });
 
-function openDisplayNameDialog() {
-  const session = state.selected;
+function openDisplayNameDialog(session = state.selected) {
   if (!session || state.displayNameSaving) return;
+  state.displayNameSession = session;
   elements.displayNameDialogError.textContent = '';
   elements.displayNameDialogDescription.textContent = `Set a display name for Session ${session.namespace}/${session.name} without changing its Kubernetes resource name.`;
   elements.displayNameInput.value = sessionDisplayName(session) === session.name ? '' : sessionDisplayName(session);
@@ -3751,14 +3870,20 @@ function setDisplayNameSaving(saving) {
 }
 
 function closeDisplayNameDialog() {
-  if (!state.displayNameSaving) elements.displayNameDialog.close();
+  if (state.displayNameSaving) return;
+  state.displayNameSession = null;
+  elements.displayNameDialog.close();
 }
 
 function handleDisplayNameDialogCancel(event) {
-  if (state.displayNameSaving) event.preventDefault();
+  if (state.displayNameSaving) {
+    event.preventDefault();
+    return;
+  }
+  state.displayNameSession = null;
 }
 
-elements.displayNameButton.addEventListener('click', openDisplayNameDialog);
+elements.displayNameButton.addEventListener('click', () => openDisplayNameDialog());
 document.querySelectorAll('.close-display-name-dialog').forEach(button => {
   button.addEventListener('click', closeDisplayNameDialog);
 });
@@ -3767,13 +3892,15 @@ elements.displayNameDialog.addEventListener('cancel', handleDisplayNameDialogCan
 elements.displayNameForm.addEventListener('submit', async event => {
   event.preventDefault();
   if (state.displayNameSaving) return;
-  const session = state.selected;
+  const session = state.displayNameSession;
   if (!session) {
+    state.displayNameSession = null;
     elements.displayNameDialog.close();
     return;
   }
   const displayName = elements.displayNameInput.value.trim();
   if ((displayName || session.name) === sessionDisplayName(session)) {
+    state.displayNameSession = null;
     elements.displayNameDialog.close();
     return;
   }
@@ -3782,6 +3909,7 @@ elements.displayNameForm.addEventListener('submit', async event => {
   try {
     await saveSessionDisplayName(session, displayName);
     elements.displayNameDialog.close();
+    state.displayNameSession = null;
     showToast(displayName ? 'Session renamed' : 'Session name reset');
   } catch (error) {
     elements.displayNameDialogError.textContent = error.message;
@@ -3875,39 +4003,68 @@ elements.sectionForm.addEventListener('submit', async event => {
   await saveSelectedSessionSection(elements.sectionChoiceCustom.value.trim());
 });
 
-elements.deleteButton.addEventListener('click', async () => {
-  const session = state.selected;
+async function deleteSession(session) {
   if (!session || !window.confirm(`Delete Session ${session.namespace}/${session.name}? The live conversation will end.`)) return;
   try {
     await api(`/api/sessions/${encodeURIComponent(session.namespace)}/${encodeURIComponent(session.name)}`, {method: 'DELETE'});
     discardSessionView(session);
-    selectSession(null);
     clearPromptDraft(session);
     clearAttachmentDraft(session);
+    if (state.selected && sessionKey(state.selected) === sessionKey(session)) selectSession(null);
     await loadSessions();
     showToast('Session deleted');
   } catch (error) {
     showToast(error.message);
   }
-});
-elements.resetButton.addEventListener('click', async () => {
-  const session = state.selected;
+}
+
+async function resetSession(session) {
   if (!session || session.resetting || !window.confirm(`Reset Session ${session.namespace}/${session.name}? This permanently deletes its conversation history and all workspace changes.`)) return;
   try {
     const resetting = await api(`/api/sessions/${encodeURIComponent(session.namespace)}/${encodeURIComponent(session.name)}/reset`, {method: 'POST'});
-    closeSocket();
-    resetCurrentSessionView();
     discardSessionView(session);
-    state.currentView = null;
     clearPromptDraft(session);
     clearAttachmentDraft(session);
-    selectSession(resetting);
+    if (state.selected && sessionKey(state.selected) === sessionKey(session)) {
+      closeSocket();
+      resetCurrentSessionView();
+      state.currentView = null;
+      selectSession(resetting);
+    }
     await loadSessions();
     showToast('Session reset requested');
   } catch (error) {
     showToast(error.message);
   }
+}
+
+elements.deleteButton.addEventListener('click', () => deleteSession(state.selected));
+elements.resetButton.addEventListener('click', () => resetSession(state.selected));
+elements.sessionActionRename.addEventListener('click', () => {
+  const session = sessionActionsTarget();
+  closeSessionActionsMenu();
+  openDisplayNameDialog(session);
 });
+elements.sessionActionReset.addEventListener('click', event => {
+  void runSessionMenuAction(event, resetSession);
+});
+elements.sessionActionDelete.addEventListener('click', event => {
+  void runSessionMenuAction(event, deleteSession);
+});
+elements.sessionActionsMenu.addEventListener('keydown', event => {
+  const items = Array.from(elements.sessionActionsMenu.querySelectorAll('[role="menuitem"]'))
+    .filter(item => !item.disabled);
+  if (!items.length) return;
+  let index = items.indexOf(document.activeElement);
+  if (event.key === 'ArrowDown') index = (index + 1) % items.length;
+  else if (event.key === 'ArrowUp') index = (index - 1 + items.length) % items.length;
+  else if (event.key === 'Home') index = 0;
+  else if (event.key === 'End') index = items.length - 1;
+  else return;
+  event.preventDefault();
+  items[index].focus();
+});
+elements.sessionActionsMenu.addEventListener('focusout', handleSessionActionsFocusOut);
 elements.conversationTab.addEventListener('click', () => setActiveView('conversation'));
 elements.changesTab.addEventListener('click', () => setActiveView('changes'));
 elements.viewTabs.addEventListener('keydown', handleViewTabKeydown);
@@ -3933,7 +4090,19 @@ function setSidebarOpen(open) {
 elements.openSidebar.addEventListener('click', () => setSidebarOpen(true));
 elements.closeSidebar.addEventListener('click', () => setSidebarOpen(false));
 elements.sidebarScrim.addEventListener('click', () => setSidebarOpen(false));
+elements.list.addEventListener('scroll', () => closeSessionActionsMenu());
+window.addEventListener('resize', () => closeSessionActionsMenu());
+document.addEventListener('pointerdown', event => {
+  if (elements.sessionActionsMenu.hidden) return;
+  if (elements.sessionActionsMenu.contains(event.target) || state.sessionActionTrigger?.contains(event.target)) return;
+  closeSessionActionsMenu();
+});
 document.addEventListener('keydown', event => {
+  if (event.key === 'Escape' && !elements.sessionActionsMenu.hidden) {
+    event.preventDefault();
+    closeSessionActionsMenu(true);
+    return;
+  }
   if (event.key === 'Escape' && elements.sidebar.classList.contains('open')) setSidebarOpen(false);
 });
 

--- a/internal/sessionserver/web/index.html
+++ b/internal/sessionserver/web/index.html
@@ -275,6 +275,13 @@
     </form>
   </dialog>
 
+  <div class="session-actions-menu" id="session-actions-menu" role="menu" hidden>
+    <button id="session-action-rename" type="button" role="menuitem">Rename</button>
+    <button id="session-action-reset" type="button" role="menuitem">Reset</button>
+    <div class="session-actions-separator" role="separator"></div>
+    <button class="danger" id="session-action-delete" type="button" role="menuitem">Delete</button>
+  </div>
+
   <div class="toast" id="toast" role="status"></div>
   <script src="/assets/app.js" defer></script>
 </body>

--- a/internal/sessionserver/web/styles.css
+++ b/internal/sessionserver/web/styles.css
@@ -66,14 +66,25 @@ button { color: inherit; }
 .session-section-group.section-drop-before::before { top: -8px; }
 .session-section-group.section-drop-after::after { bottom: -8px; }
 .session-section-group.dragging, .session-item.dragging { opacity: .45; }
-.session-item { width: 100%; border-radius: 11px; background: transparent; transition: background .15s; }
+.session-item { position: relative; width: 100%; border-radius: 11px; background: transparent; transition: background .15s; }
 .session-item:hover { background: rgba(255,255,255,.55); }
 .session-item.active { background: #fff; box-shadow: 0 4px 14px rgba(35,49,42,.06); }
 .session-item.section-saving { opacity: .55; }
-.session-item-select { width: 100%; display: grid; grid-template-columns: 9px minmax(0,1fr); gap: 9px; padding: 11px 10px; border: 0; background: transparent; text-align: left; cursor: pointer; }
+.session-item-select { width: 100%; display: grid; grid-template-columns: 9px minmax(0,1fr); gap: 9px; padding: 11px 42px 11px 10px; border: 0; background: transparent; text-align: left; cursor: pointer; }
 .session-item[draggable="true"] .session-item-select { cursor: grab; }
 .session-item[draggable="true"] .session-item-select:active { cursor: grabbing; }
 .session-item.has-pull-request .session-item-select { padding-bottom: 5px; }
+.session-item-actions { position: absolute; top: 6px; right: 5px; width: 32px; height: 32px; display: grid; place-items: center; padding: 0 0 5px; border: 0; border-radius: 8px; background: transparent; color: var(--faint); font-size: 18px; line-height: 1; cursor: pointer; }
+.session-item-actions:hover, .session-item-actions:focus-visible, .session-item-actions[aria-expanded="true"] { background: var(--line-soft); color: var(--ink); }
+.session-item-actions:focus-visible { outline: 2px solid var(--accent-2); outline-offset: 1px; }
+.session-actions-menu { position: fixed; z-index: 30; width: 176px; padding: 6px; border: 1px solid var(--line); border-radius: 12px; background: var(--card); box-shadow: 0 16px 45px rgba(25,39,31,.2); }
+.session-actions-menu[hidden] { display: none; }
+.session-actions-menu button { width: 100%; padding: 9px 10px; border: 0; border-radius: 8px; background: transparent; color: var(--ink); font-size: 12px; font-weight: 650; text-align: left; cursor: pointer; }
+.session-actions-menu button:hover { background: var(--line-soft); }
+.session-actions-menu button:focus-visible { outline: 2px solid var(--accent-2); outline-offset: -2px; background: var(--line-soft); }
+.session-actions-menu button:disabled { opacity: .45; cursor: default; }
+.session-actions-menu button.danger { color: var(--danger); }
+.session-actions-separator { height: 1px; margin: 5px 4px; background: var(--line-soft); }
 .phase-dot { width: 7px; height: 7px; margin-top: 5px; border-radius: 50%; background: #9ca69f; }
 .phase-dot.ready, .phase-dot.idle { background: #4b9a6f; box-shadow: 0 0 0 3px rgba(75,154,111,.12); }
 .phase-dot.active { background: #c68a3d; box-shadow: 0 0 0 3px rgba(198,138,61,.14); }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds an overflow menu to every Session row in the session server sidebar. The menu exposes Rename, Reset, and Delete without requiring the Session to be selected first, and supports touch, click-outside, Escape, and keyboard navigation.

This makes Session management accessible directly from the list, especially on mobile and when working with many Sessions.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

The existing selected-Session header actions remain available. Focused JavaScript coverage verifies row rendering, refresh behavior, and actions against an unselected Session.

Validation:

- `make test`
- `make verify`

#### Does this PR introduce a user-facing change?

```release-note
The Session web sidebar now provides a per-Session actions menu for renaming, resetting, or deleting Sessions.
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per-session Actions menu in the sidebar so users can Rename, Reset, or Delete any Session without changing the current selection. Previously these actions only applied to the selected Session; now they target the chosen row and only affect selection when acting on the selected Session.

- UI: Per-row "…" button opens a fixed-position `role="menu"` with ArrowUp/ArrowDown/Home/End navigation; Escape/outside click/scroll/resize close; focus restores to the correct row. The menu labels the target Session, disables Reset while resetting, survives list re-renders, and can open Rename for the targeted Session.
- Behavior: Rename, Reset, and Delete operate on the targeted Session. Reset/Delete always discard the target’s cached view and clear prompt and attachment drafts. If the target is selected: Reset also closes the socket, resets the current view, and selects the resetting Session; Delete clears the selection.
- Implementation: Adds `sessionActionKey`, `sessionActionTrigger`, and `displayNameSession`. Positions the menu relative to the trigger and keeps ARIA/focus in sync across refreshes or request failures.
- Tests/Docs/Styles: Adds a Node-based harness (invoked from Go) covering rendering, roles, keyboard focus/closing behavior, persistence across refresh, and actions on unselected Sessions. Updates docs to reference the per-row menu for rename/reset/delete. Adds markup/styles for `.session-item-actions`, `.session-actions-menu`, and the separator.

<sup>Written for commit f61a5c3abbc08a2f54606222eeff5ee52a74097a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1663?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

