### PR TITLE
Improve console sidebar information density

### DIFF
--- a/internal/consoleserver/server_test.go
+++ b/internal/consoleserver/server_test.go
@@ -1346,24 +1346,31 @@ func TestSessionUIAdaptsToPhoneViewport(t *testing.T) {
 		"edge-to-edge viewport support": `viewport-fit=cover`,
 		"Android keyboard resizing":     `interactive-widget=resizes-content`,
 		"dismissible sidebar backdrop":  `id="sidebar-scrim"`,
+		"compact session list header":   `class="session-sidebar-header"`,
 	} {
 		if !strings.Contains(string(index), expected) {
 			t.Errorf("Session page is missing %s: %s", description, expected)
 		}
 	}
 	for description, expected := range map[string]string{
-		"dynamic viewport height":     `height: 100dvh`,
-		"landscape phone breakpoint":  `(max-height: 500px) and (pointer: coarse)`,
-		"two-row phone header":        `grid-template-areas: "menu heading reset delete" "tabs tabs connection connection"`,
-		"phone header resume slot":    `.conversation-header:has(#resume-session:not([hidden])) { grid-template-areas: "menu heading resume reset delete"`,
-		"48-pixel touch targets":      `.icon-button { width: 48px; height: 48px; }`,
-		"Session action touch target": `.session-item-actions { top: 5px; right: 1px; width: 44px; height: 44px; }`,
-		"phone safe-area padding":     `env(safe-area-inset-bottom)`,
-		"non-zooming form fields":     `.composer textarea, .pending-message-input, .yaml-panel textarea, .form-grid input`,
-		"desktop composer alignment":  `.composer textarea { flex: 1; min-height: 36px;`,
-		"mobile composer alignment":   `.composer textarea { min-height: 48px; padding: 12px 0; line-height: 24px; }`,
-		"phone-sized dialog":          `max-height: calc(100dvh - 16px`,
-		"shrinking composer content":  `.composer-wrap { min-width: 0;`,
+		"dynamic viewport height":      `height: 100dvh`,
+		"desktop sidebar width":        `grid-template-columns: 286px minmax(0, 1fr)`,
+		"landscape phone breakpoint":   `(max-height: 500px) and (pointer: coarse)`,
+		"phone sidebar width":          `width: min(86vw, 310px)`,
+		"single-row phone navigation":  `grid-template-columns: repeat(3, minmax(0, 1fr))`,
+		"compact phone session row":    `.session-item-select { min-height: 60px; padding: 7px 48px 7px 8px; }`,
+		"phone create touch target":    `.new-session-button { min-height: 44px; padding: 6px 10px; }`,
+		"section reorder touch target": `.session-section-order-button { width: 44px; height: 44px; }`,
+		"two-row phone header":         `grid-template-areas: "menu heading reset delete" "tabs tabs connection connection"`,
+		"phone header resume slot":     `.conversation-header:has(#resume-session:not([hidden])) { grid-template-areas: "menu heading resume reset delete"`,
+		"48-pixel touch targets":       `.icon-button { width: 48px; height: 48px; }`,
+		"Session action touch target":  `.session-item-actions { top: 5px; right: 1px; width: 44px; height: 44px; }`,
+		"phone safe-area padding":      `env(safe-area-inset-bottom)`,
+		"non-zooming form fields":      `.composer textarea, .pending-message-input, .yaml-panel textarea, .form-grid input`,
+		"desktop composer alignment":   `.composer textarea { flex: 1; min-height: 36px;`,
+		"mobile composer alignment":    `.composer textarea { min-height: 48px; padding: 12px 0; line-height: 24px; }`,
+		"phone-sized dialog":           `max-height: calc(100dvh - 16px`,
+		"shrinking composer content":   `.composer-wrap { min-width: 0;`,
 	} {
 		if !strings.Contains(string(styles), expected) {
 			t.Errorf("Session styles are missing %s: %s", description, expected)
@@ -1882,7 +1889,9 @@ func TestSessionViewsIncludeRuntimeStatus(t *testing.T) {
 		"active display status":      `if (session.active === true) return 'Active';`,
 		"idle display status":        `if (session.active === false) return 'Idle';`,
 		"activity status in sidebar": "activity.textContent = `· ${displayStatus}`;",
+		"activity status class":      `activity.className = 'session-item-activity';`,
 		"activity status in header":  `sessionDisplayStatus(session)`,
+		"namespace metadata class":   `namespace.className = 'session-item-namespace';`,
 		"model in sidebar":           "model.textContent = `· ${session.model}`;",
 		"model in header":            `if (session.model) details.push(session.model);`,
 		"branch text":                `branch.textContent = session.branch;`,
@@ -1906,8 +1915,16 @@ func TestSessionViewsIncludeRuntimeStatus(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(styles), `.session-item-branch { margin-top: 5px;`) {
+	if !strings.Contains(string(styles), `.session-item-branch { margin-top: 3px;`) {
 		t.Error("Session sidebar does not style branch information")
+	}
+	for description, expected := range map[string]string{
+		"truncated namespace metadata": `.session-item-namespace { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }`,
+		"reserved activity status":     `.session-item-activity { flex: none; }`,
+	} {
+		if !strings.Contains(string(styles), expected) {
+			t.Errorf("Session sidebar is missing %s: %s", description, expected)
+		}
 	}
 	for state, expected := range map[string]string{
 		"idle":              `.phase-dot.ready, .phase-dot.idle {`,

--- a/internal/consoleserver/web/app.js
+++ b/internal/consoleserver/web/app.js
@@ -1021,8 +1021,10 @@ function createSessionListItem(session, draggable = false) {
   provider.className = 'provider-badge';
   provider.textContent = providerLabel(session.provider);
   const namespace = document.createElement('span');
+  namespace.className = 'session-item-namespace';
   namespace.textContent = sessionDisplayName(session) === session.name ? `· ${session.namespace}` : `· ${session.namespace}/${session.name}`;
   const activity = document.createElement('span');
+  activity.className = 'session-item-activity';
   activity.textContent = `· ${displayStatus}`;
   meta.append(provider);
   if (session.model) {

--- a/internal/consoleserver/web/index.html
+++ b/internal/consoleserver/web/index.html
@@ -31,10 +31,12 @@
         <button id="console-resources" type="button"><span aria-hidden="true">◇</span> Resources</button>
       </nav>
       <div class="session-sidebar" id="session-sidebar" hidden>
-        <button class="new-session-button" id="new-session">
-          <span aria-hidden="true">＋</span> New session
-        </button>
-        <div class="sidebar-label">Conversations</div>
+        <div class="session-sidebar-header">
+          <div class="sidebar-label">Conversations</div>
+          <button class="new-session-button" id="new-session" type="button">
+            <span aria-hidden="true">＋</span> New session
+          </button>
+        </div>
         <div class="session-list" id="session-list" aria-live="polite"></div>
       </div>
       <div class="sidebar-footer">

--- a/internal/consoleserver/web/styles.css
+++ b/internal/consoleserver/web/styles.css
@@ -33,31 +33,32 @@ body { margin: 0; overflow: hidden; color: var(--ink); background: var(--canvas)
 button, input, select, textarea { font: inherit; }
 button { color: inherit; }
 .app-shell { height: 100%; height: 100dvh; display: grid; grid-template-columns: 286px minmax(0, 1fr); }
-.sidebar { position: relative; z-index: 5; min-height: 0; display: flex; flex-direction: column; padding: 25px 17px 15px; border-right: 1px solid var(--line); background: var(--panel); }
-.brand-row { display: flex; align-items: center; gap: 11px; padding: 0 7px; }
+.sidebar { position: relative; z-index: 5; min-height: 0; display: flex; flex-direction: column; padding: 20px 13px 11px; border-right: 1px solid var(--line); background: var(--panel); }
+.brand-row { display: flex; align-items: center; gap: 11px; padding: 0 5px; }
 .brand-mark { width: 37px; height: 37px; display: grid; place-items: center; border-radius: 12px; background: var(--accent); color: #fff; font: 700 17px/1 ui-monospace, SFMono-Regular, Menlo, monospace; box-shadow: 0 7px 16px rgba(29, 81, 59, .2); }
 .brand { font: 600 17px/1.05 Georgia, "Times New Roman", serif; letter-spacing: -.015em; }
 .brand-subtitle { margin-top: 4px; color: var(--muted); font-size: 11px; font-weight: 650; letter-spacing: .11em; text-transform: uppercase; }
-.new-session-button { display: flex; align-items: center; justify-content: center; gap: 7px; width: 100%; margin: 12px 0 15px; padding: 11px 14px; border: 1px solid #cbd4cd; border-radius: 12px; background: rgba(255,255,255,.7); font-size: 13px; font-weight: 700; cursor: pointer; transition: background .15s, transform .15s, box-shadow .15s; }
+.new-session-button { min-height: 32px; display: flex; align-items: center; justify-content: center; gap: 5px; margin: 0; padding: 5px 9px; border: 1px solid #cbd4cd; border-radius: 9px; background: rgba(255,255,255,.7); font-size: 11px; font-weight: 700; cursor: pointer; transition: background .15s, transform .15s, box-shadow .15s; }
 .new-session-button:hover { background: #fff; transform: translateY(-1px); box-shadow: 0 7px 18px rgba(32,51,41,.08); }
-.namespace-form { margin: 25px 0 14px; padding: 0 5px; }
+.namespace-form { margin: 18px 0 10px; padding: 0 3px; }
 .namespace-form label { display: block; margin: 0 5px 6px; color: var(--faint); font-size: 9px; font-weight: 800; letter-spacing: .11em; text-transform: uppercase; }
 .namespace-form div { display: grid; grid-template-columns: minmax(0, 1fr) auto; }
 .namespace-form input { min-width: 0; padding: 8px 9px; border: 1px solid #cbd4cd; border-right: 0; border-radius: 9px 0 0 9px; outline: 0; background: var(--card); color: var(--ink); font-size: 11px; }
 .namespace-form input:focus { border-color: #779b88; box-shadow: 0 0 0 3px rgba(56,114,88,.08); }
 .namespace-form button { padding: 8px 9px; border: 1px solid #cbd4cd; border-radius: 0 9px 9px 0; background: var(--accent); color: white; font-size: 10px; font-weight: 700; cursor: pointer; }
-.console-nav { display: grid; gap: 3px; margin: 0 0 10px; padding-bottom: 12px; border-bottom: 1px solid var(--line); }
+.console-nav { display: grid; gap: 3px; margin: 0 0 7px; padding-bottom: 8px; border-bottom: 1px solid var(--line); }
 .console-nav button { width: 100%; display: grid; grid-template-columns: 22px minmax(0, 1fr); align-items: center; gap: 7px; padding: 9px 10px; border: 0; border-radius: 9px; background: transparent; color: var(--muted); font-size: 12px; font-weight: 700; text-align: left; cursor: pointer; }
 .console-nav button:hover { background: rgba(255,255,255,.55); color: var(--ink); }
 .console-nav button[aria-current="page"] { background: var(--card); color: var(--ink); box-shadow: 0 4px 14px rgba(35,49,42,.06); }
 .console-nav button span { display: grid; place-items: center; color: var(--accent-2); font-size: 15px; }
 .session-sidebar { flex: 1; min-height: 0; display: flex; flex-direction: column; }
 .session-sidebar[hidden] { display: none; }
-.sidebar-label { padding: 0 10px 9px; color: var(--faint); font-size: 10px; font-weight: 800; letter-spacing: .13em; text-transform: uppercase; }
+.session-sidebar-header { min-height: 38px; display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 2px 4px 4px 8px; }
+.sidebar-label { color: var(--faint); font-size: 10px; font-weight: 800; letter-spacing: .13em; text-transform: uppercase; }
 .session-list { flex: 1; min-height: 0; overflow-y: auto; scrollbar-width: thin; }
 .session-section-group { position: relative; border-radius: 11px; transition: background .15s, outline-color .15s; }
-.session-section-group + .session-section-group { margin-top: 14px; }
-.session-section-heading { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin: 0; padding: 5px 10px 6px; color: var(--faint); font-size: 9px; font-weight: 800; letter-spacing: .1em; text-transform: uppercase; }
+.session-section-group + .session-section-group { margin-top: 10px; }
+.session-section-heading { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin: 0; padding: 3px 8px 4px; color: var(--faint); font-size: 9px; font-weight: 800; letter-spacing: .1em; text-transform: uppercase; }
 .session-section-title { min-width: 0; display: flex; align-items: center; gap: 5px; overflow: hidden; cursor: grab; }
 .session-section-title:active { cursor: grabbing; }
 .session-section-title > span:last-child { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
@@ -77,11 +78,11 @@ button { color: inherit; }
 .session-item:hover { background: rgba(255,255,255,.55); }
 .session-item.active { background: #fff; box-shadow: 0 4px 14px rgba(35,49,42,.06); }
 .session-item.section-saving { opacity: .55; }
-.session-item-select { width: 100%; display: grid; grid-template-columns: 9px minmax(0,1fr); gap: 9px; padding: 11px 42px 11px 10px; border: 0; background: transparent; text-align: left; cursor: pointer; }
+.session-item-select { width: 100%; display: grid; grid-template-columns: 9px minmax(0,1fr); gap: 8px; padding: 8px 38px 8px 8px; border: 0; background: transparent; text-align: left; cursor: pointer; }
 .session-item-select[draggable="true"] { cursor: grab; }
 .session-item-select[draggable="true"]:active { cursor: grabbing; }
 .session-item.has-pull-request .session-item-select { padding-bottom: 5px; }
-.session-item-actions { position: absolute; top: 6px; right: 5px; width: 32px; height: 32px; display: grid; place-items: center; padding: 0 0 5px; border: 0; border-radius: 8px; background: transparent; color: var(--faint); font-size: 18px; line-height: 1; cursor: pointer; }
+.session-item-actions { position: absolute; top: 3px; right: 3px; width: 32px; height: 32px; display: grid; place-items: center; padding: 0 0 5px; border: 0; border-radius: 8px; background: transparent; color: var(--faint); font-size: 18px; line-height: 1; cursor: pointer; }
 .session-item-actions:hover, .session-item-actions:focus-visible, .session-item-actions[aria-expanded="true"] { background: var(--line-soft); color: var(--ink); }
 .session-item-actions:focus-visible { outline: 2px solid var(--accent-2); outline-offset: 1px; }
 .session-actions-menu { position: fixed; z-index: 30; width: 176px; padding: 6px; border: 1px solid var(--line); border-radius: 12px; background: var(--card); box-shadow: 0 16px 45px rgba(25,39,31,.2); }
@@ -100,8 +101,10 @@ button { color: inherit; }
 .session-item-title-row { min-width: 0; display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: baseline; gap: 8px; }
 .session-item-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 13px; font-weight: 680; }
 .session-item-time { color: var(--faint); font-size: 10px; font-variant-numeric: tabular-nums; white-space: nowrap; }
-.session-item-meta { display: flex; gap: 6px; margin-top: 4px; color: var(--faint); font-size: 10.5px; }
-.session-item-branch { margin-top: 5px; overflow: hidden; color: var(--muted); font: 10.5px/1.3 ui-monospace, SFMono-Regular, Menlo, monospace; text-overflow: ellipsis; white-space: nowrap; }
+.session-item-meta { display: flex; gap: 6px; margin-top: 3px; overflow: hidden; color: var(--faint); font-size: 10.5px; white-space: nowrap; }
+.session-item-namespace { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.session-item-activity { flex: none; }
+.session-item-branch { margin-top: 3px; overflow: hidden; color: var(--muted); font: 10.5px/1.3 ui-monospace, SFMono-Regular, Menlo, monospace; text-overflow: ellipsis; white-space: nowrap; }
 .pull-request-link { display: inline-flex; align-items: center; gap: 5px; color: var(--accent-2); }
 .pull-request-link::before { flex: none; width: 6px; height: 6px; border-radius: 50%; background: currentColor; content: ''; }
 .pull-request-link[data-state="draft"] { color: var(--faint); }
@@ -112,12 +115,12 @@ button { color: inherit; }
 .pull-request-checks[data-state="pending"] { color: var(--warning); }
 .pull-request-checks[data-state="success"] { color: var(--pr-open); }
 .pull-request-checks[data-state="failure"] { color: var(--danger); }
-.session-item-pull-request { width: fit-content; max-width: calc(100% - 38px); margin: 0 10px 9px 28px; overflow: hidden; font-size: 10.5px; font-weight: 700; text-decoration: none; text-overflow: ellipsis; white-space: nowrap; }
+.session-item-pull-request { width: fit-content; max-width: calc(100% - 34px); margin: 0 8px 6px 26px; overflow: hidden; font-size: 10.5px; font-weight: 700; text-decoration: none; text-overflow: ellipsis; white-space: nowrap; }
 .session-item-pull-request:hover { text-decoration: underline; }
 .provider-badge { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .session-model { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .sidebar-empty { padding: 14px 10px; color: var(--faint); font-size: 12px; line-height: 1.5; }
-.sidebar-footer { display: flex; justify-content: space-between; gap: 8px; padding: 13px 5px 0; border-top: 1px solid var(--line); }
+.sidebar-footer { display: flex; justify-content: space-between; gap: 8px; padding: 9px 3px 0; border-top: 1px solid var(--line); }
 .sidebar-scrim { display: none; }
 .quiet-button { padding: 7px 8px; border: 0; background: none; color: var(--muted); font-size: 11px; font-weight: 650; cursor: pointer; }
 .quiet-button:hover { color: var(--ink); }
@@ -435,12 +438,30 @@ button { color: inherit; }
 
 @media (max-width: 760px), (max-height: 500px) and (pointer: coarse) {
   .app-shell { display: block; }
-  .sidebar { position: fixed; inset: 0 auto 0 0; width: min(86vw, 310px); padding: calc(17px + env(safe-area-inset-top)) 17px calc(15px + env(safe-area-inset-bottom)) calc(17px + env(safe-area-inset-left)); visibility: hidden; transform: translateX(-103%); transition: transform .22s ease, visibility 0s linear .22s; box-shadow: 18px 0 60px rgba(25,39,31,.2); }
+  .sidebar { position: fixed; inset: 0 auto 0 0; width: min(86vw, 310px); padding: calc(12px + env(safe-area-inset-top)) 12px calc(10px + env(safe-area-inset-bottom)) calc(12px + env(safe-area-inset-left)); visibility: hidden; transform: translateX(-103%); transition: transform .22s ease, visibility 0s linear .22s; box-shadow: 18px 0 60px rgba(25,39,31,.2); }
   .sidebar.open { visibility: visible; transform: translateX(0); transition-delay: 0s; }
   .sidebar-scrim { position: fixed; z-index: 4; inset: 0; display: block; padding: 0; border: 0; background: rgba(25,35,30,.34); opacity: 0; visibility: hidden; transition: opacity .22s ease, visibility 0s linear .22s; }
   .sidebar.open + .sidebar-scrim { opacity: 1; visibility: visible; transition-delay: 0s; }
   .mobile-only { display: grid; }
-  .brand-row .mobile-only { margin-left: auto; }
+  .brand-row { padding: 0 2px; }
+  .brand-row .mobile-only { width: 44px; height: 44px; margin-left: auto; }
+  .namespace-form { margin: 10px 0 7px; padding: 0; }
+  .namespace-form label { display: none; }
+  .namespace-form input, .namespace-form button { min-height: 44px; }
+  .namespace-form button { padding-right: 11px; padding-left: 11px; font-size: 11px; }
+  .console-nav { grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 4px; margin-bottom: 6px; padding-bottom: 7px; }
+  .console-nav button { min-height: 44px; display: flex; justify-content: center; gap: 4px; padding: 0 4px; font-size: 11px; text-align: center; }
+  .console-nav button span { font-size: 14px; }
+  .session-sidebar-header { min-height: 44px; padding: 0 4px 0 8px; }
+  .new-session-button { min-height: 44px; padding: 6px 10px; }
+  .session-section-group + .session-section-group { margin-top: 8px; }
+  .session-section-heading { min-height: 44px; padding: 0 8px; }
+  .session-section-order-button { width: 44px; height: 44px; }
+  .session-item-select { min-height: 60px; padding: 7px 48px 7px 8px; }
+  .session-item-meta, .session-item-branch { margin-top: 2px; }
+  .session-item-pull-request { margin-bottom: 6px; }
+  .sidebar-footer { padding: 5px 3px 0; }
+  .sidebar-footer .quiet-button { min-height: 44px; }
   .console-page { height: 100%; height: 100dvh; }
   .console-page-header { min-height: 92px; padding: calc(10px + env(safe-area-inset-top)) calc(14px + env(safe-area-inset-right)) 11px calc(14px + env(safe-area-inset-left)); }
   .console-page-header h1 { font-size: 24px; }
@@ -450,7 +471,6 @@ button { color: inherit; }
   .resource-toolbar select { width: 100%; min-width: 0; font-size: 16px; }
   .resource-table-wrap { overflow-x: auto; }
   .resource-table { min-width: 680px; }
-  .session-item-select { padding-right: 52px; }
   .session-item-actions { top: 5px; right: 1px; width: 44px; height: 44px; }
   .session-actions-menu button { min-height: 44px; font-size: 14px; }
   .conversation { height: 100%; height: 100dvh; }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Improves the Console sidebar's information density so more Sessions remain visible without making controls difficult to use.

On desktop, this change keeps the persistent vertical navigation while tightening excess spacing, combining the Conversations heading with the New session action, and using more compact Session rows.

On mobile, it:

- presents Overview, Sessions, and Resources in a single horizontal navigation row
- removes the redundant visible Namespace label while preserving the input's accessible name
- keeps primary actions at least 44 pixels tall
- uses a compact Conversations header and 60-pixel Session rows

The mobile layout leaves roughly 385 pixels for the Session list on a 390-by-664-pixel viewport, compared with roughly 236 pixels before this change.

#### Resulting layout

##### Desktop — before

```text
┌──────────────────────┬───────────────────────────────────────┐
│ K  Kelos             │ compact-ui              ● Connected  │
│    CONSOLE           ├───────────────────────────────────────┤
│                      │                                       │
│ NAMESPACE            │             Conversation              │
│ ┌──────────┬────────┐│                                       │
│ │ default  │ Switch ││                                       │
│ └──────────┴────────┘│                                       │
│                      │                                       │
│ ⌂  Overview          │                                       │
│ ◌  Sessions          │                                       │
│ ◇  Resources         │                                       │
│ ──────────────────── │                                       │
│ ┌──────────────────┐ │                                       │
│ │  + New session   │ │                                       │
│ └──────────────────┘ │                                       │
│ CONVERSATIONS        │                                       │
│                      │                                       │
│ ⠿ UNSECTIONED  5 ↑ ↓ │                                       │
│ ┌──────────────────┐ │                                       │
│ │ ● compact-ui Now │ │                                       │
│ │   Codex · Idle   │ │                                       │
│ │   main           │ │                                       │
│ └──────────────────┘ │                                       │
│ ● github-token   2m  │                                       │
│   Codex · Idle       │                                       │
│   main               │                                       │
│ ● review-api     4m  │                                       │
│   Codex · Idle       │                                       │
│                      ├───────────────────────────────────────┤
│ Refresh      Sign out│ Message…                          ↑  │
└──────────────────────┴───────────────────────────────────────┘
```

##### Desktop — after

```text
┌──────────────────────┬───────────────────────────────────────┐
│ K  Kelos             │ compact-ui              ● Connected  │
│    CONSOLE           ├───────────────────────────────────────┤
│ NAMESPACE            │             Conversation              │
│ ┌──────────┬────────┐│                                       │
│ │ default  │ Switch ││                                       │
│ └──────────┴────────┘│                                       │
│ ⌂  Overview          │                                       │
│ ◌  Sessions          │                                       │
│ ◇  Resources         │                                       │
│ CONVERSATIONS  + New │                                       │
│ ⠿ UNSECTIONED  8 ↑ ↓ │                                       │
│ ┌──────────────────┐ │                                       │
│ │ ● compact-ui Now │ │                                       │
│ │   Codex · Idle   │ │                                       │
│ │   main           │ │                                       │
│ └──────────────────┘ │                                       │
│ ● github-token   2m  │                                       │
│   Codex · Idle       │                                       │
│   main               │                                       │
│ ● review-api     4m  │                                       │
│   Codex · Idle       │                                       │
│ ● fix-mobile-nav 6m  │                                       │
│   Codex · Active     │                                       │
│ ● update-console 8m  │                                       │
│   Codex · Idle       │                                       │
│ ● investigate-ci 12m │                                       │
│   Codex · Idle       │                                       │
│                      ├───────────────────────────────────────┤
│ Refresh      Sign out│ Message…                          ↑  │
└──────────────────────┴───────────────────────────────────────┘
```

##### Mobile — before

```text
┌───────────────────────────────┬────────┐
│ K  Kelos Console          ×   │░░░░░░░░│
│                               │░ page ░│
│ NAMESPACE                     │░░░░░░░░│
│ ┌──────────────────┬────────┐ │░░░░░░░░│
│ │ default          │ Switch │ │░░░░░░░░│
│ └──────────────────┴────────┘ │░░░░░░░░│
│ ⌂  Overview                   │░░░░░░░░│
│ ◌  Sessions                   │░░░░░░░░│
│ ◇  Resources                  │░░░░░░░░│
│ ───────────────────────────── │░░░░░░░░│
│ ┌───────────────────────────┐ │░░░░░░░░│
│ │       + New session       │ │░░░░░░░░│
│ └───────────────────────────┘ │░░░░░░░░│
│ CONVERSATIONS                 │░░░░░░░░│
│ ⠿ UNSECTIONED       5   ↑  ↓  │░░░░░░░░│
│ ┌───────────────────────────┐ │░░░░░░░░│
│ │ ● compact-ui          Now │ │░░░░░░░░│
│ │   Codex · gpt · Idle      │ │░░░░░░░░│
│ │   main                    │ │░░░░░░░░│
│ └───────────────────────────┘ │░░░░░░░░│
│ ● github-token           2m   │░░░░░░░░│
│   Codex · gpt · Idle          │░░░░░░░░│
│   main                        │░░░░░░░░│
│                               │░░░░░░░░│
│ Refresh              Sign out│░░░░░░░░│
└───────────────────────────────┴────────┘
```

##### Mobile — after

```text
┌───────────────────────────────┬────────┐
│ K  Kelos Console          ×   │░░░░░░░░│
│ ┌──────────────────┬────────┐ │░ page ░│
│ │ default          │ Switch │ │░░░░░░░░│
│ └──────────────────┴────────┘ │░░░░░░░░│
│ ┌─────────┬─────────┬───────┐ │░░░░░░░░│
│ │⌂ Overview│◌ Sessions│◇ Res.│ │░░░░░░░░│
│ └─────────┴─────────┴───────┘ │░░░░░░░░│
│ CONVERSATIONS    + New session│░░░░░░░░│
│ ⠿ UNSECTIONED       8   ↑  ↓  │░░░░░░░░│
│ ┌───────────────────────────┐ │░░░░░░░░│
│ │ ● compact-ui          Now │ │░░░░░░░░│
│ │   Codex · gpt · Idle      │ │░░░░░░░░│
│ │   main                    │ │░░░░░░░░│
│ └───────────────────────────┘ │░░░░░░░░│
│ ● github-token           2m   │░░░░░░░░│
│   Codex · gpt · Idle          │░░░░░░░░│
│   main                        │░░░░░░░░│
│ ● review-api             4m   │░░░░░░░░│
│   Codex · default · Idle      │░░░░░░░░│
│ ● fix-mobile-nav         6m   │░░░░░░░░│
│   Codex · default · Active    │░░░░░░░░│
│ ● update-console         8m   │░░░░░░░░│
│   Codex · default · Idle      │░░░░░░░░│
│                               │░░░░░░░░│
│ Refresh              Sign out│░░░░░░░░│
└───────────────────────────────┴────────┘
```

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Validation:

- `make update`
- `env -u CODEX_AUTH_JSON -u CODEX_HOME make test`
- `make verify`
- `git diff --check`

Automated browser screenshots were unavailable because the development container does not include Chromium's required shared libraries. Responsive structure, sizing, and touch targets are covered by the Console tests.

#### Does this PR introduce a user-facing change?

```release-note
Improve the Console sidebar layout so more Sessions remain visible on desktop and mobile.
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compacts the Console sidebar so more Sessions remain visible on desktop and mobile without reducing touch targets or accessibility. Previously the sidebar used loose spacing, a separate Conversations header and New session button, a two‑row mobile nav, and taller rows; now spacing is tighter, the header and action are combined, mobile nav is single‑row, rows are 60px on phones, and metadata truncates cleanly.

- HTML: adds a `.session-sidebar-header` to group the Conversations label and New session action; adds `.session-item-namespace` and `.session-item-activity` spans in list items; session list structure is unchanged.
- CSS: keeps desktop grid at `grid-template-columns: 286px minmax(0, 1fr)`; sets phone sidebar width to `min(86vw, 310px)`; uses single‑row phone nav (`repeat(3, minmax(0, 1fr))`); enforces 44px minimum touch targets (nav, namespace controls, New session, section reorder, actions); sets phone session rows to 60px; truncates namespace metadata and reserves activity width; tightens meta/branch spacing (`.session-item-branch { margin-top: 3px; }`).
- Accessibility: hides the visible Namespace label on mobile while preserving the input’s accessible name.
- Tests: update `TestSessionUIAdaptsToPhoneViewport` and `TestSessionViewsIncludeRuntimeStatus` to assert new selectors and layout rules (header grouping, single‑row nav, 60px rows, 44px targets, namespace/activity classes, branch spacing). No API or config changes.

<sup>Written for commit 26f1364ff3233187555bf77a9a105c0caa21a0c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1680?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

