### PR TITLE
Add Session suspend action to console

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -451,8 +451,9 @@ container. Persistent storage is recommended for durable Sessions. When the
 field is omitted, the workspace uses `emptyDir`, which is primarily useful for
 development because its history and changes do not survive Pod replacement.
 
-Set `spec.suspend` to `true` to suspend a Session without deleting it, then set
-it back to `false` or use the Resume action in the shared web client to resume.
+Set `spec.suspend` to `true` or use the Suspend action in the shared web client
+to suspend a Session without deleting it. Set the field back to `false` or use
+the Resume action in the shared web client to resume.
 A suspended Session rejects web connection attempts and the terminal client
 waits for it to resume. Configured persistent workspace and conversation data
 remain available across suspension. An `emptyDir` workspace is deleted with the

--- a/internal/consoleserver/server.go
+++ b/internal/consoleserver/server.go
@@ -428,6 +428,10 @@ func (s *Server) api(writer http.ResponseWriter, request *http.Request) {
 		s.resetSession(writer, request, namespace, name)
 		return
 	}
+	if len(parts) == 4 && parts[3] == "suspend" && request.Method == http.MethodPost {
+		s.suspendSession(writer, request, namespace, name)
+		return
+	}
 	if len(parts) == 4 && parts[3] == "resume" && request.Method == http.MethodPost {
 		s.resumeSession(writer, request, namespace, name)
 		return
@@ -1029,6 +1033,42 @@ func (s *Server) resetSession(writer http.ResponseWriter, request *http.Request,
 		return
 	}
 	writeJSON(writer, http.StatusAccepted, summarize(session))
+}
+
+func (s *Server) suspendSession(writer http.ResponseWriter, request *http.Request, namespace, name string) {
+	var session kelos.Session
+	if err := s.client.Get(request.Context(), client.ObjectKey{Namespace: namespace, Name: name}, &session); err != nil {
+		writeKubernetesError(writer, fmt.Sprintf("getting Session %q to suspend", name), err)
+		return
+	}
+	if session.Spec.Suspend != nil && *session.Spec.Suspend {
+		writeJSON(writer, http.StatusAccepted, summarize(&session))
+		return
+	}
+
+	original := session.DeepCopy()
+	suspend := true
+	session.Spec.Suspend = &suspend
+	if err := s.client.Patch(
+		request.Context(),
+		&session,
+		client.MergeFromWithOptions(original, client.MergeFromWithOptimisticLock{}),
+	); err != nil {
+		status := http.StatusInternalServerError
+		switch {
+		case apierrors.IsNotFound(err):
+			status = http.StatusNotFound
+		case apierrors.IsInvalid(err):
+			status = http.StatusBadRequest
+		case apierrors.IsForbidden(err):
+			status = http.StatusForbidden
+		case apierrors.IsConflict(err):
+			status = http.StatusConflict
+		}
+		writeError(writer, status, fmt.Sprintf("suspending Session %q: %v", name, err))
+		return
+	}
+	writeJSON(writer, http.StatusAccepted, summarize(&session))
 }
 
 func (s *Server) resumeSession(writer http.ResponseWriter, request *http.Request, namespace, name string) {

--- a/internal/consoleserver/server_test.go
+++ b/internal/consoleserver/server_test.go
@@ -20,9 +20,11 @@ import (
 
 	"github.com/gorilla/websocket"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -41,6 +43,15 @@ type fakeSessionAttachmentTransfer struct {
 	uploadedData []byte
 	attachment   sessionruntime.Attachment
 	downloadData []byte
+}
+
+type patchErrorClient struct {
+	client.Client
+	err error
+}
+
+func (c *patchErrorClient) Patch(context.Context, client.Object, client.Patch, ...client.PatchOption) error {
+	return c.err
 }
 
 func (f *fakeSessionAttachmentTransfer) Upload(_ context.Context, _, _, name string, source io.Reader) (sessionruntime.Attachment, error) {
@@ -638,7 +649,7 @@ func TestSessionJavaScriptResumesIdleSuspension(t *testing.T) {
 	for _, expected := range []string{
 		"selectSession(session, true)",
 		"if (resumeIdle && session.idleSuspended) resumeIdleSession(session);",
-		"await requestSessionResume(session);",
+		"await requestSessionLifecycleAction(session, 'resume');",
 	} {
 		if !strings.Contains(javascript, expected) {
 			t.Errorf("Session JavaScript is missing idle resume behavior %q", expected)
@@ -646,13 +657,19 @@ func TestSessionJavaScriptResumesIdleSuspension(t *testing.T) {
 	}
 }
 
-func TestSessionPageOffersUserSuspensionResume(t *testing.T) {
+func TestSessionPageOffersUserSuspensionControls(t *testing.T) {
 	index, err := webFiles.ReadFile("web/index.html")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if expected := `id="resume-session" aria-label="Resume session"`; !strings.Contains(string(index), expected) {
-		t.Errorf("Session page is missing resume control %q", expected)
+	for _, expected := range []string{
+		`id="suspend-session" aria-label="Suspend session"`,
+		`id="resume-session" aria-label="Resume session"`,
+		`id="session-action-lifecycle" type="button" role="menuitem"`,
+	} {
+		if !strings.Contains(string(index), expected) {
+			t.Errorf("Session page is missing suspension control %q", expected)
+		}
 	}
 
 	source, err := webFiles.ReadFile("web/app.js")
@@ -660,11 +677,16 @@ func TestSessionPageOffersUserSuspensionResume(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, expected := range []string{
+		"return session?.userSuspended || session?.idleSuspended ? 'resume' : 'suspend';",
+		"elements.sessionActionLifecycle.textContent = action === 'resume' ? 'Resume' : 'Suspend';",
+		"elements.sessionActionLifecycle.addEventListener('click', event => {",
+		"elements.suspendButton.hidden = !session || session.userSuspended;",
+		"elements.suspendButton.addEventListener('click', suspendSelectedSession);",
 		"elements.resumeButton.hidden = !session?.userSuspended;",
 		"elements.resumeButton.addEventListener('click', resumeSelectedSession);",
 	} {
 		if !strings.Contains(string(source), expected) {
-			t.Errorf("Session JavaScript is missing user suspension resume behavior %q", expected)
+			t.Errorf("Session JavaScript is missing user suspension behavior %q", expected)
 		}
 	}
 }
@@ -866,7 +888,7 @@ func TestApplicationDisplayNameBehavior(t *testing.T) {
 	}
 }
 
-func TestApplicationSessionResumeBehavior(t *testing.T) {
+func TestApplicationSessionSuspensionBehavior(t *testing.T) {
 	node, err := exec.LookPath("node")
 	if err != nil {
 		t.Skip("Node.js is not installed")
@@ -1362,7 +1384,7 @@ func TestSessionUIAdaptsToPhoneViewport(t *testing.T) {
 		"phone create touch target":    `.new-session-button { min-height: 44px; padding: 6px 10px; }`,
 		"section reorder touch target": `.session-section-order-button { width: 44px; height: 44px; }`,
 		"two-row phone header":         `grid-template-areas: "menu heading reset delete" "tabs tabs connection connection"`,
-		"phone header resume slot":     `.conversation-header:has(#resume-session:not([hidden])) { grid-template-areas: "menu heading resume reset delete"`,
+		"phone lifecycle action slot":  `.conversation-header:has(.session-lifecycle-action:not([hidden])) { grid-template-areas: "menu heading lifecycle reset delete"`,
 		"48-pixel touch targets":       `.icon-button { width: 48px; height: 48px; }`,
 		"Session action touch target":  `.session-item-actions { top: 5px; right: 1px; width: 44px; height: 44px; }`,
 		"phone safe-area padding":      `env(safe-area-inset-bottom)`,
@@ -1567,6 +1589,98 @@ func TestSessionDisplayNameAPI(t *testing.T) {
 	}
 	if _, exists := updated.Annotations[sessionDisplayNameAnnotation]; exists || updated.Annotations["owner"] != "platform" {
 		t.Fatalf("Session annotations after clearing display name = %v", updated.Annotations)
+	}
+}
+
+func TestSessionSuspendAPISuspendsSession(t *testing.T) {
+	server := testServer(t)
+	session := &kelos.Session{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "chat",
+			Namespace:   "team-a",
+			Annotations: map[string]string{"owner": "platform"},
+		},
+		Spec: kelos.SessionSpec{Worker: kelos.WorkerSpec{
+			Type:        "codex",
+			Model:       "gpt-5",
+			Credentials: &kelos.Credentials{Type: kelos.CredentialTypeNone},
+		}},
+		Status: kelos.SessionStatus{Phase: kelos.SessionPhaseReady},
+	}
+	if err := server.client.Create(t.Context(), session); err != nil {
+		t.Fatal(err)
+	}
+
+	request := httptest.NewRequest(http.MethodPost, "/api/sessions/team-a/chat/suspend", nil)
+	request.Header.Set("Authorization", "Bearer secret-token")
+	response := httptest.NewRecorder()
+	server.ServeHTTP(response, request)
+	if response.Code != http.StatusAccepted {
+		t.Fatalf("suspend status = %d body = %s", response.Code, response.Body.String())
+	}
+	var summary sessionSummary
+	if err := json.Unmarshal(response.Body.Bytes(), &summary); err != nil {
+		t.Fatal(err)
+	}
+	if !summary.UserSuspended {
+		t.Fatal("suspend response userSuspended = false, want true")
+	}
+
+	var updated kelos.Session
+	if err := server.client.Get(t.Context(), client.ObjectKeyFromObject(session), &updated); err != nil {
+		t.Fatal(err)
+	}
+	if updated.Spec.Suspend == nil || !*updated.Spec.Suspend {
+		t.Fatalf("suspended Session suspend = %v, want true", updated.Spec.Suspend)
+	}
+	if updated.Spec.Worker.Model != "gpt-5" || updated.Annotations["owner"] != "platform" {
+		t.Fatalf("suspended Session lost unrelated fields: %#v", updated)
+	}
+
+	request = httptest.NewRequest(http.MethodPost, "/api/sessions/team-a/chat/suspend", nil)
+	request.Header.Set("Authorization", "Bearer secret-token")
+	response = httptest.NewRecorder()
+	server.ServeHTTP(response, request)
+	if response.Code != http.StatusAccepted {
+		t.Fatalf("repeated suspend status = %d body = %s", response.Code, response.Body.String())
+	}
+	if err := json.Unmarshal(response.Body.Bytes(), &summary); err != nil {
+		t.Fatal(err)
+	}
+	if !summary.UserSuspended {
+		t.Fatal("repeated suspend response userSuspended = false, want true")
+	}
+}
+
+func TestSessionSuspendAPIReturnsNotFoundWhenPatchTargetDisappears(t *testing.T) {
+	server := testServer(t)
+	session := &kelos.Session{
+		ObjectMeta: metav1.ObjectMeta{Name: "chat", Namespace: "team-a"},
+		Spec: kelos.SessionSpec{Worker: kelos.WorkerSpec{
+			Type:        "codex",
+			Credentials: &kelos.Credentials{Type: kelos.CredentialTypeNone},
+		}},
+	}
+	if err := server.client.Create(t.Context(), session); err != nil {
+		t.Fatal(err)
+	}
+	server.client = &patchErrorClient{
+		Client: server.client,
+		err: apierrors.NewNotFound(
+			schema.GroupResource{Group: kelos.GroupVersion.Group, Resource: "sessions"},
+			session.Name,
+		),
+	}
+
+	request := httptest.NewRequest(http.MethodPost, "/api/sessions/team-a/chat/suspend", nil)
+	request.Header.Set("Authorization", "Bearer secret-token")
+	response := httptest.NewRecorder()
+	server.ServeHTTP(response, request)
+	if response.Code != http.StatusNotFound {
+		t.Fatalf("suspend status = %d body = %s", response.Code, response.Body.String())
+	}
+	if !strings.Contains(response.Body.String(), `suspending Session \"chat\"`) {
+		t.Fatalf("suspend body = %s", response.Body.String())
 	}
 }
 

--- a/internal/consoleserver/testdata/session_actions_test.js
+++ b/internal/consoleserver/testdata/session_actions_test.js
@@ -115,6 +115,7 @@ function applicationSlice(start, end) {
 
 vm.runInThisContext(applicationSlice('function sessionKey', 'function sessionViewKey'), {filename: 'app.js'});
 vm.runInThisContext(applicationSlice('function createSessionListItem', 'function sectionLabel'), {filename: 'app.js'});
+vm.runInThisContext(applicationSlice('async function requestSessionLifecycleAction', 'function createWelcome'), {filename: 'app.js'});
 vm.runInThisContext(applicationSlice('async function deleteSession', 'elements.resumeButton.addEventListener'), {filename: 'app.js'});
 
 global.sessionDisplayStatus = () => 'Ready';
@@ -127,18 +128,23 @@ global.selectSession = () => {};
 function resetHarness() {
   global.elements = {
     list: new TestNode('div'),
-    sessionActionsMenu: new TestNode('div', {top: 0, right: 0, bottom: 0, width: 176, height: 120}),
+    sessionActionsMenu: new TestNode('div', {top: 0, right: 0, bottom: 0, width: 176, height: 160}),
     sessionActionRename: new TestNode('button'),
+    sessionActionLifecycle: new TestNode('button'),
     sessionActionReset: new TestNode('button'),
     newSessionButton: new TestNode('button'),
   };
-  elements.sessionActionsMenu.append(elements.sessionActionRename, elements.sessionActionReset);
+  elements.sessionActionsMenu.append(elements.sessionActionRename, elements.sessionActionLifecycle, elements.sessionActionReset);
   elements.sessionActionsMenu.hidden = true;
   document.activeElement = null;
   global.state = {
     sessions: [],
     selected: null,
     currentView: null,
+    namespaceGeneration: 0,
+    sessionListGeneration: 0,
+    suspendingSession: false,
+    resumingSession: false,
     sessionActionKey: '',
     sessionActionTrigger: null,
     sectionAssignments: new Set(),
@@ -164,6 +170,7 @@ async function testEverySessionRowHasActionsMenu() {
   assert.equal(stopped, true);
   assert.equal(state.sessionActionKey, 'default/review');
   assert.equal(elements.sessionActionsMenu.hidden, false);
+  assert.equal(elements.sessionActionLifecycle.textContent, 'Suspend');
   assert.equal(actions.attributes.get('aria-expanded'), 'true');
   assert.equal(document.activeElement, elements.sessionActionRename);
 
@@ -203,7 +210,7 @@ function testOpenMenuSurvivesSessionRefresh() {
   const firstItem = createSessionListItem(session);
   openSessionActionsMenu(session, firstItem.children[1]);
 
-  const refreshed = {...session, displayName: 'Review CI', resetting: true};
+  const refreshed = {...session, displayName: 'Review CI', resetting: true, idleSuspended: true};
   state.sessions = [refreshed];
   state.sessionActionTrigger = null;
   const refreshedItem = createSessionListItem(refreshed);
@@ -212,6 +219,7 @@ function testOpenMenuSurvivesSessionRefresh() {
   const refreshedActions = refreshedItem.children[1];
   assert.equal(elements.sessionActionsMenu.hidden, false);
   assert.equal(elements.sessionActionsMenu.attributes.get('aria-label'), 'Actions for Review CI');
+  assert.equal(elements.sessionActionLifecycle.textContent, 'Resume');
   assert.equal(elements.sessionActionReset.disabled, true);
   assert.equal(refreshedActions.attributes.get('aria-expanded'), 'true');
 }
@@ -257,6 +265,43 @@ async function testActionsCanTargetAnUnselectedSession() {
   assert.deepEqual(clearedAttachments, ['team-a/target', 'team-a/target']);
   assert.equal(selectionChanges, 0);
   assert.equal(state.selected, selected);
+}
+
+async function testLifecycleActionTargetsAnUnselectedSession() {
+  resetHarness();
+  const selected = {namespace: 'default', name: 'selected'};
+  const target = {namespace: 'team-a', name: 'target', userSuspended: false};
+  state.sessions = [selected, target];
+  state.selected = selected;
+  state.namespaceGeneration = 4;
+  state.sessionActionKey = sessionKey(target);
+
+  const requests = [];
+  const toasts = [];
+  let socketCloses = 0;
+  global.api = async (requestPath, options) => {
+    requests.push({path: requestPath, options});
+    return {...target, userSuspended: requestPath.endsWith('/suspend')};
+  };
+  global.renderSessions = () => {};
+  global.renderHeader = () => {};
+  global.closeSocket = () => { socketCloses++; };
+  global.connectSocket = () => {};
+  global.setConnection = () => {};
+  global.showToast = message => { toasts.push(message); };
+
+  await runSessionMenuAction({detail: 1}, toggleSessionSuspension);
+  state.sessionActionKey = sessionKey(state.sessions[1]);
+  await runSessionMenuAction({detail: 1}, toggleSessionSuspension);
+
+  assert.deepEqual(requests, [
+    {path: '/api/sessions/team-a/target/suspend', options: {method: 'POST'}},
+    {path: '/api/sessions/team-a/target/resume', options: {method: 'POST'}},
+  ]);
+  assert.deepEqual(toasts, ['Session suspend requested', 'Session resume requested']);
+  assert.equal(socketCloses, 0);
+  assert.equal(state.selected, selected);
+  assert.equal(state.sessions[1].userSuspended, false);
 }
 
 async function testActionsUpdateTheSelectedSession() {
@@ -366,9 +411,11 @@ async function testTouchActionRunsBeforeMenuCloses() {
 
 assert.match(index, /id="session-actions-menu" role="menu"/);
 assert.match(index, /id="session-action-rename"[^>]+role="menuitem"/);
+assert.match(index, /id="session-action-lifecycle"[^>]+role="menuitem"/);
 assert.match(index, /id="session-action-reset"[^>]+role="menuitem"/);
 assert.match(index, /id="session-action-delete"[^>]+role="menuitem"/);
 assert.match(styles, /\.session-actions-menu button:focus-visible \{[^}]*outline: 2px solid var\(--accent-2\)/);
+assert.match(application, /sessionActionLifecycle\.addEventListener\('click'/);
 assert.match(application, /sessionActionsMenu\.addEventListener\('focusout'/);
 
 testEverySessionRowHasActionsMenu()
@@ -377,6 +424,7 @@ testEverySessionRowHasActionsMenu()
     testOpenMenuSurvivesSessionRefresh();
     return testActionsCanTargetAnUnselectedSession();
   })
+  .then(() => testLifecycleActionTargetsAnUnselectedSession())
   .then(() => testActionsUpdateTheSelectedSession())
   .then(() => testKeyboardActionsRestoreFocusAfterRefresh())
   .then(() => testKeyboardActionRestoresFocusAfterRequestFailure())

--- a/internal/consoleserver/testdata/session_history_test.js
+++ b/internal/consoleserver/testdata/session_history_test.js
@@ -174,6 +174,7 @@ function resetHarness() {
     runtimeStatus: new TestNode('div'),
     sidebar: new TestNode('aside'),
     displayNameButton: new TestNode('button'),
+    suspendButton: new TestNode('button'),
     resumeButton: new TestNode('button'),
     resetButton: new TestNode('button'),
     deleteButton: new TestNode('button'),

--- a/internal/consoleserver/testdata/session_resume_test.js
+++ b/internal/consoleserver/testdata/session_resume_test.js
@@ -13,7 +13,8 @@ function applicationSlice(start, end) {
   return application.slice(startIndex, endIndex);
 }
 
-vm.runInThisContext(applicationSlice('async function requestSessionResume', 'function createWelcome'), {filename: 'app.js'});
+vm.runInThisContext(applicationSlice('function sessionLifecycleAction', 'function updateSessionActionsMenu'), {filename: 'app.js'});
+vm.runInThisContext(applicationSlice('async function requestSessionLifecycleAction', 'function createWelcome'), {filename: 'app.js'});
 vm.runInThisContext(applicationSlice('async function loadSessions', 'async function loadConfig'), {filename: 'app.js'});
 
 async function testUserSuspendedSessionResume() {
@@ -58,6 +59,85 @@ async function testUserSuspendedSessionResume() {
   assert.deepEqual(toasts, ['Session resume requested']);
 }
 
+async function testSessionSuspend() {
+  const session = {namespace: 'team-a', name: 'chat', phase: 'Ready', userSuspended: false};
+  global.sessionKey = value => `${value.namespace}/${value.name}`;
+  global.state = {
+    namespaceGeneration: 4,
+    sessionListGeneration: 0,
+    sessions: [session],
+    selected: session,
+    suspendingSession: false,
+  };
+  let request;
+  let sessionsRendered = 0;
+  let socketClosures = 0;
+  const headerStates = [];
+  const connectionStates = [];
+  const toasts = [];
+  global.api = async (requestPath, options) => {
+    request = {path: requestPath, options};
+    return {...session, userSuspended: true};
+  };
+  global.renderSessions = () => { sessionsRendered++; };
+  global.renderHeader = () => {
+    headerStates.push({
+      suspendingSession: state.suspendingSession,
+      userSuspended: state.selected.userSuspended,
+    });
+  };
+  global.closeSocket = () => { socketClosures++; };
+  global.setConnection = (status, label) => { connectionStates.push({status, label}); };
+  global.showToast = message => { toasts.push(message); };
+
+  await suspendSelectedSession();
+
+  assert.equal(request.path, '/api/sessions/team-a/chat/suspend');
+  assert.deepEqual(request.options, {method: 'POST'});
+  assert.equal(state.sessions[0].userSuspended, true);
+  assert.equal(state.selected.userSuspended, true);
+  assert.equal(state.suspendingSession, false);
+  assert.equal(sessionsRendered, 1);
+  assert.equal(socketClosures, 1);
+  assert.deepEqual(connectionStates, [{status: 'connecting', label: 'Suspending'}]);
+  assert.deepEqual(headerStates[headerStates.length - 1], {
+    suspendingSession: false,
+    userSuspended: true,
+  });
+  assert.deepEqual(toasts, ['Session suspend requested']);
+}
+
+async function testSuspendFailureReconnectsSelectedSession() {
+  const session = {namespace: 'team-a', name: 'chat', phase: 'Ready', userSuspended: false};
+  global.sessionKey = value => `${value.namespace}/${value.name}`;
+  global.state = {
+    namespaceGeneration: 4,
+    sessionListGeneration: 0,
+    sessions: [session],
+    selected: session,
+    suspendingSession: false,
+  };
+  let socketClosures = 0;
+  let socketConnections = 0;
+  const toasts = [];
+  global.api = async () => {
+    assert.equal(socketClosures, 1);
+    throw new Error('suspend failed');
+  };
+  global.renderHeader = () => {};
+  global.closeSocket = () => { socketClosures++; };
+  global.connectSocket = () => { socketConnections++; };
+  global.setConnection = () => {};
+  global.showToast = message => { toasts.push(message); };
+
+  await suspendSelectedSession();
+
+  assert.equal(socketClosures, 1);
+  assert.equal(socketConnections, 1);
+  assert.equal(state.suspendingSession, false);
+  assert.deepEqual(toasts, ['suspend failed']);
+}
+
 async function testResumeIgnoresOlderSessionList() {
   const suspended = {namespace: 'team-a', name: 'chat', phase: 'Suspended', userSuspended: true};
   const resumed = {...suspended, userSuspended: false};
@@ -79,7 +159,7 @@ async function testResumeIgnoresOlderSessionList() {
   global.renderHeader = () => {};
 
   const loading = loadSessions();
-  await requestSessionResume(suspended);
+  await requestSessionLifecycleAction(suspended, 'resume');
   resolveList([suspended]);
   await loading;
 
@@ -87,6 +167,10 @@ async function testResumeIgnoresOlderSessionList() {
   assert.equal(state.selected.userSuspended, false);
 }
 
-testUserSuspendedSessionResume().then(testResumeIgnoresOlderSessionList).then(() => {
-  process.stdout.write('Session resume tests passed\n');
-});
+testUserSuspendedSessionResume()
+  .then(testSessionSuspend)
+  .then(testSuspendFailureReconnectsSelectedSession)
+  .then(testResumeIgnoresOlderSessionList)
+  .then(() => {
+    process.stdout.write('Session suspension tests passed\n');
+  });

--- a/internal/consoleserver/web/app.js
+++ b/internal/consoleserver/web/app.js
@@ -11,6 +11,7 @@ const elements = {
   saveDisplayNameButton: document.querySelector('#save-session-display-name'),
   sessionActionsMenu: document.querySelector('#session-actions-menu'),
   sessionActionRename: document.querySelector('#session-action-rename'),
+  sessionActionLifecycle: document.querySelector('#session-action-lifecycle'),
   sessionActionReset: document.querySelector('#session-action-reset'),
   sessionActionDelete: document.querySelector('#session-action-delete'),
   overviewButton: document.querySelector('#console-overview'),
@@ -92,6 +93,7 @@ const elements = {
   persistentVolume: document.querySelector('#volume-claim-enabled'),
   volumeClaimFields: document.querySelector('#volume-claim-fields'),
   createButton: document.querySelector('#create-session'),
+  suspendButton: document.querySelector('#suspend-session'),
   resumeButton: document.querySelector('#resume-session'),
   resetButton: document.querySelector('#reset-session'),
   deleteButton: document.querySelector('#delete-session'),
@@ -151,6 +153,7 @@ const state = {
   sourceGeneration: 0,
   sourceLoading: false,
   creatingSession: false,
+  suspendingSession: false,
   resumingSession: false,
   consoleView: 'overview',
   resourceGroups: [],
@@ -1125,13 +1128,23 @@ function closeSessionActionsMenu(restoreFocus = false) {
   if (restoreFocus && trigger) trigger.focus();
 }
 
+function sessionLifecycleAction(session) {
+  return session?.userSuspended || session?.idleSuspended ? 'resume' : 'suspend';
+}
+
+function updateSessionActionsMenu(session) {
+  const action = sessionLifecycleAction(session);
+  elements.sessionActionLifecycle.textContent = action === 'resume' ? 'Resume' : 'Suspend';
+  elements.sessionActionReset.disabled = session.resetting;
+  elements.sessionActionsMenu.setAttribute('aria-label', `Actions for ${sessionDisplayName(session)}`);
+}
+
 function openSessionActionsMenu(session, trigger) {
   closeSessionActionsMenu();
   state.sessionActionKey = sessionKey(session);
   state.sessionActionTrigger = trigger;
   trigger.setAttribute('aria-expanded', 'true');
-  elements.sessionActionReset.disabled = session.resetting;
-  elements.sessionActionsMenu.setAttribute('aria-label', `Actions for ${sessionDisplayName(session)}`);
+  updateSessionActionsMenu(session);
   elements.sessionActionsMenu.hidden = false;
   positionSessionActionsMenu(trigger);
   elements.sessionActionRename.focus();
@@ -1153,8 +1166,7 @@ function syncSessionActionsMenu() {
     return;
   }
   state.sessionActionTrigger.setAttribute('aria-expanded', 'true');
-  elements.sessionActionReset.disabled = session.resetting;
-  elements.sessionActionsMenu.setAttribute('aria-label', `Actions for ${sessionDisplayName(session)}`);
+  updateSessionActionsMenu(session);
   positionSessionActionsMenu(state.sessionActionTrigger);
 }
 
@@ -1953,16 +1965,16 @@ function selectSession(session, resumeIdle = false) {
 
 async function resumeIdleSession(session) {
   try {
-    await requestSessionResume(session);
+    await requestSessionLifecycleAction(session, 'resume');
   } catch (error) {
     showToast(error.message);
   }
 }
 
-async function requestSessionResume(session) {
+async function requestSessionLifecycleAction(session, action) {
   const generation = state.namespaceGeneration;
   const updated = await api(
-    `/api/sessions/${encodeURIComponent(session.namespace)}/${encodeURIComponent(session.name)}/resume`,
+    `/api/sessions/${encodeURIComponent(session.namespace)}/${encodeURIComponent(session.name)}/${action}`,
     {method: 'POST'},
   );
   if (generation !== state.namespaceGeneration) return updated;
@@ -1974,20 +1986,57 @@ async function requestSessionResume(session) {
   return updated;
 }
 
-async function resumeSelectedSession() {
-  const session = state.selected;
-  if (!session?.userSuspended || state.resumingSession) return;
+async function suspendSession(session) {
+  if (!session || session.userSuspended || state.suspendingSession) return;
+  const generation = state.namespaceGeneration;
+  const key = sessionKey(session);
+  const selected = state.selected && sessionKey(state.selected) === key;
+  state.suspendingSession = true;
+  renderHeader();
+  if (selected) {
+    closeSocket();
+    setConnection('connecting', 'Suspending');
+  }
+  try {
+    await requestSessionLifecycleAction(session, 'suspend');
+    if (generation === state.namespaceGeneration) showToast('Session suspend requested');
+  } catch (error) {
+    if (generation === state.namespaceGeneration) {
+      showToast(error.message);
+      if (selected && state.selected && sessionKey(state.selected) === key) connectSocket();
+    }
+  } finally {
+    state.suspendingSession = false;
+    renderHeader();
+  }
+}
+
+async function resumeSession(session) {
+  if (sessionLifecycleAction(session) !== 'resume' || state.resumingSession) return;
+  const generation = state.namespaceGeneration;
   state.resumingSession = true;
   renderHeader();
   try {
-    await requestSessionResume(session);
-    showToast('Session resume requested');
+    await requestSessionLifecycleAction(session, 'resume');
+    if (generation === state.namespaceGeneration) showToast('Session resume requested');
   } catch (error) {
-    showToast(error.message);
+    if (generation === state.namespaceGeneration) showToast(error.message);
   } finally {
     state.resumingSession = false;
     renderHeader();
   }
+}
+
+function toggleSessionSuspension(session) {
+  return sessionLifecycleAction(session) === 'resume' ? resumeSession(session) : suspendSession(session);
+}
+
+function suspendSelectedSession() {
+  return suspendSession(state.selected);
+}
+
+function resumeSelectedSession() {
+  return resumeSession(state.selected);
 }
 
 function createWelcome() {
@@ -2006,6 +2055,8 @@ function renderHeader() {
   elements.displayNameButton.hidden = !session;
   elements.displayNameButton.disabled = !session;
   renderSelectedSessionSection(session);
+  elements.suspendButton.hidden = !session || session.userSuspended;
+  elements.suspendButton.disabled = !session || session.userSuspended || state.suspendingSession;
   elements.resumeButton.hidden = !session?.userSuspended;
   elements.resumeButton.disabled = !session?.userSuspended || state.resumingSession;
   elements.resetButton.disabled = !session || session.resetting;
@@ -4379,12 +4430,16 @@ async function resetSession(session) {
 }
 
 elements.resumeButton.addEventListener('click', resumeSelectedSession);
+elements.suspendButton.addEventListener('click', suspendSelectedSession);
 elements.deleteButton.addEventListener('click', () => deleteSession(state.selected));
 elements.resetButton.addEventListener('click', () => resetSession(state.selected));
 elements.sessionActionRename.addEventListener('click', () => {
   const session = sessionActionsTarget();
   closeSessionActionsMenu();
   openDisplayNameDialog(session);
+});
+elements.sessionActionLifecycle.addEventListener('click', event => {
+  void runSessionMenuAction(event, toggleSessionSuspension);
 });
 elements.sessionActionReset.addEventListener('click', event => {
   void runSessionMenuAction(event, resetSession);

--- a/internal/consoleserver/web/index.html
+++ b/internal/consoleserver/web/index.html
@@ -114,7 +114,8 @@
             <button id="changes-tab" type="button" role="tab" aria-selected="false" aria-controls="changes-view" tabindex="-1" disabled>Changes <span id="changes-count">0</span></button>
           </div>
           <span class="connection-pill" id="connection-pill" data-state="idle"><span></span>Not connected</span>
-          <button class="icon-button" id="resume-session" aria-label="Resume session" title="Resume session" disabled hidden>▶</button>
+          <button class="icon-button session-lifecycle-action" id="suspend-session" aria-label="Suspend session" title="Suspend session" disabled hidden>⏸</button>
+          <button class="icon-button session-lifecycle-action" id="resume-session" aria-label="Resume session" title="Resume session" disabled hidden>▶</button>
           <button class="icon-button danger" id="reset-session" aria-label="Reset session" title="Reset session" disabled>↺</button>
           <button class="icon-button danger" id="delete-session" aria-label="Delete session" title="Delete session" disabled>⌫</button>
         </div>
@@ -357,6 +358,7 @@
 
   <div class="session-actions-menu" id="session-actions-menu" role="menu" hidden>
     <button id="session-action-rename" type="button" role="menuitem">Rename</button>
+    <button id="session-action-lifecycle" type="button" role="menuitem">Suspend</button>
     <button id="session-action-reset" type="button" role="menuitem">Reset</button>
     <div class="session-actions-separator" role="separator"></div>
     <button class="danger" id="session-action-delete" type="button" role="menuitem">Delete</button>

--- a/internal/consoleserver/web/styles.css
+++ b/internal/consoleserver/web/styles.css
@@ -475,12 +475,12 @@ button { color: inherit; }
   .session-actions-menu button { min-height: 44px; font-size: 14px; }
   .conversation { height: 100%; height: 100dvh; }
   .conversation-header { display: grid; grid-template-areas: "menu heading reset delete" "tabs tabs connection connection"; grid-template-columns: 48px minmax(0, 1fr) 48px 48px; gap: 8px 10px; padding: calc(8px + env(safe-area-inset-top)) calc(10px + env(safe-area-inset-right)) 9px calc(10px + env(safe-area-inset-left)); }
-  .conversation-header:has(#resume-session:not([hidden])) { grid-template-areas: "menu heading resume reset delete" "tabs tabs connection connection connection"; grid-template-columns: 48px minmax(0, 1fr) 48px 48px 48px; }
+  .conversation-header:has(.session-lifecycle-action:not([hidden])) { grid-template-areas: "menu heading lifecycle reset delete" "tabs tabs connection connection connection"; grid-template-columns: 48px minmax(0, 1fr) 48px 48px 48px; }
   #open-sidebar { grid-area: menu; }
   .session-heading { grid-area: heading; }
   .header-actions { display: contents; }
   .view-tabs { grid-area: tabs; width: fit-content; }
-  #resume-session { grid-area: resume; }
+  .session-lifecycle-action { grid-area: lifecycle; }
   #reset-session { grid-area: reset; }
   #delete-session { grid-area: delete; }
   .connection-pill { grid-area: connection; width: 48px; height: 48px; max-width: 48px; justify-content: center; justify-self: end; overflow: hidden; padding: 0; color: transparent; font-size: 0; gap: 0; }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds a Suspend action to the Session header in the shared web console. The action sets `Session.spec.suspend`, closes the active browser connection, and switches to the existing Resume action while the Session is suspended.

Adds server and browser coverage for the suspend request and updates the Session lifecycle documentation.

#### UI preview

```text
Session header

Ready Session
+----------------+-----------------------------------------------------------+
| Sessions       | my-session                                                |
| > my-session   | [Conversation] [Changes]  Connected                       |
|                | [|| Suspend] [Reset] [Delete]                             |
+----------------+-----------------------------------------------------------+
                                  |
                                  v
Suspended Session
+----------------+-----------------------------------------------------------+
| Sessions       | my-session                                                |
| > my-session   | [Conversation] [Changes]  Suspended                       |
|                | [> Resume]    [Reset] [Delete]                            |
+----------------+-----------------------------------------------------------+

Session tab action menu

Ready Session                         Suspended Session
+------------------------+             +------------------------+
| > my-session     [...] |             | > my-session     [...] |
+------------------------+             +------------------------+
                  |                                       |
          +-------v-------+                       +-------v-------+
          | Rename        |                       | Rename        |
          | Suspend       |                       | Resume        |
          | Reset         |                       | Reset         |
          |---------------|                       |---------------|
          | Delete        |                       | Delete        |
          +---------------+                       +---------------+
```

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

- `make verify` passes.
- `make test TEST_FLAGS=-run=TestSession` passes.
- The full `make test` run reaches and passes `internal/consoleserver`, but fails in the unchanged `internal/controller` tests `TestCodexEntrypointUsesPersistentSessionHome` and `TestAgentEntrypointsPreserveSkillReferenceFiles`. The first failure reproduces independently.

#### Does this PR introduce a user-facing change?

```release-note
Console users can suspend and resume Sessions without using kubectl.
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Suspend action to the web console and a POST suspend API that sets Session.spec.suspend. Previously suspension required kubectl; now users can pause a Session from the header or actions menu, the selected session’s socket closes, the connection shows “Suspending,” and controls switch to Resume until resumed.

- Server/API: POST `/api/sessions/{namespace}/{name}/suspend` sets `spec.suspend=true` via optimistic-lock merge patch; returns 202 with a session summary; idempotent if already suspended; preserves unrelated fields; maps not found/invalid/forbidden/conflict to HTTP status codes.
- Web console: adds a Suspend header button when not user-suspended; adds a lifecycle item in the actions menu that toggles label and behavior between Suspend/Resume based on user/idle suspension and targets the focused row; unifies suspend/resume via `requestSessionLifecycleAction`; on suspend, closes the selected session’s socket and sets the connection label to “Suspending,” reconnects on failure; phone header positions whichever lifecycle control is visible using `.session-lifecycle-action`.
- Tests/docs: API and browser tests cover suspend/resume via header and actions menu, including unselected targets and menu state updates; docs now reference the Suspend action in the web client.

<sup>Written for commit 4c714e4bb8cb7586848fed2af9efa4a50eb79ae5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1681?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

