### PR TITLE
Fix mobile Session action controls

### DIFF
--- a/internal/consoleserver/server_test.go
+++ b/internal/consoleserver/server_test.go
@@ -950,17 +950,18 @@ func TestSessionUIAdaptsToPhoneViewport(t *testing.T) {
 		}
 	}
 	for description, expected := range map[string]string{
-		"dynamic viewport height":    `height: 100dvh`,
-		"landscape phone breakpoint": `(max-height: 500px) and (pointer: coarse)`,
-		"two-row phone header":       `grid-template-areas: "menu heading reset delete" "tabs tabs connection connection"`,
-		"phone header resume slot":   `.conversation-header:has(#resume-session:not([hidden])) { grid-template-areas: "menu heading resume reset delete"`,
-		"48-pixel touch targets":     `.icon-button { width: 48px; height: 48px; }`,
-		"phone safe-area padding":    `env(safe-area-inset-bottom)`,
-		"non-zooming form fields":    `.composer textarea, .pending-message-input, .yaml-panel textarea, .form-grid input`,
-		"desktop composer alignment": `.composer textarea { flex: 1; min-height: 36px;`,
-		"mobile composer alignment":  `.composer textarea { min-height: 48px; padding: 12px 0; line-height: 24px; }`,
-		"phone-sized dialog":         `max-height: calc(100dvh - 16px`,
-		"shrinking composer content": `.composer-wrap { min-width: 0;`,
+		"dynamic viewport height":     `height: 100dvh`,
+		"landscape phone breakpoint":  `(max-height: 500px) and (pointer: coarse)`,
+		"two-row phone header":        `grid-template-areas: "menu heading reset delete" "tabs tabs connection connection"`,
+		"phone header resume slot":    `.conversation-header:has(#resume-session:not([hidden])) { grid-template-areas: "menu heading resume reset delete"`,
+		"48-pixel touch targets":      `.icon-button { width: 48px; height: 48px; }`,
+		"Session action touch target": `.session-item-actions { top: 5px; right: 1px; width: 44px; height: 44px; }`,
+		"phone safe-area padding":     `env(safe-area-inset-bottom)`,
+		"non-zooming form fields":     `.composer textarea, .pending-message-input, .yaml-panel textarea, .form-grid input`,
+		"desktop composer alignment":  `.composer textarea { flex: 1; min-height: 36px;`,
+		"mobile composer alignment":   `.composer textarea { min-height: 48px; padding: 12px 0; line-height: 24px; }`,
+		"phone-sized dialog":          `max-height: calc(100dvh - 16px`,
+		"shrinking composer content":  `.composer-wrap { min-width: 0;`,
 	} {
 		if !strings.Contains(string(styles), expected) {
 			t.Errorf("Session styles are missing %s: %s", description, expected)
@@ -1561,7 +1562,7 @@ func TestSessionUISections(t *testing.T) {
 	for description, expected := range map[string]string{
 		"section grouping":      `const sessionsBySection = new Map();`,
 		"unsectioned group":     `name.textContent = section || 'Unsectioned';`,
-		"Session drag handling": `configureSessionDrag(item, session);`,
+		"Session drag handling": `configureSessionDrag(item, button, session);`,
 		"section drag handling": `configureSectionDrag(group, heading, title, section);`,
 		"unsectioned ordering":  `if (!available.includes('')) available.push('');`,
 		"browser order storage": `window.localStorage.setItem(sectionOrderStorageKey(namespace), JSON.stringify(normalized));`,

--- a/internal/consoleserver/testdata/session_actions_test.js
+++ b/internal/consoleserver/testdata/session_actions_test.js
@@ -172,6 +172,29 @@ async function testEverySessionRowHasActionsMenu() {
   assert.equal(document.activeElement, actions);
 }
 
+async function testSessionDragDoesNotCaptureActions() {
+  resetHarness();
+  const session = {namespace: 'default', name: 'review', provider: 'codex'};
+  state.sessions = [session];
+
+  let dragHandle;
+  const configureDrag = global.configureSessionDrag;
+  global.configureSessionDrag = (item, handle) => {
+    assert.equal(item.draggable, false);
+    dragHandle = handle;
+  };
+  const item = createSessionListItem(session, true);
+  global.configureSessionDrag = configureDrag;
+  const select = item.children.find(child => child.className === 'session-item-select');
+  const actions = item.children.find(child => child.className === 'session-item-actions');
+
+  assert.equal(select.draggable, true);
+  assert.equal(dragHandle, select);
+  assert.equal(actions.draggable, false);
+  await actions.dispatch('click', {stopPropagation() {}});
+  assert.equal(elements.sessionActionsMenu.hidden, false);
+}
+
 function testOpenMenuSurvivesSessionRefresh() {
   resetHarness();
   const session = {namespace: 'default', name: 'review', provider: 'codex'};
@@ -325,6 +348,7 @@ assert.match(styles, /\.session-actions-menu button:focus-visible \{[^}]*outline
 assert.match(application, /sessionActionsMenu\.addEventListener\('focusout'/);
 
 testEverySessionRowHasActionsMenu()
+  .then(() => testSessionDragDoesNotCaptureActions())
   .then(() => {
     testOpenMenuSurvivesSessionRefresh();
     return testActionsCanTargetAnUnselectedSession();

--- a/internal/consoleserver/web/app.js
+++ b/internal/consoleserver/web/app.js
@@ -911,10 +911,10 @@ function createSessionListItem(session, draggable = false) {
   const key = sessionKey(session);
   const assigningSection = state.sectionAssignments.has(key);
   item.className = `session-item${state.selected && sessionKey(state.selected) === key ? ' active' : ''}${assigningSection ? ' section-saving' : ''}`;
-  item.draggable = draggable && !assigningSection;
   const button = document.createElement('button');
   button.className = 'session-item-select';
   button.type = 'button';
+  button.draggable = draggable && !assigningSection;
   const dot = document.createElement('span');
   const displayStatus = sessionDisplayStatus(session);
   dot.className = `phase-dot ${String(displayStatus).toLowerCase().replaceAll(' ', '-')}`;
@@ -979,7 +979,7 @@ function createSessionListItem(session, draggable = false) {
     link.draggable = false;
     item.append(link);
   }
-  if (item.draggable) configureSessionDrag(item, session);
+  if (button.draggable) configureSessionDrag(item, button, session);
   return item;
 }
 
@@ -1175,14 +1175,14 @@ function finishSidebarDrag() {
   clearSidebarDropIndicators();
 }
 
-function configureSessionDrag(item, session) {
-  item.addEventListener('dragstart', event => {
+function configureSessionDrag(item, handle, session) {
+  handle.addEventListener('dragstart', event => {
     state.sidebarDrag = {kind: 'session', session};
     item.classList.add('dragging');
     event.dataTransfer.effectAllowed = 'move';
     event.dataTransfer.setData('text/plain', sessionKey(session));
   });
-  item.addEventListener('dragend', () => {
+  handle.addEventListener('dragend', () => {
     item.classList.remove('dragging');
     finishSidebarDrag();
   });

--- a/internal/consoleserver/web/styles.css
+++ b/internal/consoleserver/web/styles.css
@@ -78,8 +78,8 @@ button { color: inherit; }
 .session-item.active { background: #fff; box-shadow: 0 4px 14px rgba(35,49,42,.06); }
 .session-item.section-saving { opacity: .55; }
 .session-item-select { width: 100%; display: grid; grid-template-columns: 9px minmax(0,1fr); gap: 9px; padding: 11px 42px 11px 10px; border: 0; background: transparent; text-align: left; cursor: pointer; }
-.session-item[draggable="true"] .session-item-select { cursor: grab; }
-.session-item[draggable="true"] .session-item-select:active { cursor: grabbing; }
+.session-item-select[draggable="true"] { cursor: grab; }
+.session-item-select[draggable="true"]:active { cursor: grabbing; }
 .session-item.has-pull-request .session-item-select { padding-bottom: 5px; }
 .session-item-actions { position: absolute; top: 6px; right: 5px; width: 32px; height: 32px; display: grid; place-items: center; padding: 0 0 5px; border: 0; border-radius: 8px; background: transparent; color: var(--faint); font-size: 18px; line-height: 1; cursor: pointer; }
 .session-item-actions:hover, .session-item-actions:focus-visible, .session-item-actions[aria-expanded="true"] { background: var(--line-soft); color: var(--ink); }
@@ -445,6 +445,9 @@ button { color: inherit; }
   .resource-toolbar select { width: 100%; min-width: 0; font-size: 16px; }
   .resource-table-wrap { overflow-x: auto; }
   .resource-table { min-width: 680px; }
+  .session-item-select { padding-right: 52px; }
+  .session-item-actions { top: 5px; right: 1px; width: 44px; height: 44px; }
+  .session-actions-menu button { min-height: 44px; font-size: 14px; }
   .conversation { height: 100%; height: 100dvh; }
   .conversation-header { display: grid; grid-template-areas: "menu heading reset delete" "tabs tabs connection connection"; grid-template-columns: 48px minmax(0, 1fr) 48px 48px; gap: 8px 10px; padding: calc(8px + env(safe-area-inset-top)) calc(10px + env(safe-area-inset-right)) 9px calc(10px + env(safe-area-inset-left)); }
   .conversation-header:has(#resume-session:not([hidden])) { grid-template-areas: "menu heading resume reset delete" "tabs tabs connection connection connection"; grid-template-columns: 48px minmax(0, 1fr) 48px 48px 48px; }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Makes the per-Session actions menu reliable on mobile devices. Session drag handling is limited to the Session selection surface so touch gestures on the sibling overflow control are not captured as row drags.

The overflow trigger and its menu items also use larger mobile touch targets.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Validation:

- `make verify`
- `internal/consoleserver` passes as part of `make test`
- The complete `make test` target still reports two unrelated existing failures: `TestCodexEntrypointUsesPersistentSessionHome` and the Codex case of `TestAgentEntrypointsPreserveSkillReferenceFiles`

#### Does this PR introduce a user-facing change?

```release-note
Session action menus now respond reliably and provide larger touch targets on mobile devices.
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the per-Session actions menu reliable on mobile by limiting drag to the Session select button and enlarging touch targets. Previously the entire row was draggable and intercepted taps on the actions button; now only the select button is draggable, and actions/menu buttons use 44px targets on phones.

- JS: `createSessionListItem` sets `button.draggable` and calls `configureSessionDrag(item, button, session)`; `configureSessionDrag` now attaches events to the provided handle. Update callers accordingly.
- CSS: Replace `.session-item[draggable="true"] .session-item-select` with `.session-item-select[draggable="true"]`. Increase `.session-item-actions` and menu button sizes under the phone rules.
- Tests: Add a regression test to ensure actions are not captured by drag and update style assertions for the new mobile targets.

<sup>Written for commit 19f40cd6ce1b077b6e3a0a4ab5e6cbeca210fa4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1674?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

