### PR TITLE
Document CI remediation repository placeholders

### DIFF
--- a/examples/17-taskspawner-ci-remediation/README.md
+++ b/examples/17-taskspawner-ci-remediation/README.md
@@ -46,7 +46,11 @@ In addition to the standard webhook variables, `check_run` events expose:
 
 1. Enable the **Check runs** event on your GitHub repository webhook (Settings →
    Webhooks → your webhook → "Let me select individual events").
-2. Apply the manifests:
+2. Edit `taskspawner.yaml` and replace both `myorg/myrepo` placeholders with
+   your repository. Set `spec.when.githubWebhook.repository` to the repository
+   name in `owner/repo` format and set the Workspace's `spec.repo` to its clone
+   URL. Both values must identify the repository configured in step 1.
+3. Apply the manifests:
 
    ```bash
    kubectl apply -f taskspawner.yaml

--- a/examples/17-taskspawner-ci-remediation/taskspawner.yaml
+++ b/examples/17-taskspawner-ci-remediation/taskspawner.yaml
@@ -7,6 +7,7 @@ spec:
   # Watch for failing CI checks and dispatch an agent to diagnose and fix them.
   when:
     githubWebhook:
+      # TODO: Replace with your repository in "owner/repo" format.
       repository: myorg/myrepo
       events:
         - "check_run"
@@ -108,6 +109,7 @@ metadata:
   name: my-repo-workspace
   namespace: default
 spec:
+  # TODO: Replace with the clone URL for the repository above.
   repo: "https://github.com/myorg/myrepo.git"
   # secretRef:
   #   name: github-token


### PR DESCRIPTION
#### What type of PR is this?

/kind docs

#### What this PR does / why we need it:

Documents the two repository placeholders that users must replace before applying the CI remediation example. The manifest also marks both placeholder fields inline and explains their required formats.

#### Which issue(s) this PR is related to:

Fixes #1628

#### Special notes for your reviewer:

Verified with `make verify`.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the required repository placeholders in the CI remediation example so users configure it correctly. Previously the example assumed implicit values; now the README and `taskspawner.yaml` mark both fields and specify formats.

- README: adds a step to edit `taskspawner.yaml` before applying—replace `myorg/myrepo`, set `spec.when.githubWebhook.repository` to owner/repo, and set the Workspace `spec.repo` to the clone URL; both must reference the repository used by the webhook.
- `taskspawner.yaml`: adds inline TODO comments above the two fields to guide replacement.
- No functional changes; example behavior is unchanged.

<sup>Written for commit 3467e168f582986e93f6d26b14a274942f23bca8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1672?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

