### PR TITLE
Fix Session menu actions on mobile

### DIFF
--- a/internal/consoleserver/testdata/session_actions_test.js
+++ b/internal/consoleserver/testdata/session_actions_test.js
@@ -98,6 +98,7 @@ global.window = {
   confirm: () => true,
   innerHeight: 800,
   innerWidth: 400,
+  setTimeout,
 };
 
 const application = fs.readFileSync(path.join(__dirname, '..', 'web', 'app.js'), 'utf8');
@@ -340,6 +341,29 @@ function testMenuClosesWhenFocusLeaves() {
   assert.equal(elements.sessionActionsMenu.hidden, true);
 }
 
+async function testTouchActionRunsBeforeMenuCloses() {
+  resetHarness();
+  const target = {namespace: 'team-a', name: 'target', provider: 'codex'};
+  state.sessions = [target];
+  const action = createSessionListItem(target).children[1];
+  openSessionActionsMenu(target, action);
+
+  let actionTarget;
+  handleSessionActionsFocusOut({relatedTarget: null});
+  assert.equal(elements.sessionActionsMenu.hidden, false);
+  await runSessionMenuAction({detail: 1}, async session => { actionTarget = session; });
+  await new Promise(resolve => setTimeout(resolve, 0));
+
+  assert.equal(actionTarget, target);
+  assert.equal(elements.sessionActionsMenu.hidden, true);
+
+  openSessionActionsMenu(target, action);
+  document.activeElement = null;
+  handleSessionActionsFocusOut({relatedTarget: null});
+  await new Promise(resolve => setTimeout(resolve, 0));
+  assert.equal(elements.sessionActionsMenu.hidden, true);
+}
+
 assert.match(index, /id="session-actions-menu" role="menu"/);
 assert.match(index, /id="session-action-rename"[^>]+role="menuitem"/);
 assert.match(index, /id="session-action-reset"[^>]+role="menuitem"/);
@@ -356,6 +380,7 @@ testEverySessionRowHasActionsMenu()
   .then(() => testActionsUpdateTheSelectedSession())
   .then(() => testKeyboardActionsRestoreFocusAfterRefresh())
   .then(() => testKeyboardActionRestoresFocusAfterRequestFailure())
+  .then(() => testTouchActionRunsBeforeMenuCloses())
   .then(() => {
     testMenuClosesWhenFocusLeaves();
     process.stdout.write('Session actions tests passed\n');

--- a/internal/consoleserver/web/app.js
+++ b/internal/consoleserver/web/app.js
@@ -1070,7 +1070,16 @@ function syncSessionActionsMenu() {
 
 function handleSessionActionsFocusOut(event) {
   if (elements.sessionActionsMenu.contains(event.relatedTarget) || state.sessionActionTrigger?.contains(event.relatedTarget)) return;
-  closeSessionActionsMenu();
+  if (event.relatedTarget) {
+    closeSessionActionsMenu();
+    return;
+  }
+  const trigger = state.sessionActionTrigger;
+  window.setTimeout(() => {
+    if (trigger !== state.sessionActionTrigger) return;
+    if (elements.sessionActionsMenu.contains(document.activeElement) || trigger?.contains(document.activeElement)) return;
+    closeSessionActionsMenu();
+  }, 0);
 }
 
 function sectionLabel(section) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Allows mobile users to select Rename, Reset, or Delete after opening a Session actions menu.

Some touch browsers emit `focusout` without a next focus target before dispatching the menu item's click. The menu now defers closing in that case, preserving its Session target until the click runs, while still closing when focus actually remains outside.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Validation:

- `make verify`
- `internal/consoleserver` passes as part of `make test`
- The local complete `make test` target still reports the environment-specific `TestCodexEntrypointUsesPersistentSessionHome` failure and the Codex case of `TestAgentEntrypointsPreserveSkillReferenceFiles`

#### Does this PR introduce a user-facing change?

```release-note
Session action menu items now work on mobile devices.
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Session action menu items now work on mobile. Previously, some touch browsers closed the menu on focusout before the item click (Rename/Reset/Delete), dropping the target session; now the click runs first, then the menu closes, and behavior on desktop is unchanged.

**Review notes**
- Updates `handleSessionActionsFocusOut` to defer closing when `relatedTarget` is null, using `setTimeout(0)` and checking `document.activeElement` and `state.sessionActionTrigger`.
- Adds `testTouchActionRunsBeforeMenuCloses` and exposes `window.setTimeout` in the test harness.

<sup>Written for commit 8ef230ef986699964e4eff6bf830364d6088abe5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1675?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

