### PR TITLE
Use GPT-5.6 Luna for Codex e2e tests

### DIFF
--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	claudeCodeModel = "haiku"
-	codexModel      = "gpt-5.3-codex-spark"
+	codexModel      = "gpt-5.6-luna"
 	openCodeModel   = "opencode/big-pickle"
 )
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Updates the Codex e2e test model from the deprecated `gpt-5.3-codex-spark` model to the cost-efficient `gpt-5.6-luna` model.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

`make verify` passes. The e2e suite was not run locally because it requires a cluster and agent credentials.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches Codex e2e tests from deprecated `gpt-5.3-codex-spark` to `gpt-5.6-luna` to keep the suite supported and reduce cost.

- Updates only the `codexModel` constant in test/e2e/suite_test.go; no other code paths change.
- No configuration or API changes; CI e2e should pass with existing agent credentials.
- Watch for output drift from `gpt-5.6-luna` that could affect brittle assertions.

<sup>Written for commit 9df7e1cebe2a59f769d055311187fbbc3fc9b86c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1666?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

