### PR TITLE
Increase deploy-dev controller memory

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -166,10 +166,10 @@ jobs:
             resources:
               requests:
                 cpu: 10m
-                memory: 64Mi
+                memory: 128Mi
               limits:
                 cpu: 500m
-                memory: 128Mi
+                memory: 256Mi
           sessionServer:
             enabled: true
             secretName: kelos-session-server-auth


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Increases the deploy-dev controller manager memory request from 64Mi to 128Mi and its memory limit from 128Mi to 256Mi. The existing 128Mi limit caused repeated OOMKills, leaving the controller unavailable to reconcile pending Session updates.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

`make verify` passes. CPU resources are unchanged.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents OOMKills of the deploy-dev controller by increasing memory so it stays available to reconcile Session updates. Raises memory request from 64Mi to 128Mi and limit from 128Mi to 256Mi; CPU remains unchanged.

- Change is confined to `.github/workflows/deploy-dev.yaml` and affects dev deploys only.
- No migration required; takes effect on the next dev deployment.

<sup>Written for commit 7d6e4b52c67611aeff7093554a95f2644c9344f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1667?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

