### PR TITLE
Show Task logs in the Console

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -475,6 +475,12 @@ connect to Sessions across namespaces while operating on one active namespace
 at a time. Users can switch the active namespace live from the sidebar.
 `consoleServer.defaultNamespace` sets its initial value, and resource inventory,
 Session form options, and credential options are loaded only from the active namespace.
+Selecting a Task from the resource inventory shows its agent container logs and
+manifest. The Logs tab shows up to the latest 2,000 lines with a 2 MiB maximum
+and can be refreshed while the Task is running. WorkerPool-backed Task views
+include only the selected Task's segment from the recent shared worker Pod log.
+The Console reports that the segment is unavailable when its markers are
+outside the bounded log window.
 Selecting an existing Session as a source populates both the form fields and the
 editable YAML manifest. Settings that the form cannot represent remain editable
 in YAML mode.

--- a/internal/consoleserver/server.go
+++ b/internal/consoleserver/server.go
@@ -56,7 +56,15 @@ const (
 	maxSessionSectionLength      = 64
 	requestBodyLimit             = 1024 * 1024
 	attachmentRequestLimit       = sessionruntime.MaxAttachmentBytes + 1024*1024
+	taskLogTailLineLimit         = 2000
+	taskLogTailByteLimit         = 2 * 1024 * 1024
+	taskLogScannerMaxTokenSize   = 10 * 1024 * 1024
+	taskLogOmittedMessage        = "[... earlier log output omitted ...]\n"
+	workerTaskLogLineLimit       = taskLogTailLineLimit + 2
+	workerTaskLogSinceMargin     = 5 * time.Second
 )
+
+var errTaskLogSegmentUnavailable = errors.New("Task log segment is unavailable in the recent WorkerPool log window")
 
 //go:embed web/*
 var webFiles embed.FS
@@ -84,6 +92,7 @@ type Server struct {
 	upgrader         websocket.Upgrader
 	bridge           func(context.Context, *sessionSocket, string, string, func() error) error
 	attachments      sessionAttachmentTransfer
+	taskLogStream    func(context.Context, *kelos.Task, int64) (io.ReadCloser, error)
 }
 
 type sessionAttachmentTransfer interface {
@@ -266,6 +275,7 @@ func New(config Config) (*Server, error) {
 		},
 	}
 	server.bridge = server.bridgeExec
+	server.taskLogStream = server.openTaskLogStream
 	server.handler = server.routes()
 	return server, nil
 }
@@ -393,6 +403,10 @@ func (s *Server) api(writer http.ResponseWriter, request *http.Request) {
 	}
 	if len(parts) == 4 && parts[0] == "resources" && request.Method == http.MethodGet {
 		s.getConsoleResource(writer, request, parts[1], parts[2], parts[3])
+		return
+	}
+	if len(parts) == 5 && parts[0] == "resources" && parts[1] == "tasks" && parts[4] == "logs" && request.Method == http.MethodGet {
+		s.getTaskLogs(writer, request, parts[2], parts[3])
 		return
 	}
 	if len(parts) < 3 || parts[0] != "sessions" {
@@ -567,6 +581,189 @@ func (s *Server) getConsoleResource(writer http.ResponseWriter, request *http.Re
 		Namespace: namespace,
 		YAML:      string(data),
 	})
+}
+
+func (s *Server) getTaskLogs(writer http.ResponseWriter, request *http.Request, namespace, name string) {
+	var task kelos.Task
+	if err := s.client.Get(request.Context(), client.ObjectKey{Namespace: namespace, Name: name}, &task); err != nil {
+		writeKubernetesError(writer, fmt.Sprintf("getting Task %q", name), err)
+		return
+	}
+	if task.Status.PodName == "" {
+		writeError(writer, http.StatusConflict, fmt.Sprintf("Task %q has no pod yet", name))
+		return
+	}
+
+	logs, err := s.readTaskLogs(request.Context(), &task)
+	if err != nil {
+		if errors.Is(err, errTaskLogSegmentUnavailable) {
+			writeError(writer, http.StatusNotFound, fmt.Sprintf("Task %q log segment is unavailable in the recent WorkerPool log window", name))
+			return
+		}
+		writeKubernetesError(writer, fmt.Sprintf("getting logs for Task %q", name), err)
+		return
+	}
+
+	writer.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	writer.WriteHeader(http.StatusOK)
+	_, _ = io.WriteString(writer, logs)
+}
+
+func (s *Server) readTaskLogs(ctx context.Context, task *kelos.Task) (string, error) {
+	if task.Spec.WorkerPoolRef == nil {
+		stream, err := s.taskLogStream(ctx, task, taskLogTailLineLimit)
+		if err != nil {
+			return "", err
+		}
+		defer stream.Close()
+		return tailLogLines(stream, taskLogTailLineLimit, taskLogTailByteLimit)
+	}
+
+	stream, err := s.taskLogStream(ctx, task, workerTaskLogLineLimit)
+	if err != nil {
+		return "", err
+	}
+	logs, found, err := tailWorkerTaskLogSegment(stream, task.Name, taskLogTailLineLimit, taskLogTailByteLimit, true)
+	_ = stream.Close()
+	if err != nil {
+		return "", err
+	}
+	if !found {
+		return "", errTaskLogSegmentUnavailable
+	}
+	return logs, nil
+}
+
+func (s *Server) openTaskLogStream(ctx context.Context, task *kelos.Task, tailLines int64) (io.ReadCloser, error) {
+	return s.clientset.CoreV1().Pods(task.Namespace).GetLogs(task.Status.PodName, taskPodLogOptions(task, tailLines)).Stream(ctx)
+}
+
+func taskPodLogOptions(task *kelos.Task, tailLines int64) *corev1.PodLogOptions {
+	options := &corev1.PodLogOptions{Container: kelos.AgentContainerName}
+	if tailLines > 0 {
+		options.TailLines = &tailLines
+	}
+	if task.Spec.WorkerPoolRef == nil {
+		return options
+	}
+
+	// The worker can observe its Pod assignment just before StartTime is persisted.
+	if task.Status.StartTime != nil {
+		sinceTime := metav1.NewTime(task.Status.StartTime.Add(-workerTaskLogSinceMargin))
+		options.SinceTime = &sinceTime
+	}
+	if !task.CreationTimestamp.IsZero() && (options.SinceTime == nil || task.CreationTimestamp.After(options.SinceTime.Time)) {
+		createdAt := task.CreationTimestamp
+		options.SinceTime = &createdAt
+	}
+	return options
+}
+
+type boundedLogTail struct {
+	lines     []string
+	start     int
+	byteSize  int
+	maxLines  int
+	maxBytes  int
+	truncated bool
+}
+
+func newBoundedLogTail(maxLines, maxBytes int) *boundedLogTail {
+	maxBytes -= len(taskLogOmittedMessage)
+	return &boundedLogTail{
+		lines:    make([]string, 0, maxLines),
+		maxLines: maxLines,
+		maxBytes: maxBytes,
+	}
+}
+
+func (tail *boundedLogTail) reset() {
+	tail.lines = tail.lines[:0]
+	tail.start = 0
+	tail.byteSize = 0
+	tail.truncated = false
+}
+
+func (tail *boundedLogTail) add(line string) {
+	if len(line)+1 > tail.maxBytes {
+		start := len(line) - (tail.maxBytes - 1)
+		for start < len(line) && !utf8.RuneStart(line[start]) {
+			start++
+		}
+		line = line[start:]
+		tail.truncated = true
+	}
+	lineBytes := len(line) + 1
+	for len(tail.lines)-tail.start > 0 && (len(tail.lines)-tail.start >= tail.maxLines || tail.byteSize+lineBytes > tail.maxBytes) {
+		tail.byteSize -= len(tail.lines[tail.start]) + 1
+		tail.lines[tail.start] = ""
+		tail.start++
+		tail.truncated = true
+	}
+	if tail.start >= tail.maxLines {
+		copy(tail.lines, tail.lines[tail.start:])
+		tail.lines = tail.lines[:len(tail.lines)-tail.start]
+		tail.start = 0
+	}
+	tail.lines = append(tail.lines, line)
+	tail.byteSize += lineBytes
+}
+
+func (tail *boundedLogTail) string() string {
+	if len(tail.lines) == tail.start {
+		return ""
+	}
+	var result strings.Builder
+	result.Grow(tail.byteSize)
+	if tail.truncated {
+		result.WriteString(taskLogOmittedMessage)
+	}
+	for _, line := range tail.lines[tail.start:] {
+		result.WriteString(line)
+		result.WriteByte('\n')
+	}
+	return result.String()
+}
+
+func tailLogLines(reader io.Reader, maxLines, maxBytes int) (string, error) {
+	tail := newBoundedLogTail(maxLines, maxBytes)
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 0, 64*1024), taskLogScannerMaxTokenSize)
+	for scanner.Scan() {
+		tail.add(scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+	return tail.string(), nil
+}
+
+func tailWorkerTaskLogSegment(reader io.Reader, taskName string, maxLines, maxBytes int, acceptPartial bool) (string, bool, error) {
+	startMarker := "---KELOS_TASK_START--- " + taskName
+	endMarker := "---KELOS_TASK_END--- " + taskName
+	tail := newBoundedLogTail(maxLines, maxBytes)
+	inSegment := false
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 0, 64*1024), taskLogScannerMaxTokenSize)
+	for scanner.Scan() {
+		line := scanner.Text()
+		switch {
+		case line == startMarker:
+			inSegment = true
+			tail.reset()
+		case line == endMarker && (inSegment || acceptPartial):
+			return tail.string(), true, nil
+		case inSegment || acceptPartial:
+			tail.add(line)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", false, err
+	}
+	if inSegment {
+		return tail.string(), true, nil
+	}
+	return "", false, nil
 }
 
 func consoleResourceDefinitionFor(resource string) (consoleResourceDefinition, bool) {

--- a/internal/consoleserver/server_test.go
+++ b/internal/consoleserver/server_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -15,6 +16,7 @@ import (
 	"sync"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/gorilla/websocket"
 	corev1 "k8s.io/api/core/v1"
@@ -113,6 +115,9 @@ func TestConsoleApplicationIncludesResourceViews(t *testing.T) {
 		`id="overview-view"`,
 		`id="resources-view"`,
 		`id="resource-detail-dialog"`,
+		`id="resource-detail-logs-tab"`,
+		`id="refresh-resource-logs"`,
+		`id="resource-detail-logs"`,
 	} {
 		if !strings.Contains(response.Body.String(), expected) {
 			t.Errorf("Console application does not contain %s", expected)
@@ -126,8 +131,13 @@ func TestConsoleApplicationIncludesResourceViews(t *testing.T) {
 		"async function loadResources",
 		"function renderOverview",
 		"function renderResources",
+		"function setResourceDetailView",
+		"function handleResourceDetailTabKeydown",
+		"async function loadResourceTaskLogs",
 		"async function openResourceDetail",
+		"elements.resourceDetailTabs.addEventListener('keydown', handleResourceDetailTabKeydown)",
 		"/api/resources?namespace=",
+		"/api/resources/tasks/",
 	} {
 		if !strings.Contains(string(javascript), expected) {
 			t.Errorf("Console JavaScript does not contain %q", expected)
@@ -137,7 +147,7 @@ func TestConsoleApplicationIncludesResourceViews(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, expected := range []string{".resource-summary-grid", ".resource-summary-card", ".resource-table", ".resource-detail-dialog"} {
+	for _, expected := range []string{".resource-summary-grid", ".resource-summary-card", ".resource-table", ".resource-detail-dialog", ".resource-detail-tabs[hidden]"} {
 		if !strings.Contains(string(styles), expected) {
 			t.Errorf("Console styles do not contain %q", expected)
 		}
@@ -210,6 +220,285 @@ func TestConsoleResourcesListAndGet(t *testing.T) {
 		if !strings.Contains(detail.YAML, expected) {
 			t.Errorf("resource detail YAML does not contain %q:\n%s", expected, detail.YAML)
 		}
+	}
+}
+
+func TestConsoleTaskLogs(t *testing.T) {
+	server := testServer(t)
+	task := &kelos.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: "running-task", Namespace: "team-a"},
+		Status:     kelos.TaskStatus{Phase: kelos.TaskPhaseRunning, PodName: "running-task-pod"},
+	}
+	if err := server.client.Create(t.Context(), task); err != nil {
+		t.Fatal(err)
+	}
+	server.taskLogStream = func(_ context.Context, got *kelos.Task, tailLines int64) (io.ReadCloser, error) {
+		if got.Name != task.Name || got.Status.PodName != task.Status.PodName {
+			t.Fatalf("Task passed to log stream = %#v", got)
+		}
+		if tailLines != taskLogTailLineLimit {
+			t.Fatalf("Task log tail lines = %d, want %d", tailLines, taskLogTailLineLimit)
+		}
+		return io.NopCloser(strings.NewReader("agent output\n")), nil
+	}
+
+	request := httptest.NewRequest(http.MethodGet, "/api/resources/tasks/team-a/running-task/logs", nil)
+	request.Header.Set("Authorization", "Bearer secret-token")
+	response := httptest.NewRecorder()
+	server.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("Task logs status = %d body = %s", response.Code, response.Body.String())
+	}
+	if got, want := response.Header().Get("Content-Type"), "text/plain; charset=utf-8"; got != want {
+		t.Errorf("Task logs Content-Type = %q, want %q", got, want)
+	}
+	if got, want := response.Body.String(), "agent output\n"; got != want {
+		t.Errorf("Task logs = %q, want %q", got, want)
+	}
+}
+
+func TestConsoleWorkerPoolTaskLogsOnlyIncludeSelectedTask(t *testing.T) {
+	server := testServer(t)
+	task := &kelos.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: "task-b", Namespace: "team-a"},
+		Spec:       kelos.TaskSpec{WorkerPoolRef: &kelos.WorkerPoolReference{Name: "pool"}},
+		Status:     kelos.TaskStatus{Phase: kelos.TaskPhaseSucceeded, PodName: "pool-0"},
+	}
+	if err := server.client.Create(t.Context(), task); err != nil {
+		t.Fatal(err)
+	}
+	server.taskLogStream = func(_ context.Context, _ *kelos.Task, tailLines int64) (io.ReadCloser, error) {
+		if tailLines != workerTaskLogLineLimit {
+			t.Fatalf("WorkerPool Task log tail lines = %d, want %d", tailLines, workerTaskLogLineLimit)
+		}
+		return io.NopCloser(strings.NewReader(strings.Join([]string{
+			"worker startup",
+			"---KELOS_TASK_START--- task-a",
+			"task-a output",
+			"---KELOS_TASK_END--- task-a",
+			"---KELOS_TASK_START--- task-b",
+			"task-b output",
+			"---KELOS_TASK_END--- task-b",
+			"worker idle",
+		}, "\n"))), nil
+	}
+
+	request := httptest.NewRequest(http.MethodGet, "/api/resources/tasks/team-a/task-b/logs", nil)
+	request.Header.Set("Authorization", "Bearer secret-token")
+	response := httptest.NewRecorder()
+	server.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("WorkerPool Task logs status = %d body = %s", response.Code, response.Body.String())
+	}
+	if got, want := response.Body.String(), "task-b output\n"; got != want {
+		t.Errorf("WorkerPool Task logs = %q, want %q", got, want)
+	}
+}
+
+func TestTaskPodLogOptionsBoundLogRetrieval(t *testing.T) {
+	task := &kelos.Task{}
+	options := taskPodLogOptions(task, taskLogTailLineLimit)
+	if options.Container != kelos.AgentContainerName {
+		t.Errorf("Pod log container = %q, want %q", options.Container, kelos.AgentContainerName)
+	}
+	if options.TailLines == nil || *options.TailLines != taskLogTailLineLimit {
+		t.Errorf("Pod log tail lines = %v, want %d", options.TailLines, taskLogTailLineLimit)
+	}
+	if options.SinceTime != nil {
+		t.Errorf("Pod log since time = %v, want nil", options.SinceTime)
+	}
+
+	startedAt := metav1.NewTime(time.Unix(20, 0))
+	task.Spec.WorkerPoolRef = &kelos.WorkerPoolReference{Name: "pool"}
+	task.Status.StartTime = &startedAt
+	options = taskPodLogOptions(task, workerTaskLogLineLimit)
+	if options.TailLines == nil || *options.TailLines != workerTaskLogLineLimit {
+		t.Errorf("WorkerPool Pod log tail lines = %v, want %d", options.TailLines, workerTaskLogLineLimit)
+	}
+	wantSinceTime := startedAt.Add(-workerTaskLogSinceMargin)
+	if options.SinceTime == nil || !options.SinceTime.Time.Equal(wantSinceTime) {
+		t.Errorf("WorkerPool Pod log since time = %v, want %v", options.SinceTime, wantSinceTime)
+	}
+
+	createdAt := metav1.NewTime(time.Unix(18, 0))
+	task.CreationTimestamp = createdAt
+	options = taskPodLogOptions(task, workerTaskLogLineLimit)
+	if options.SinceTime == nil || !options.SinceTime.Time.Equal(createdAt.Time) {
+		t.Errorf("WorkerPool Pod log clamped since time = %v, want %v", options.SinceTime, createdAt)
+	}
+
+	task.Status.StartTime = nil
+	options = taskPodLogOptions(task, workerTaskLogLineLimit)
+	if options.SinceTime == nil || !options.SinceTime.Time.Equal(createdAt.Time) {
+		t.Errorf("WorkerPool Pod log since time without start time = %v, want %v", options.SinceTime, createdAt)
+	}
+}
+
+func TestReadTaskLogsBoundsHistoricalWorkerPoolTaskRetrieval(t *testing.T) {
+	server := testServer(t)
+	task := &kelos.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: "task-b", Namespace: "team-a"},
+		Spec:       kelos.TaskSpec{WorkerPoolRef: &kelos.WorkerPoolReference{Name: "pool"}},
+		Status:     kelos.TaskStatus{Phase: kelos.TaskPhaseSucceeded, PodName: "pool-0"},
+	}
+	var requestedTailLines []int64
+	server.taskLogStream = func(_ context.Context, _ *kelos.Task, tailLines int64) (io.ReadCloser, error) {
+		requestedTailLines = append(requestedTailLines, tailLines)
+		return io.NopCloser(strings.NewReader("recent unrelated worker output\n")), nil
+	}
+
+	logs, err := server.readTaskLogs(t.Context(), task)
+	if !errors.Is(err, errTaskLogSegmentUnavailable) {
+		t.Fatalf("historical WorkerPool Task log error = %v, want %v", err, errTaskLogSegmentUnavailable)
+	}
+	if logs != "" {
+		t.Errorf("historical WorkerPool Task logs = %q, want empty", logs)
+	}
+	if got, want := fmt.Sprint(requestedTailLines), fmt.Sprint([]int64{workerTaskLogLineLimit}); got != want {
+		t.Errorf("WorkerPool Task log requests = %s, want %s", got, want)
+	}
+}
+
+func TestReadTaskLogsRequiresMarkerForRunningWorkerPoolTask(t *testing.T) {
+	server := testServer(t)
+	task := &kelos.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: "task-b", Namespace: "team-a"},
+		Spec:       kelos.TaskSpec{WorkerPoolRef: &kelos.WorkerPoolReference{Name: "pool"}},
+		Status:     kelos.TaskStatus{Phase: kelos.TaskPhaseRunning, PodName: "pool-0"},
+	}
+	var requestedTailLines []int64
+	server.taskLogStream = func(_ context.Context, _ *kelos.Task, tailLines int64) (io.ReadCloser, error) {
+		requestedTailLines = append(requestedTailLines, tailLines)
+		return io.NopCloser(strings.NewReader("recent output without the start marker\n")), nil
+	}
+
+	logs, err := server.readTaskLogs(t.Context(), task)
+	if !errors.Is(err, errTaskLogSegmentUnavailable) {
+		t.Fatalf("running WorkerPool Task log error = %v, want %v", err, errTaskLogSegmentUnavailable)
+	}
+	if logs != "" {
+		t.Errorf("running WorkerPool Task logs = %q, want empty", logs)
+	}
+	if got, want := fmt.Sprint(requestedTailLines), fmt.Sprint([]int64{workerTaskLogLineLimit}); got != want {
+		t.Errorf("running WorkerPool Task log requests = %s, want %s", got, want)
+	}
+}
+
+func TestConsoleWorkerPoolTaskLogsReportUnavailableSegment(t *testing.T) {
+	server := testServer(t)
+	task := &kelos.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: "task-b", Namespace: "team-a"},
+		Spec:       kelos.TaskSpec{WorkerPoolRef: &kelos.WorkerPoolReference{Name: "pool"}},
+		Status:     kelos.TaskStatus{Phase: kelos.TaskPhaseSucceeded, PodName: "pool-0"},
+	}
+	if err := server.client.Create(t.Context(), task); err != nil {
+		t.Fatal(err)
+	}
+	server.taskLogStream = func(_ context.Context, _ *kelos.Task, _ int64) (io.ReadCloser, error) {
+		return io.NopCloser(strings.NewReader("recent unrelated worker output\n")), nil
+	}
+
+	request := httptest.NewRequest(http.MethodGet, "/api/resources/tasks/team-a/task-b/logs", nil)
+	request.Header.Set("Authorization", "Bearer secret-token")
+	response := httptest.NewRecorder()
+	server.ServeHTTP(response, request)
+
+	if response.Code != http.StatusNotFound || !strings.Contains(response.Body.String(), `Task \"task-b\" log segment is unavailable`) {
+		t.Fatalf("unavailable WorkerPool Task logs status = %d body = %s", response.Code, response.Body.String())
+	}
+}
+
+func TestTailLogLinesAppliesLineAndByteLimits(t *testing.T) {
+	logs, err := tailLogLines(strings.NewReader("one\ntwo\nthree\nfour\n"), 2, 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := taskLogOmittedMessage + "three\nfour\n"; logs != want {
+		t.Errorf("line-limited logs = %q, want %q", logs, want)
+	}
+
+	maxBytes := len(taskLogOmittedMessage) + 10
+	logs, err = tailLogLines(strings.NewReader(strings.Repeat("x", 100)+"\n"), 10, maxBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(logs) > maxBytes {
+		t.Errorf("byte-limited logs length = %d, want at most %d", len(logs), maxBytes)
+	}
+	if want := taskLogOmittedMessage + strings.Repeat("x", 9) + "\n"; logs != want {
+		t.Errorf("byte-limited logs = %q, want %q", logs, want)
+	}
+
+	maxBytes = len(taskLogOmittedMessage) + 6
+	logs, err = tailLogLines(strings.NewReader("한글\n"), 10, maxBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !utf8.ValidString(logs) {
+		t.Errorf("byte-limited logs are not valid UTF-8: %q", logs)
+	}
+	if want := taskLogOmittedMessage + "글\n"; logs != want {
+		t.Errorf("UTF-8 byte-limited logs = %q, want %q", logs, want)
+	}
+}
+
+func TestTailWorkerTaskLogSegmentStopsAtTaskEnd(t *testing.T) {
+	logs, found, err := tailWorkerTaskLogSegment(strings.NewReader(strings.Join([]string{
+		"worker startup",
+		"---KELOS_TASK_START--- task-b",
+		"first",
+		"second",
+		"third",
+		"---KELOS_TASK_END--- task-b",
+		"later worker output",
+	}, "\n")), "task-b", 2, 1024, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found {
+		t.Fatal("WorkerPool Task log segment was not found")
+	}
+	if want := taskLogOmittedMessage + "second\nthird\n"; logs != want {
+		t.Errorf("WorkerPool Task log tail = %q, want %q", logs, want)
+	}
+}
+
+func TestTailWorkerTaskLogSegmentAcceptsTailWithoutStartMarker(t *testing.T) {
+	logs, found, err := tailWorkerTaskLogSegment(strings.NewReader(strings.Join([]string{
+		"second-to-last",
+		"last",
+		"---KELOS_TASK_END--- task-b",
+		"later worker output",
+	}, "\n")), "task-b", 2, 1024, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found {
+		t.Fatal("WorkerPool Task log tail was not found")
+	}
+	if want := "second-to-last\nlast\n"; logs != want {
+		t.Errorf("WorkerPool Task partial log tail = %q, want %q", logs, want)
+	}
+}
+
+func TestConsoleTaskLogsReportMissingPod(t *testing.T) {
+	server := testServer(t)
+	if err := server.client.Create(t.Context(), &kelos.Task{
+		ObjectMeta: metav1.ObjectMeta{Name: "pending-task", Namespace: "team-a"},
+		Status:     kelos.TaskStatus{Phase: kelos.TaskPhasePending},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	request := httptest.NewRequest(http.MethodGet, "/api/resources/tasks/team-a/pending-task/logs", nil)
+	request.Header.Set("Authorization", "Bearer secret-token")
+	response := httptest.NewRecorder()
+	server.ServeHTTP(response, request)
+
+	if response.Code != http.StatusConflict || !strings.Contains(response.Body.String(), `Task \"pending-task\" has no pod yet`) {
+		t.Fatalf("Task logs without Pod status = %d body = %s", response.Code, response.Body.String())
 	}
 }
 

--- a/internal/consoleserver/testdata/console_resources_test.js
+++ b/internal/consoleserver/testdata/console_resources_test.js
@@ -14,7 +14,7 @@ function applicationSlice(start, end) {
 }
 
 vm.runInThisContext(applicationSlice('async function refreshConsole', 'async function openResourceDetail'), {filename: 'app.js'});
-vm.runInThisContext(applicationSlice('async function openResourceDetail', 'function sessionKey'), {filename: 'app.js'});
+vm.runInThisContext(applicationSlice('function setResourceDetailView', 'function sessionKey'), {filename: 'app.js'});
 
 function deferred() {
   let resolve;
@@ -30,15 +30,32 @@ async function testResourceDetailsIgnoreStaleResponses() {
   global.elements = {
     resourceDetailTitle: {textContent: ''},
     resourceDetailSubtitle: {textContent: ''},
+    resourceDetailTabs: {hidden: false},
+    resourceDetailLogsTab: {setAttribute() {}, tabIndex: 0},
+    resourceDetailManifestTab: {setAttribute() {}, tabIndex: -1},
+    resourceDetailLogsPanel: {hidden: true},
+    resourceDetailManifestPanel: {hidden: false},
+    refreshResourceLogs: {disabled: true},
+    resourceDetailLogs: {textContent: ''},
     resourceDetailYAML: {textContent: ''},
     resourceDetailDialog: {showModal() {}},
   };
-  global.state = {resourceDetailGeneration: 0};
+  global.state = {
+    resourceDetailGeneration: 0,
+    resourceDetailLogGeneration: 0,
+    resourceDetailTask: null,
+  };
 
-  const requests = [];
+  const manifestRequests = [];
   global.api = requestPath => {
     const request = deferred();
-    requests.push({path: requestPath, ...request});
+    manifestRequests.push({path: requestPath, ...request});
+    return request.promise;
+  };
+  const logRequests = [];
+  global.apiText = requestPath => {
+    const request = deferred();
+    logRequests.push({path: requestPath, ...request});
     return request.promise;
   };
 
@@ -52,13 +69,20 @@ async function testResourceDetailsIgnoreStaleResponses() {
   );
 
   assert.equal(elements.resourceDetailTitle.textContent, 'Task second');
-  requests[1].resolve({yaml: 'name: second'});
+  assert.equal(elements.resourceDetailLogsPanel.hidden, false);
+  assert.equal(logRequests[1].path, '/api/resources/tasks/default/second/logs');
+  manifestRequests[1].resolve({yaml: 'name: second'});
+  logRequests[1].resolve('second logs');
   await second;
   assert.equal(elements.resourceDetailYAML.textContent, 'name: second');
+  assert.equal(elements.resourceDetailLogs.textContent, 'second logs');
+  assert.equal(elements.refreshResourceLogs.disabled, false);
 
-  requests[0].resolve({yaml: 'name: first'});
+  manifestRequests[0].resolve({yaml: 'name: first'});
+  logRequests[0].resolve('first logs');
   await first;
   assert.equal(elements.resourceDetailYAML.textContent, 'name: second');
+  assert.equal(elements.resourceDetailLogs.textContent, 'second logs');
 }
 
 async function testRefreshReportsOptionFailures() {
@@ -73,6 +97,32 @@ async function testRefreshReportsOptionFailures() {
   assert.equal(message, 'options unavailable');
 }
 
+function testResourceDetailTabsSupportKeyboardNavigation() {
+  let clicked = false;
+  let focused = false;
+  let prevented = false;
+  const logsTab = {};
+  const manifestTab = {
+    click() { clicked = true; },
+    focus() { focused = true; },
+  };
+  global.elements = {
+    resourceDetailLogsTab: logsTab,
+    resourceDetailManifestTab: manifestTab,
+  };
+
+  handleResourceDetailTabKeydown({
+    target: logsTab,
+    key: 'ArrowRight',
+    preventDefault() { prevented = true; },
+  });
+
+  assert.equal(clicked, true);
+  assert.equal(focused, true);
+  assert.equal(prevented, true);
+}
+
 testResourceDetailsIgnoreStaleResponses()
   .then(() => testRefreshReportsOptionFailures())
+  .then(() => testResourceDetailTabsSupportKeyboardNavigation())
   .then(() => process.stdout.write('Console resources tests passed\n'));

--- a/internal/consoleserver/web/app.js
+++ b/internal/consoleserver/web/app.js
@@ -27,6 +27,13 @@ const elements = {
   resourceDetailDialog: document.querySelector('#resource-detail-dialog'),
   resourceDetailTitle: document.querySelector('#resource-detail-title'),
   resourceDetailSubtitle: document.querySelector('#resource-detail-subtitle'),
+  resourceDetailTabs: document.querySelector('#resource-detail-tabs'),
+  resourceDetailLogsTab: document.querySelector('#resource-detail-logs-tab'),
+  resourceDetailManifestTab: document.querySelector('#resource-detail-manifest-tab'),
+  resourceDetailLogsPanel: document.querySelector('#resource-detail-logs-panel'),
+  resourceDetailManifestPanel: document.querySelector('#resource-detail-manifest-panel'),
+  refreshResourceLogs: document.querySelector('#refresh-resource-logs'),
+  resourceDetailLogs: document.querySelector('#resource-detail-logs'),
   resourceDetailYAML: document.querySelector('#resource-detail-yaml'),
   namespaceLabels: document.querySelectorAll('.console-namespace'),
   newSessionButton: document.querySelector('#new-session'),
@@ -149,6 +156,8 @@ const state = {
   resourceGroups: [],
   resourceListGeneration: 0,
   resourceDetailGeneration: 0,
+  resourceDetailLogGeneration: 0,
+  resourceDetailTask: null,
   sourceStorageClassNamePresent: false,
   loadedSource: null,
   displayNameSaving: false,
@@ -182,6 +191,25 @@ async function api(path, options = {}) {
   }
   if (response.status === 204) return null;
   return response.json();
+}
+
+async function apiText(path) {
+  const response = await fetch(path);
+  if (response.status === 401) {
+    window.location.replace('/login');
+    throw new Error('Authentication required');
+  }
+  const body = await response.text();
+  if (!response.ok) {
+    let message = `${response.status} ${response.statusText}`;
+    try {
+      message = JSON.parse(body).error || message;
+    } catch (_) {
+      // Keep the HTTP status when the response is not a JSON API error.
+    }
+    throw new Error(message);
+  }
+  return body;
 }
 
 function showToast(message) {
@@ -353,20 +381,80 @@ async function refreshConsole() {
   }
 }
 
+function setResourceDetailView(view) {
+  const showLogs = view === 'logs' && !elements.resourceDetailTabs.hidden;
+  elements.resourceDetailLogsPanel.hidden = !showLogs;
+  elements.resourceDetailManifestPanel.hidden = showLogs;
+  elements.resourceDetailLogsTab.setAttribute('aria-selected', String(showLogs));
+  elements.resourceDetailLogsTab.tabIndex = showLogs ? 0 : -1;
+  elements.resourceDetailManifestTab.setAttribute('aria-selected', String(!showLogs));
+  elements.resourceDetailManifestTab.tabIndex = showLogs ? -1 : 0;
+}
+
+function handleResourceDetailTabKeydown(event) {
+  const tabs = [elements.resourceDetailLogsTab, elements.resourceDetailManifestTab];
+  const current = tabs.indexOf(event.target);
+  if (current < 0) return;
+
+  let target;
+  if (event.key === 'ArrowLeft') target = tabs[(current - 1 + tabs.length) % tabs.length];
+  if (event.key === 'ArrowRight') target = tabs[(current + 1) % tabs.length];
+  if (event.key === 'Home') target = tabs[0];
+  if (event.key === 'End') target = tabs[tabs.length - 1];
+  if (!target) return;
+
+  event.preventDefault();
+  target.click();
+  target.focus();
+}
+
+async function loadResourceTaskLogs(item, detailGeneration) {
+  const logGeneration = ++state.resourceDetailLogGeneration;
+  elements.refreshResourceLogs.disabled = true;
+  elements.resourceDetailLogs.textContent = 'Loading logs…';
+  try {
+    const logs = await apiText(`/api/resources/tasks/${encodeURIComponent(item.namespace)}/${encodeURIComponent(item.name)}/logs`);
+    if (detailGeneration !== state.resourceDetailGeneration || logGeneration !== state.resourceDetailLogGeneration) return;
+    elements.resourceDetailLogs.textContent = logs || 'No logs yet.';
+  } catch (error) {
+    if (detailGeneration !== state.resourceDetailGeneration || logGeneration !== state.resourceDetailLogGeneration) return;
+    elements.resourceDetailLogs.textContent = error.message;
+  } finally {
+    if (detailGeneration === state.resourceDetailGeneration && logGeneration === state.resourceDetailLogGeneration) {
+      elements.refreshResourceLogs.disabled = false;
+    }
+  }
+}
+
 async function openResourceDetail(collection, item) {
   const generation = ++state.resourceDetailGeneration;
+  const showTaskLogs = collection.resource === 'tasks';
   elements.resourceDetailTitle.textContent = `${collection.kind} ${item.name}`;
   elements.resourceDetailSubtitle.textContent = `${item.namespace}/${item.name}`;
-  elements.resourceDetailYAML.textContent = 'Loading manifest…';
-  elements.resourceDetailDialog.showModal();
-  try {
-    const detail = await api(`/api/resources/${encodeURIComponent(collection.resource)}/${encodeURIComponent(item.namespace)}/${encodeURIComponent(item.name)}`);
-    if (generation !== state.resourceDetailGeneration) return;
-    elements.resourceDetailYAML.textContent = detail.yaml;
-  } catch (error) {
-    if (generation !== state.resourceDetailGeneration) return;
-    elements.resourceDetailYAML.textContent = error.message;
+  elements.resourceDetailTabs.hidden = !showTaskLogs;
+  state.resourceDetailTask = showTaskLogs ? {namespace: item.namespace, name: item.name} : null;
+  if (!showTaskLogs) {
+    state.resourceDetailLogGeneration++;
+    elements.refreshResourceLogs.disabled = true;
+    elements.resourceDetailLogs.textContent = '';
   }
+  elements.resourceDetailYAML.textContent = 'Loading manifest…';
+  setResourceDetailView(showTaskLogs ? 'logs' : 'manifest');
+  elements.resourceDetailDialog.showModal();
+
+  const manifestRequest = (async () => {
+    try {
+      const detail = await api(`/api/resources/${encodeURIComponent(collection.resource)}/${encodeURIComponent(item.namespace)}/${encodeURIComponent(item.name)}`);
+      if (generation !== state.resourceDetailGeneration) return;
+      elements.resourceDetailYAML.textContent = detail.yaml;
+    } catch (error) {
+      if (generation !== state.resourceDetailGeneration) return;
+      elements.resourceDetailYAML.textContent = error.message;
+    }
+  })();
+  const logsRequest = showTaskLogs ? loadResourceTaskLogs(state.resourceDetailTask, generation) : Promise.resolve();
+
+  await Promise.all([manifestRequest, logsRequest]);
 }
 
 function sessionKey(session) {
@@ -4325,6 +4413,12 @@ elements.resourcesButton.addEventListener('click', () => setConsoleView('resourc
 elements.resourceKind.addEventListener('change', renderResources);
 document.querySelectorAll('.close-resource-detail').forEach(button => {
   button.addEventListener('click', () => elements.resourceDetailDialog.close());
+});
+elements.resourceDetailLogsTab.addEventListener('click', () => setResourceDetailView('logs'));
+elements.resourceDetailManifestTab.addEventListener('click', () => setResourceDetailView('manifest'));
+elements.resourceDetailTabs.addEventListener('keydown', handleResourceDetailTabKeydown);
+elements.refreshResourceLogs.addEventListener('click', () => {
+  if (state.resourceDetailTask) void loadResourceTaskLogs(state.resourceDetailTask, state.resourceDetailGeneration);
 });
 document.querySelector('#refresh-console').addEventListener('click', () => {
   void refreshConsole();

--- a/internal/consoleserver/web/index.html
+++ b/internal/consoleserver/web/index.html
@@ -333,7 +333,20 @@
         </div>
         <button class="icon-button close-resource-detail" type="button" aria-label="Close">×</button>
       </div>
-      <pre id="resource-detail-yaml"></pre>
+      <div class="mode-switch resource-detail-tabs" id="resource-detail-tabs" role="tablist" aria-label="Task details" hidden>
+        <button id="resource-detail-logs-tab" type="button" role="tab" aria-selected="true" aria-controls="resource-detail-logs-panel">Logs</button>
+        <button id="resource-detail-manifest-tab" type="button" role="tab" aria-selected="false" aria-controls="resource-detail-manifest-panel" tabindex="-1">Manifest</button>
+      </div>
+      <section class="resource-detail-panel resource-detail-logs-panel" id="resource-detail-logs-panel" role="tabpanel" aria-labelledby="resource-detail-logs-tab" hidden>
+        <div class="resource-detail-log-toolbar">
+          <span>Showing up to the latest 2,000 lines (2 MiB maximum).</span>
+          <button class="quiet-button" id="refresh-resource-logs" type="button">Refresh</button>
+        </div>
+        <pre id="resource-detail-logs"></pre>
+      </section>
+      <section class="resource-detail-panel" id="resource-detail-manifest-panel" role="tabpanel" aria-labelledby="resource-detail-manifest-tab">
+        <pre id="resource-detail-yaml"></pre>
+      </section>
       <div class="dialog-actions">
         <button class="secondary-button close-resource-detail" type="button">Close</button>
       </div>

--- a/internal/consoleserver/web/styles.css
+++ b/internal/consoleserver/web/styles.css
@@ -372,6 +372,11 @@ button { color: inherit; }
 .resource-detail-dialog { width: min(94vw, 820px); }
 .resource-detail-content { padding: 23px; }
 .resource-detail-content pre { max-height: min(65vh, 680px); overflow: auto; margin: 18px 0 0; padding: 15px; border: 1px solid var(--code-border); border-radius: 11px; background: var(--code-bg); color: var(--code-ink); font: 11.5px/1.55 ui-monospace,SFMono-Regular,Menlo,monospace; white-space: pre; }
+.resource-detail-tabs[hidden] { display: none; }
+.resource-detail-panel[hidden] { display: none; }
+.resource-detail-log-toolbar { display: flex; align-items: center; justify-content: space-between; gap: 16px; margin-top: 14px; color: var(--faint); font-size: 10px; }
+.resource-detail-log-toolbar .quiet-button:disabled { cursor: wait; opacity: .55; }
+.resource-detail-logs-panel pre { margin-top: 8px; white-space: pre-wrap; overflow-wrap: anywhere; }
 .dialog-header { display: flex; justify-content: space-between; align-items: flex-start; gap: 20px; }
 .dialog-header h2 { margin: 0; font: 600 25px/1.2 Georgia,"Times New Roman",serif; }
 .dialog-header p { margin: 6px 0 0; color: var(--muted); font-size: 12px; }

--- a/internal/helmchart/render_test.go
+++ b/internal/helmchart/render_test.go
@@ -308,7 +308,7 @@ func TestRender_ConsoleServer(t *testing.T) {
 	for _, expected := range []string{
 		"name: kelos-console-server",
 		"secretName: console-auth",
-		"resources:\n      - pods/exec",
+		"resources:\n      - pods\n    verbs:\n      - get\n  - apiGroups:\n      - \"\"\n    resources:\n      - pods/log\n    verbs:\n      - get\n  - apiGroups:\n      - \"\"\n    resources:\n      - pods/exec",
 		"resources:\n      - agentconfigs\n      - sessions\n      - sessionspawners\n      - taskbudgets\n      - taskrecords\n      - tasks\n      - taskspawners\n      - workerpools\n      - workspaces\n    verbs:\n      - get\n      - list",
 		"resources:\n      - sessions\n    verbs:\n      - create\n      - delete\n      - patch\n      - watch",
 		"--token-file=/var/run/secrets/kelos-console/token",

--- a/internal/manifests/charts/kelos/templates/rbac.yaml
+++ b/internal/manifests/charts/kelos/templates/rbac.yaml
@@ -299,6 +299,12 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - pods/log
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
       - pods/exec
     verbs:
       - create


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

- adds an authenticated Console endpoint for Task agent-container logs
- opens Task resource details on a Logs tab while keeping the manifest available
- bounds log responses to the latest 2,000 lines and 2 MiB, with an in-dialog Refresh action
- performs one bounded Kubernetes tail request for WorkerPool Tasks and reports segments outside the recent window without scanning full Pod history
- isolates WorkerPool-backed logs to the selected Task segment
- supports keyboard navigation between the Logs and Manifest tabs
- grants the Console server read access to the `pods/log` subresource

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

- `make test`
- `make verify`

#### Does this PR introduce a user-facing change?

```release-note
The Kelos Console now displays bounded, refreshable agent logs when inspecting Tasks.
```
