### PR TITLE
Make Session idle policy mutable

### DIFF
--- a/api/v1alpha2/session_types.go
+++ b/api/v1alpha2/session_types.go
@@ -228,7 +228,6 @@ type Session struct {
 	// +kubebuilder:validation:XValidation:rule="(!has(self.initialBranch) ? '' : self.initialBranch) == (!has(oldSelf.initialBranch) ? '' : oldSelf.initialBranch)",message="initialBranch is immutable"
 	// +kubebuilder:validation:XValidation:rule="(!has(self.initialPrompt) ? '' : self.initialPrompt) == (!has(oldSelf.initialPrompt) ? '' : oldSelf.initialPrompt)",message="initialPrompt is immutable"
 	// +kubebuilder:validation:XValidation:rule="has(self.volumeClaimTemplate) == has(oldSelf.volumeClaimTemplate) && (!has(self.volumeClaimTemplate) || self.volumeClaimTemplate == oldSelf.volumeClaimTemplate)",message="volumeClaimTemplate is immutable"
-	// +kubebuilder:validation:XValidation:rule="has(self.idlePolicy) == has(oldSelf.idlePolicy) && (!has(self.idlePolicy) || self.idlePolicy == oldSelf.idlePolicy)",message="idlePolicy is immutable"
 	Spec   SessionSpec   `json:"spec"`
 	Status SessionStatus `json:"status,omitempty"`
 }

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -197,8 +197,8 @@ the refreshed value on their next sync and are not supported.
 A Session is one interactive Claude Code, Codex, or OpenCode conversation that
 web and terminal clients can share and reconnect to. The spec is immutable
 except for `spec.worker.credentials`, `spec.worker.model`,
-fields under `spec.worker.podOverrides` other than `serviceAccountName`, and
-`spec.suspend`.
+`spec.suspend`, `spec.idlePolicy`, and fields under `spec.worker.podOverrides`
+other than `serviceAccountName`.
 Conversation events and history are retained on the Session workspace rather
 than in the Kubernetes API. If configured, `spec.initialPrompt` also remains in
 the Session resource and is visible through the Kubernetes API.

--- a/internal/manifests/charts/kelos/charts/kelos-crds/templates/session-crd.yaml
+++ b/internal/manifests/charts/kelos/charts/kelos-crds/templates/session-crd.yaml
@@ -7232,9 +7232,6 @@ spec:
               rule: has(self.volumeClaimTemplate) == has(oldSelf.volumeClaimTemplate)
                 && (!has(self.volumeClaimTemplate) || self.volumeClaimTemplate ==
                 oldSelf.volumeClaimTemplate)
-            - message: idlePolicy is immutable
-              rule: has(self.idlePolicy) == has(oldSelf.idlePolicy) && (!has(self.idlePolicy)
-                || self.idlePolicy == oldSelf.idlePolicy)
             - message: worker.type must be claude-code, codex, or opencode
               rule: has(self.worker.type) && self.worker.type in ['claude-code', 'codex',
                 'opencode']

--- a/internal/manifests/install-crd.yaml
+++ b/internal/manifests/install-crd.yaml
@@ -7873,9 +7873,6 @@ spec:
               rule: has(self.volumeClaimTemplate) == has(oldSelf.volumeClaimTemplate)
                 && (!has(self.volumeClaimTemplate) || self.volumeClaimTemplate ==
                 oldSelf.volumeClaimTemplate)
-            - message: idlePolicy is immutable
-              rule: has(self.idlePolicy) == has(oldSelf.idlePolicy) && (!has(self.idlePolicy)
-                || self.idlePolicy == oldSelf.idlePolicy)
             - message: worker.type must be claude-code, codex, or opencode
               rule: has(self.worker.type) && self.worker.type in ['claude-code', 'codex',
                 'opencode']

--- a/test/integration/session_test.go
+++ b/test/integration/session_test.go
@@ -659,6 +659,33 @@ spec:
 		}
 	})
 
+	It("allows adding and removing the Session idle policy", func() {
+		session := validSession(namespace, "mutable-idle-policy", "codex")
+		Expect(k8sClient.Create(ctx, session)).To(Succeed())
+
+		session.Spec.IdlePolicy = &kelos.SessionIdlePolicy{SuspendAfterSeconds: ptr.To(int32(3600))}
+		Expect(k8sClient.Update(ctx, session)).To(Succeed())
+
+		session.Spec.IdlePolicy = nil
+		Expect(k8sClient.Update(ctx, session)).To(Succeed())
+
+		var current kelos.Session
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(session), &current)).To(Succeed())
+		Expect(current.Spec.IdlePolicy).To(BeNil())
+	})
+
+	It("rejects invalid Session idle policy updates", func() {
+		session := validSession(namespace, "invalid-idle-policy-update", "codex")
+		session.Spec.IdlePolicy = &kelos.SessionIdlePolicy{
+			SuspendAfterSeconds: ptr.To(int32(3600)),
+			DeleteAfterSeconds:  ptr.To(int32(7200)),
+		}
+		Expect(k8sClient.Create(ctx, session)).To(Succeed())
+
+		session.Spec.IdlePolicy.SuspendAfterSeconds = ptr.To(int32(7200))
+		Expect(k8sClient.Update(ctx, session)).NotTo(Succeed())
+	})
+
 	It("keeps Session configuration immutable", func() {
 		mutations := []struct {
 			name   string
@@ -690,9 +717,6 @@ spec:
 			}},
 			{name: "volume-claim-template", mutate: func(session *kelos.Session) {
 				session.Spec.VolumeClaimTemplate = nil
-			}},
-			{name: "idle-policy", mutate: func(session *kelos.Session) {
-				session.Spec.IdlePolicy = &kelos.SessionIdlePolicy{SuspendAfterSeconds: ptr.To(int32(60))}
 			}},
 		}
 		for _, mutation := range mutations {


### PR DESCRIPTION
#### What type of PR is this?

/kind api

#### What this PR does / why we need it:

Allows `Session.spec.idlePolicy` to be updated after a Session is created. The CRD previously rejected every idle policy update through an immutability CEL rule, which prevented operators from tuning or disabling lifecycle thresholds without recreating the Session.

This removes that rule from the API markers and generated CRDs, documents the field as mutable, and adds integration coverage for updating a stored idle policy.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

The existing non-negative duration and `suspendAfterSeconds < deleteAfterSeconds` validations remain enforced. Other immutable Session fields are unchanged.

Validation:

- `make test-integration`
- `make verify`

#### Does this PR introduce a user-facing change?

```release-note
Session idle policies can now be updated after a Session is created.
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows updating `Session.spec.idlePolicy` so operators can tune or disable suspend/delete thresholds without recreating a Session. Previously any change was rejected by a CEL immutability rule; now updates (including add/remove) are allowed while existing duration validations still apply.

- Removes the CEL immutability rule for `spec.idlePolicy` from API markers and regenerated CRDs.
- Updates `docs/reference.md` to document `spec.idlePolicy` as mutable.
- Adds integration tests for add/remove and invalid updates; removes idle policy from the "immutable" test set.
- Validations unchanged: non-negative durations and `suspendAfterSeconds < deleteAfterSeconds`. No migration required.

<sup>Written for commit b7b56a1f7689114446e0c2148b3b74f0632dc847. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

