### PR TITLE
Visualize resource relationships in the console

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -476,7 +476,9 @@ connect to Sessions across namespaces while operating on one active namespace
 at a time. Users can switch the active namespace live from the sidebar.
 `consoleServer.defaultNamespace` sets its initial value, and resource inventory,
 Session form options, and credential options are loaded only from the active namespace.
-Selecting a Task from the resource inventory shows its agent container logs and
+The Resources page shows the incoming and outgoing relationships for one
+selected object, with a searchable inventory for inspecting the full namespace.
+Selecting a Task from either resource view shows its agent container logs and
 manifest. The Logs tab shows up to the latest 2,000 lines with a 2 MiB maximum
 and can be refreshed while the Task is running. WorkerPool-backed Task views
 include only the selected Task's segment from the recent shared worker Pod log.

--- a/internal/consoleserver/server.go
+++ b/internal/consoleserver/server.go
@@ -29,6 +29,7 @@ import (
 	apiMeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	yamlutil "k8s.io/apimachinery/pkg/util/yaml"
@@ -215,6 +216,25 @@ type consoleResourceSummary struct {
 	CreatedAt string `json:"createdAt,omitempty"`
 	Phase     string `json:"phase,omitempty"`
 	Message   string `json:"message,omitempty"`
+}
+
+type consoleResourceReference struct {
+	Resource string `json:"resource"`
+	Kind     string `json:"kind"`
+	Name     string `json:"name"`
+}
+
+type consoleResourceRelationship struct {
+	Source       consoleResourceReference `json:"source"`
+	Target       consoleResourceReference `json:"target"`
+	Relationship string                   `json:"relationship"`
+	Inferred     bool                     `json:"inferred,omitempty"`
+}
+
+type consoleResourceObject struct {
+	Definition consoleResourceDefinition
+	Summary    consoleResourceSummary
+	Object     client.Object
 }
 
 type consoleResourceDetail struct {
@@ -462,16 +482,22 @@ func (s *Server) listConsoleResources(writer http.ResponseWriter, request *http.
 	namespace := s.requestNamespace(request)
 	groups := make([]consoleResourceGroup, 0, 4)
 	groupIndexes := make(map[string]int)
+	allObjects := make([]consoleResourceObject, 0)
 	for _, definition := range consoleResourceDefinitions {
 		list := definition.NewList()
 		if err := s.client.List(request.Context(), list, client.InNamespace(namespace)); err != nil {
 			writeError(writer, http.StatusInternalServerError, fmt.Sprintf("listing %s: %v", definition.Label, err))
 			return
 		}
-		items, err := consoleResourceSummaries(list)
+		objects, err := consoleResourceObjects(definition, list)
 		if err != nil {
 			writeError(writer, http.StatusInternalServerError, fmt.Sprintf("summarizing %s: %v", definition.Label, err))
 			return
+		}
+		allObjects = append(allObjects, objects...)
+		items := make([]consoleResourceSummary, 0, len(objects))
+		for _, object := range objects {
+			items = append(items, object.Summary)
 		}
 		index, ok := groupIndexes[definition.Group]
 		if !ok {
@@ -486,19 +512,24 @@ func (s *Server) listConsoleResources(writer http.ResponseWriter, request *http.
 			Items:    items,
 		})
 	}
-	writeJSON(writer, http.StatusOK, map[string]any{"namespace": namespace, "groups": groups})
+	relationships, err := consoleResourceRelationships(allObjects)
+	if err != nil {
+		writeError(writer, http.StatusInternalServerError, fmt.Sprintf("relating resources: %v", err))
+		return
+	}
+	writeJSON(writer, http.StatusOK, map[string]any{"namespace": namespace, "groups": groups, "relationships": relationships})
 }
 
-func consoleResourceSummaries(list client.ObjectList) ([]consoleResourceSummary, error) {
+func consoleResourceObjects(definition consoleResourceDefinition, list client.ObjectList) ([]consoleResourceObject, error) {
 	objects, err := apiMeta.ExtractList(list)
 	if err != nil {
 		return nil, err
 	}
-	items := make([]consoleResourceSummary, 0, len(objects))
+	items := make([]consoleResourceObject, 0, len(objects))
 	for _, object := range objects {
-		accessor, err := apiMeta.Accessor(object)
-		if err != nil {
-			return nil, err
+		resourceObject, ok := object.(client.Object)
+		if !ok {
+			return nil, fmt.Errorf("%T does not implement client.Object", object)
 		}
 		content, err := runtime.DefaultUnstructuredConverter.ToUnstructured(object)
 		if err != nil {
@@ -513,25 +544,168 @@ func consoleResourceSummaries(list client.ObjectList) ([]consoleResourceSummary,
 		}
 		message, _, _ := unstructured.NestedString(content, "status", "message")
 		createdAt := ""
-		created := accessor.GetCreationTimestamp()
+		created := resourceObject.GetCreationTimestamp()
 		if !created.IsZero() {
 			createdAt = created.UTC().Format(time.RFC3339)
 		}
-		items = append(items, consoleResourceSummary{
-			Name:      accessor.GetName(),
-			Namespace: accessor.GetNamespace(),
-			CreatedAt: createdAt,
-			Phase:     phase,
-			Message:   message,
+		items = append(items, consoleResourceObject{
+			Definition: definition,
+			Summary: consoleResourceSummary{
+				Name:      resourceObject.GetName(),
+				Namespace: resourceObject.GetNamespace(),
+				CreatedAt: createdAt,
+				Phase:     phase,
+				Message:   message,
+			},
+			Object: resourceObject,
 		})
 	}
 	sort.Slice(items, func(i, j int) bool {
-		if items[i].CreatedAt != items[j].CreatedAt {
-			return items[i].CreatedAt > items[j].CreatedAt
+		if items[i].Summary.CreatedAt != items[j].Summary.CreatedAt {
+			return items[i].Summary.CreatedAt > items[j].Summary.CreatedAt
 		}
-		return items[i].Name < items[j].Name
+		return items[i].Summary.Name < items[j].Summary.Name
 	})
 	return items, nil
+}
+
+func consoleResourceRelationships(objects []consoleResourceObject) ([]consoleResourceRelationship, error) {
+	relationships := make(map[string]consoleResourceRelationship)
+	add := func(source, target consoleResourceReference, relationship string, inferred bool) {
+		if source.Name == "" || target.Name == "" {
+			return
+		}
+		key := strings.Join([]string{source.Resource, source.Name, target.Resource, target.Name, relationship}, "\x00")
+		relationships[key] = consoleResourceRelationship{Source: source, Target: target, Relationship: relationship, Inferred: inferred}
+	}
+
+	for _, object := range objects {
+		source := consoleReference(object.Definition, object.Summary.Name)
+		switch value := object.Object.(type) {
+		case *kelos.Task:
+			consoleWorkerRelationships(source, value.Spec.Worker, add)
+			consoleLegacyWorkerRelationships(source, value.Spec.WorkspaceRef, value.Spec.AgentConfigRefs, add)
+			if value.Spec.WorkerPoolRef != nil {
+				add(source, consoleReferenceFor("workerpools", value.Spec.WorkerPoolRef.Name), "runs on", false)
+			}
+			for _, dependency := range value.Spec.DependsOn {
+				add(source, consoleReferenceFor("tasks", dependency), "depends on", false)
+			}
+			if !consoleOwnerRelationship(object.Object, source, "TaskSpawner", "creates", add) {
+				origin := value.Annotations["kelos.dev/created-from-taskspawner"]
+				if origin != "" {
+					add(consoleReferenceFor("taskspawners", origin), source, "creates", false)
+				} else {
+					add(consoleReferenceFor("taskspawners", value.Labels["kelos.dev/taskspawner"]), source, "creates", true)
+				}
+			}
+		case *kelos.Session:
+			consoleWorkerRelationships(source, &value.Spec.Worker, add)
+			if !consoleOwnerRelationship(object.Object, source, "SessionSpawner", "creates", add) {
+				add(consoleReferenceFor("sessionspawners", value.Annotations["kelos.dev/sessionspawner-name"]), source, "creates", false)
+			}
+		case *kelos.TaskSpawner:
+			consoleWorkerRelationships(source, value.Spec.TaskTemplate.Worker, add)
+			consoleLegacyWorkerRelationships(source, value.Spec.TaskTemplate.WorkspaceRef, value.Spec.TaskTemplate.AgentConfigRefs, add)
+			if value.Spec.TaskTemplate.WorkerPoolRef != nil {
+				add(source, consoleReferenceFor("workerpools", value.Spec.TaskTemplate.WorkerPoolRef.Name), "runs Tasks on", false)
+			}
+			for _, dependency := range value.Spec.TaskTemplate.DependsOn {
+				add(source, consoleReferenceFor("tasks", dependency), "spawned Tasks depend on", false)
+			}
+		case *kelos.SessionSpawner:
+			consoleWorkerRelationships(source, &value.Spec.SessionTemplate.Worker, add)
+		case *kelos.WorkerPool:
+			consoleWorkerRelationships(source, &value.Spec.Worker, add)
+		case *kelos.TaskRecord:
+			add(consoleReferenceFor("tasks", value.Spec.TaskRef.Name), source, "recorded as", false)
+		}
+	}
+
+	budgetCandidates := make([]consoleResourceObject, 0)
+	for _, object := range objects {
+		switch object.Object.(type) {
+		case *kelos.Task, *kelos.TaskRecord:
+			budgetCandidates = append(budgetCandidates, object)
+		}
+	}
+	for _, object := range objects {
+		budget, ok := object.Object.(*kelos.TaskBudget)
+		if !ok {
+			continue
+		}
+		selector, err := metav1.LabelSelectorAsSelector(&budget.Spec.TaskSelector)
+		if err != nil {
+			return nil, fmt.Errorf("TaskBudget %q selector: %w", budget.Name, err)
+		}
+		source := consoleReference(object.Definition, object.Summary.Name)
+		for _, candidate := range budgetCandidates {
+			if !selector.Matches(labels.Set(candidate.Object.GetLabels())) {
+				continue
+			}
+			target := consoleReference(candidate.Definition, candidate.Summary.Name)
+			switch candidate.Object.(type) {
+			case *kelos.Task:
+				add(source, target, "limits", true)
+			case *kelos.TaskRecord:
+				add(source, target, "accounts for", true)
+			}
+		}
+	}
+
+	result := make([]consoleResourceRelationship, 0, len(relationships))
+	for _, relationship := range relationships {
+		result = append(result, relationship)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		left := result[i]
+		right := result[j]
+		return strings.Join([]string{left.Source.Resource, left.Source.Name, left.Target.Resource, left.Target.Name, left.Relationship}, "\x00") <
+			strings.Join([]string{right.Source.Resource, right.Source.Name, right.Target.Resource, right.Target.Name, right.Relationship}, "\x00")
+	})
+	return result, nil
+}
+
+func consoleReference(definition consoleResourceDefinition, name string) consoleResourceReference {
+	return consoleResourceReference{Resource: definition.Resource, Kind: definition.Kind, Name: name}
+}
+
+func consoleReferenceFor(resource, name string) consoleResourceReference {
+	definition, ok := consoleResourceDefinitionFor(resource)
+	if !ok {
+		return consoleResourceReference{Resource: resource, Name: name}
+	}
+	return consoleReference(definition, name)
+}
+
+func consoleWorkerRelationships(source consoleResourceReference, worker *kelos.WorkerSpec, add func(consoleResourceReference, consoleResourceReference, string, bool)) {
+	if worker == nil {
+		return
+	}
+	consoleLegacyWorkerRelationships(source, worker.WorkspaceRef, worker.AgentConfigRefs, add)
+}
+
+func consoleLegacyWorkerRelationships(source consoleResourceReference, workspace *kelos.WorkspaceReference, agentConfigs []kelos.AgentConfigReference, add func(consoleResourceReference, consoleResourceReference, string, bool)) {
+	if workspace != nil {
+		add(source, consoleReferenceFor("workspaces", workspace.Name), "uses", false)
+	}
+	for _, agentConfig := range agentConfigs {
+		add(source, consoleReferenceFor("agentconfigs", agentConfig.Name), "uses", false)
+	}
+}
+
+func consoleOwnerRelationship(object client.Object, target consoleResourceReference, ownerKind, relationship string, add func(consoleResourceReference, consoleResourceReference, string, bool)) bool {
+	definition, ok := consoleResourceDefinitionForKind(ownerKind)
+	if !ok {
+		return false
+	}
+	for _, owner := range object.GetOwnerReferences() {
+		if owner.Kind == ownerKind {
+			add(consoleReference(definition, owner.Name), target, relationship, false)
+			return true
+		}
+	}
+	return false
 }
 
 func consoleResourceCondition(content map[string]any) string {
@@ -771,6 +945,15 @@ func tailWorkerTaskLogSegment(reader io.Reader, taskName string, maxLines, maxBy
 func consoleResourceDefinitionFor(resource string) (consoleResourceDefinition, bool) {
 	for _, definition := range consoleResourceDefinitions {
 		if definition.Resource == resource {
+			return definition, true
+		}
+	}
+	return consoleResourceDefinition{}, false
+}
+
+func consoleResourceDefinitionForKind(kind string) (consoleResourceDefinition, bool) {
+	for _, definition := range consoleResourceDefinitions {
+		if definition.Kind == kind {
 			return definition, true
 		}
 	}

--- a/internal/consoleserver/server_test.go
+++ b/internal/consoleserver/server_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
@@ -125,6 +126,12 @@ func TestConsoleApplicationIncludesResourceViews(t *testing.T) {
 		`id="console-resources"`,
 		`id="overview-view"`,
 		`id="resources-view"`,
+		`id="resource-diagram-tab"`,
+		`id="resource-diagram"`,
+		`id="resource-relationship-focus"`,
+		`id="resource-inventory-panel"`,
+		`id="resource-type-list"`,
+		`id="resource-search"`,
 		`id="resource-detail-dialog"`,
 		`id="resource-detail-logs-tab"`,
 		`id="refresh-resource-logs"`,
@@ -141,6 +148,7 @@ func TestConsoleApplicationIncludesResourceViews(t *testing.T) {
 	for _, expected := range []string{
 		"async function loadResources",
 		"function renderOverview",
+		"function renderResourceDiagram",
 		"function renderResources",
 		"function setResourceDetailView",
 		"function handleResourceDetailTabKeydown",
@@ -158,7 +166,7 @@ func TestConsoleApplicationIncludesResourceViews(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, expected := range []string{".resource-summary-grid", ".resource-summary-card", ".resource-table", ".resource-detail-dialog", ".resource-detail-tabs[hidden]"} {
+	for _, expected := range []string{".resource-summary-grid", ".resource-summary-card", ".resource-diagram", ".resource-relationship-node", ".resource-browser", ".resource-type-list", ".resource-table", ".resource-detail-dialog", ".resource-detail-tabs[hidden]"} {
 		if !strings.Contains(string(styles), expected) {
 			t.Errorf("Console styles do not contain %q", expected)
 		}
@@ -231,6 +239,140 @@ func TestConsoleResourcesListAndGet(t *testing.T) {
 		if !strings.Contains(detail.YAML, expected) {
 			t.Errorf("resource detail YAML does not contain %q:\n%s", expected, detail.YAML)
 		}
+	}
+}
+
+func TestConsoleResourceRelationships(t *testing.T) {
+	server := testServer(t)
+	controller := true
+	objects := []client.Object{
+		&kelos.TaskSpawner{
+			ObjectMeta: metav1.ObjectMeta{Name: "issues", Namespace: "team-a", UID: "spawner-uid"},
+			Spec: kelos.TaskSpawnerSpec{TaskTemplate: kelos.TaskTemplate{
+				WorkerPoolRef: &kelos.WorkerPoolReference{Name: "pool"},
+			}},
+		},
+		&kelos.TaskSpawner{
+			ObjectMeta: metav1.ObjectMeta{Name: "automation", Namespace: "team-a"},
+			Spec: kelos.TaskSpawnerSpec{TaskTemplate: kelos.TaskTemplate{
+				WorkspaceRef:    &kelos.WorkspaceReference{Name: "repository"},
+				AgentConfigRefs: []kelos.AgentConfigReference{{Name: "reviewer"}},
+				DependsOn:       []string{"prerequisite"},
+			}},
+		},
+		&kelos.SessionSpawner{ObjectMeta: metav1.ObjectMeta{Name: "webhook", Namespace: "team-a"}},
+		&kelos.Workspace{ObjectMeta: metav1.ObjectMeta{Name: "repository", Namespace: "team-a"}},
+		&kelos.AgentConfig{ObjectMeta: metav1.ObjectMeta{Name: "reviewer", Namespace: "team-a"}},
+		&kelos.WorkerPool{
+			ObjectMeta: metav1.ObjectMeta{Name: "pool", Namespace: "team-a"},
+			Spec: kelos.WorkerPoolSpec{Worker: kelos.WorkerSpec{
+				WorkspaceRef:    &kelos.WorkspaceReference{Name: "repository"},
+				AgentConfigRefs: []kelos.AgentConfigReference{{Name: "reviewer"}},
+			}},
+		},
+		&kelos.Task{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "fix-console",
+				Namespace: "team-a",
+				Labels:    map[string]string{"team": "console"},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: kelos.GroupVersion.String(),
+					Kind:       "TaskSpawner",
+					Name:       "issues",
+					UID:        "spawner-uid",
+					Controller: &controller,
+				}},
+			},
+			Spec: kelos.TaskSpec{WorkerPoolRef: &kelos.WorkerPoolReference{Name: "pool"}},
+		},
+		&kelos.Task{ObjectMeta: metav1.ObjectMeta{Name: "prerequisite", Namespace: "team-a"}},
+		&kelos.Task{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "legacy-task",
+				Namespace: "team-a",
+				Labels:    map[string]string{"kelos.dev/taskspawner": "issues"},
+			},
+			Spec: kelos.TaskSpec{
+				WorkspaceRef:    &kelos.WorkspaceReference{Name: "repository"},
+				AgentConfigRefs: []kelos.AgentConfigReference{{Name: "reviewer"}},
+				DependsOn:       []string{"prerequisite"},
+			},
+		},
+		&kelos.Task{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "manual-task",
+				Namespace:   "team-a",
+				Annotations: map[string]string{"kelos.dev/created-from-taskspawner": "issues"},
+			},
+		},
+		&kelos.Session{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "console-session",
+				Namespace:   "team-a",
+				Annotations: map[string]string{"kelos.dev/sessionspawner-name": "webhook"},
+			},
+			Spec: kelos.SessionSpec{Worker: kelos.WorkerSpec{
+				WorkspaceRef:    &kelos.WorkspaceReference{Name: "repository"},
+				AgentConfigRefs: []kelos.AgentConfigReference{{Name: "reviewer"}},
+			}},
+		},
+		&kelos.TaskRecord{
+			ObjectMeta: metav1.ObjectMeta{Name: "fix-console-record", Namespace: "team-a", Labels: map[string]string{"team": "console"}},
+			Spec:       kelos.TaskRecordSpec{TaskRef: kelos.TaskReference{Name: "fix-console"}},
+		},
+		&kelos.TaskBudget{
+			ObjectMeta: metav1.ObjectMeta{Name: "console-budget", Namespace: "team-a"},
+			Spec:       kelos.TaskBudgetSpec{TaskSelector: metav1.LabelSelector{MatchLabels: map[string]string{"team": "console"}}},
+		},
+	}
+	for _, object := range objects {
+		if err := server.client.Create(t.Context(), object); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	request := httptest.NewRequest(http.MethodGet, "/api/resources?namespace=team-a", nil)
+	request.Header.Set("Authorization", "Bearer secret-token")
+	response := httptest.NewRecorder()
+	server.ServeHTTP(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("resource inventory status = %d body = %s", response.Code, response.Body.String())
+	}
+	var inventory struct {
+		Relationships []consoleResourceRelationship `json:"relationships"`
+	}
+	if err := json.Unmarshal(response.Body.Bytes(), &inventory); err != nil {
+		t.Fatal(err)
+	}
+
+	actual := make(map[string]bool, len(inventory.Relationships))
+	for _, relationship := range inventory.Relationships {
+		key := fmt.Sprintf("%s/%s %s %s/%s", relationship.Source.Resource, relationship.Source.Name, relationship.Relationship, relationship.Target.Resource, relationship.Target.Name)
+		actual[key] = relationship.Inferred
+	}
+	expected := map[string]bool{
+		"taskspawners/automation spawned Tasks depend on tasks/prerequisite":     false,
+		"taskspawners/automation uses agentconfigs/reviewer":                     false,
+		"taskspawners/automation uses workspaces/repository":                     false,
+		"taskspawners/issues creates tasks/fix-console":                          false,
+		"taskspawners/issues creates tasks/legacy-task":                          true,
+		"taskspawners/issues runs Tasks on workerpools/pool":                     false,
+		"tasks/fix-console runs on workerpools/pool":                             false,
+		"tasks/legacy-task depends on tasks/prerequisite":                        false,
+		"tasks/legacy-task uses agentconfigs/reviewer":                           false,
+		"tasks/legacy-task uses workspaces/repository":                           false,
+		"workerpools/pool uses workspaces/repository":                            false,
+		"workerpools/pool uses agentconfigs/reviewer":                            false,
+		"sessions/console-session uses workspaces/repository":                    false,
+		"sessions/console-session uses agentconfigs/reviewer":                    false,
+		"sessionspawners/webhook creates sessions/console-session":               false,
+		"tasks/fix-console recorded as taskrecords/fix-console-record":           false,
+		"taskbudgets/console-budget limits tasks/fix-console":                    true,
+		"taskbudgets/console-budget accounts for taskrecords/fix-console-record": true,
+		"taskspawners/issues creates tasks/manual-task":                          false,
+	}
+	if !maps.Equal(actual, expected) {
+		t.Fatalf("resource relationships = %#v, want %#v", actual, expected)
 	}
 }
 

--- a/internal/consoleserver/testdata/console_resources_test.js
+++ b/internal/consoleserver/testdata/console_resources_test.js
@@ -13,8 +13,96 @@ function applicationSlice(start, end) {
   return application.slice(startIndex, endIndex);
 }
 
+vm.runInThisContext(applicationSlice('const allResourceKind', 'async function loadResources'), {filename: 'app.js'});
 vm.runInThisContext(applicationSlice('async function refreshConsole', 'async function openResourceDetail'), {filename: 'app.js'});
 vm.runInThisContext(applicationSlice('function setResourceDetailView', 'function sessionKey'), {filename: 'app.js'});
+
+function testResourceInventorySupportsAllTypesAndSearch() {
+  const collections = [
+    {resource: 'tasks', kind: 'Task', label: 'Tasks', items: [
+      {name: 'fix-console', phase: 'Running', message: 'Agent is working', createdAt: '2026-08-22T12:00:00Z'},
+    ]},
+    {resource: 'workspaces', kind: 'Workspace', label: 'Workspaces', items: [
+      {name: 'kelos', createdAt: '2026-08-21T12:00:00Z'},
+    ]},
+  ];
+
+  const allEntries = resourceEntries(collections, allResourceKind);
+  assert.equal(allEntries.length, 2);
+  assert.equal(allEntries[0].item.name, 'fix-console');
+  assert.deepEqual(resourceEntries(collections, 'tasks'), [
+    {collection: collections[0], item: collections[0].items[0]},
+  ]);
+  assert.deepEqual(filterResourceEntries(allEntries, 'WORKING'), [allEntries[0]]);
+  assert.deepEqual(filterResourceEntries(allEntries, 'workspace'), [allEntries[1]]);
+  assert.deepEqual(filterResourceEntries(allEntries, 'missing'), []);
+}
+
+function testResourceRelationshipHelpersResolveExistingAndMissingResources() {
+  const task = {name: 'fix-console', namespace: 'default', phase: 'Running'};
+  const collection = {resource: 'tasks', kind: 'Task', label: 'Tasks', items: [task]};
+  global.state = {
+    namespace: 'default',
+    resourceGroups: [{name: 'Workloads', resources: [collection]}],
+  };
+
+  assert.equal(resourceReferenceKey({resource: 'tasks', name: 'fix-console'}), 'tasks/fix-console');
+  assert.deepEqual(resourceEntryForReference({resource: 'tasks', kind: 'Task', name: 'fix-console'}), {collection: {...collection, group: 'Workloads'}, item: task});
+  assert.deepEqual(resourceEntryForReference({resource: 'workspaces', kind: 'Workspace', name: 'missing'}), {
+    collection: {resource: 'workspaces', kind: 'Workspace', label: 'Workspace'},
+    item: {name: 'missing', namespace: 'default', phase: 'Missing', missing: true},
+  });
+
+  const creates = {
+    source: {resource: 'taskspawners', name: 'issues'},
+    target: {resource: 'tasks', name: 'fix-console'},
+    relationship: 'creates',
+  };
+  const uses = {
+    source: {resource: 'tasks', name: 'fix-console'},
+    target: {resource: 'workspaces', name: 'repository'},
+    relationship: 'uses',
+  };
+  assert.deepEqual(resourceRelationshipsForFocus([creates, uses], 'tasks/fix-console'), {
+    incoming: [creates],
+    outgoing: [uses],
+  });
+}
+
+function testResourceViewTabsSupportKeyboardNavigation() {
+  let focused = false;
+  let prevented = false;
+  const diagramTab = {
+    setAttribute(name, value) { this[name] = value; },
+    click() { setResourceView('diagram'); },
+    focus() { focused = true; },
+  };
+  const inventoryTab = {
+    setAttribute(name, value) { this[name] = value; },
+    click() { setResourceView('inventory'); },
+    focus() {},
+  };
+  global.elements = {
+    resourceDiagramTab: diagramTab,
+    resourceInventoryTab: inventoryTab,
+    resourceDiagramPanel: {hidden: false},
+    resourceInventoryPanel: {hidden: true},
+  };
+
+  setResourceView('inventory');
+  assert.equal(elements.resourceDiagramPanel.hidden, true);
+  assert.equal(elements.resourceInventoryPanel.hidden, false);
+  assert.equal(inventoryTab['aria-selected'], 'true');
+
+  handleResourceViewTabKeydown({
+    target: inventoryTab,
+    key: 'ArrowLeft',
+    preventDefault() { prevented = true; },
+  });
+  assert.equal(elements.resourceDiagramPanel.hidden, false);
+  assert.equal(focused, true);
+  assert.equal(prevented, true);
+}
 
 function deferred() {
   let resolve;
@@ -122,6 +210,9 @@ function testResourceDetailTabsSupportKeyboardNavigation() {
   assert.equal(prevented, true);
 }
 
+testResourceInventorySupportsAllTypesAndSearch();
+testResourceRelationshipHelpersResolveExistingAndMissingResources();
+testResourceViewTabsSupportKeyboardNavigation();
 testResourceDetailsIgnoreStaleResponses()
   .then(() => testRefreshReportsOptionFailures())
   .then(() => testResourceDetailTabsSupportKeyboardNavigation())

--- a/internal/consoleserver/web/app.js
+++ b/internal/consoleserver/web/app.js
@@ -23,7 +23,19 @@ const elements = {
   sessionSidebar: document.querySelector('#session-sidebar'),
   summaryGrid: document.querySelector('#resource-summary-grid'),
   recentResources: document.querySelector('#recent-resources'),
+  resourceDiagramTab: document.querySelector('#resource-diagram-tab'),
+  resourceInventoryTab: document.querySelector('#resource-inventory-tab'),
+  resourceDiagramPanel: document.querySelector('#resource-diagram-panel'),
+  resourceInventoryPanel: document.querySelector('#resource-inventory-panel'),
+  resourceDiagram: document.querySelector('#resource-diagram'),
+  resourceRelationshipFocus: document.querySelector('#resource-relationship-focus'),
   resourceKind: document.querySelector('#resource-kind'),
+  resourceTypeList: document.querySelector('#resource-type-list'),
+  resourceTotalCount: document.querySelector('#resource-total-count'),
+  resourceListTitle: document.querySelector('#resource-list-title'),
+  resourceListCount: document.querySelector('#resource-list-count'),
+  resourceListSummary: document.querySelector('#resource-list-summary'),
+  resourceSearch: document.querySelector('#resource-search'),
   resourceList: document.querySelector('#resource-list'),
   resourceDetailDialog: document.querySelector('#resource-detail-dialog'),
   resourceDetailTitle: document.querySelector('#resource-detail-title'),
@@ -157,6 +169,7 @@ const state = {
   resumingSession: false,
   consoleView: 'overview',
   resourceGroups: [],
+  resourceRelationships: [],
   resourceListGeneration: 0,
   resourceDetailGeneration: 0,
   resourceDetailLogGeneration: 0,
@@ -222,6 +235,18 @@ function showToast(message) {
   showToast.timer = window.setTimeout(() => elements.toast.classList.remove('show'), 3200);
 }
 
+const allResourceKind = '__all__';
+const resourceDescriptions = {
+  sessions: 'Long-lived, interactive agent conversations.',
+  tasks: 'Finite units of agent work and their current state.',
+  taskrecords: 'Task lifecycle and usage records.',
+  taskspawners: 'Automation that creates Tasks from schedules and events.',
+  sessionspawners: 'Automation that creates Sessions from events.',
+  workerpools: 'Reusable execution capacity for Tasks.',
+  taskbudgets: 'Limits and usage for Task execution.',
+  workspaces: 'Repository sources and workspace setup.',
+  agentconfigs: 'Shared agent instructions and integrations.',
+};
 function resourceCollections() {
   return state.resourceGroups.flatMap(group => group.resources.map(resource => ({...resource, group: group.name})));
 }
@@ -252,11 +277,11 @@ function resourceStatus(item) {
   return item.phase || 'Configured';
 }
 
-function createResourceTable(entries) {
+function createResourceTable(entries, emptyMessage = `No resources in ${state.namespace}.`) {
   if (!entries.length) {
     const empty = document.createElement('div');
     empty.className = 'resource-empty';
-    empty.textContent = `No resources in ${state.namespace}.`;
+    empty.textContent = emptyMessage;
     return empty;
   }
   const table = document.createElement('table');
@@ -273,29 +298,42 @@ function createResourceTable(entries) {
   const body = document.createElement('tbody');
   for (const {collection, item} of entries) {
     const row = document.createElement('tr');
-    const cell = document.createElement('td');
-    cell.colSpan = 4;
+    if (item.message) row.title = item.message;
+
+    const nameCell = document.createElement('td');
+    nameCell.dataset.label = 'Name';
     const button = document.createElement('button');
-    button.className = 'resource-row-button';
+    button.className = 'resource-name-button';
     button.type = 'button';
-    button.title = item.message || `Inspect ${collection.kind} ${item.namespace}/${item.name}`;
-    const name = document.createElement('span');
-    name.className = 'resource-row-name';
-    name.textContent = item.name;
-    const kind = document.createElement('span');
-    kind.className = 'resource-row-kind';
-    kind.textContent = collection.kind;
+    button.textContent = item.name;
+    button.setAttribute('aria-label', `Inspect ${collection.kind} ${item.namespace}/${item.name}`);
+    button.addEventListener('click', () => openResourceDetail(collection, item));
+    nameCell.append(button);
+    if (item.message) {
+      const message = document.createElement('div');
+      message.className = 'resource-row-message';
+      message.textContent = item.message;
+      nameCell.append(message);
+    }
+
+    const kindCell = document.createElement('td');
+    kindCell.className = 'resource-row-kind';
+    kindCell.dataset.label = 'Kind';
+    kindCell.textContent = collection.kind;
+
+    const statusCell = document.createElement('td');
+    statusCell.dataset.label = 'Status';
     const phase = document.createElement('span');
     phase.className = 'resource-row-phase';
     phase.dataset.state = resourceStatus(item).toLowerCase();
     phase.textContent = resourceStatus(item);
-    const age = document.createElement('span');
-    age.className = 'resource-row-age';
-    age.textContent = resourceAge(item.createdAt);
-    button.append(name, kind, phase, age);
-    button.addEventListener('click', () => openResourceDetail(collection, item));
-    cell.append(button);
-    row.append(cell);
+    statusCell.append(phase);
+
+    const ageCell = document.createElement('td');
+    ageCell.className = 'resource-row-age';
+    ageCell.dataset.label = 'Created';
+    ageCell.textContent = resourceAge(item.createdAt);
+    row.append(nameCell, kindCell, statusCell, ageCell);
     body.append(row);
   }
   table.append(head, body);
@@ -315,9 +353,8 @@ function renderOverview() {
     count.textContent = String(collection.items.length);
     card.append(label, count);
     card.addEventListener('click', () => {
-      elements.resourceKind.value = collection.resource;
-      renderResources();
       setConsoleView('resources');
+      openResourceInventory(collection.resource);
     });
     elements.summaryGrid.append(card);
   }
@@ -337,6 +374,12 @@ function renderOverview() {
 function renderResourceKindOptions() {
   const selected = elements.resourceKind.value;
   elements.resourceKind.replaceChildren();
+  const collections = resourceCollections();
+  const total = collections.reduce((count, collection) => count + collection.items.length, 0);
+  const allOption = document.createElement('option');
+  allOption.value = allResourceKind;
+  allOption.textContent = `All resources (${total})`;
+  elements.resourceKind.append(allOption);
   for (const group of state.resourceGroups) {
     const optionGroup = document.createElement('optgroup');
     optionGroup.label = group.name;
@@ -348,16 +391,301 @@ function renderResourceKindOptions() {
     }
     elements.resourceKind.append(optionGroup);
   }
+  if (selected === allResourceKind || collections.some(collection => collection.resource === selected)) {
+    elements.resourceKind.value = selected;
+  } else {
+    elements.resourceKind.value = allResourceKind;
+  }
+  renderResourceTypeNavigation();
+  renderResourceRelationshipFocusOptions();
+  renderResourceDiagram();
+}
+
+function setResourceView(view) {
+  const showDiagram = view !== 'inventory';
+  elements.resourceDiagramPanel.hidden = !showDiagram;
+  elements.resourceInventoryPanel.hidden = showDiagram;
+  elements.resourceDiagramTab.setAttribute('aria-selected', String(showDiagram));
+  elements.resourceDiagramTab.tabIndex = showDiagram ? 0 : -1;
+  elements.resourceInventoryTab.setAttribute('aria-selected', String(!showDiagram));
+  elements.resourceInventoryTab.tabIndex = showDiagram ? -1 : 0;
+}
+
+function handleResourceViewTabKeydown(event) {
+  const tabs = [elements.resourceDiagramTab, elements.resourceInventoryTab];
+  const current = tabs.indexOf(event.target);
+  if (current < 0) return;
+  let target;
+  if (event.key === 'ArrowLeft') target = tabs[(current - 1 + tabs.length) % tabs.length];
+  if (event.key === 'ArrowRight') target = tabs[(current + 1) % tabs.length];
+  if (event.key === 'Home') target = tabs[0];
+  if (event.key === 'End') target = tabs[tabs.length - 1];
+  if (!target) return;
+  event.preventDefault();
+  target.click();
+  target.focus();
+}
+
+function openResourceInventory(resource) {
+  selectResourceKind(resource);
+  setResourceView('inventory');
+}
+
+function resourceReferenceKey(reference) {
+  return `${reference.resource}/${reference.name}`;
+}
+
+function resourceEntryForReference(reference) {
+  const collection = resourceCollections().find(item => item.resource === reference.resource);
+  const item = collection?.items.find(candidate => candidate.name === reference.name);
+  if (collection && item) return {collection, item};
+  return {
+    collection: {resource: reference.resource, kind: reference.kind || reference.resource, label: reference.kind || reference.resource},
+    item: {name: reference.name, namespace: state.namespace, phase: 'Missing', missing: true},
+  };
+}
+
+function renderResourceRelationshipFocusOptions() {
+  const selected = elements.resourceRelationshipFocus.value;
+  elements.resourceRelationshipFocus.replaceChildren();
+  for (const group of state.resourceGroups) {
+    const optionGroup = document.createElement('optgroup');
+    optionGroup.label = group.name;
+    for (const collection of group.resources) {
+      for (const item of collection.items) {
+        const option = document.createElement('option');
+        option.value = resourceReferenceKey({resource: collection.resource, name: item.name});
+        option.textContent = `${collection.kind}/${item.name}`;
+        optionGroup.append(option);
+      }
+    }
+    if (optionGroup.children.length) elements.resourceRelationshipFocus.append(optionGroup);
+  }
+  const options = Array.from(elements.resourceRelationshipFocus.options);
+  if (options.some(option => option.value === selected)) {
+    elements.resourceRelationshipFocus.value = selected;
+  } else {
+    const related = new Set(state.resourceRelationships.flatMap(relationship => [
+      resourceReferenceKey(relationship.source),
+      resourceReferenceKey(relationship.target),
+    ]));
+    elements.resourceRelationshipFocus.value = options.find(option => related.has(option.value))?.value || options[0]?.value || '';
+  }
+  elements.resourceRelationshipFocus.disabled = !options.length;
+}
+
+function focusResource(reference) {
+  const key = resourceReferenceKey(reference);
+  if (!Array.from(elements.resourceRelationshipFocus.options).some(option => option.value === key)) return;
+  elements.resourceRelationshipFocus.value = key;
+  renderResourceDiagram();
+}
+
+function createResourceRelationshipNode(reference, selected = false) {
+  const {collection, item} = resourceEntryForReference(reference);
+  const node = document.createElement('button');
+  node.className = 'resource-relationship-node';
+  node.type = 'button';
+  node.dataset.resource = collection.resource;
+  if (selected) node.dataset.selected = 'true';
+  const heading = document.createElement('span');
+  heading.className = 'resource-relationship-node-heading';
+  const kind = document.createElement('span');
+  kind.textContent = collection.kind;
+  const status = document.createElement('span');
+  status.dataset.state = resourceStatus(item).toLowerCase();
+  status.textContent = resourceStatus(item);
+  heading.append(kind, status);
+  const name = document.createElement('strong');
+  name.textContent = item.name;
+  node.append(heading, name);
+  if (item.message) {
+    const message = document.createElement('span');
+    message.className = 'resource-relationship-node-message';
+    message.textContent = item.message;
+    node.append(message);
+  }
+  if (item.missing) {
+    node.disabled = true;
+    node.title = `${collection.kind} ${item.name} was not found in ${state.namespace}`;
+  } else if (selected) {
+    node.title = `Inspect ${collection.kind} ${item.name}`;
+    node.addEventListener('click', () => openResourceDetail(collection, item));
+  } else {
+    node.title = `Focus ${collection.kind} ${item.name}`;
+    node.addEventListener('click', () => focusResource(reference));
+  }
+  return node;
+}
+
+function createResourceRelationshipConnector(relationship) {
+  const connector = document.createElement('div');
+  connector.className = 'resource-relationship-connector';
+  connector.dataset.inferred = String(Boolean(relationship.inferred));
+  const label = document.createElement('span');
+  label.textContent = relationship.relationship;
+  const arrow = document.createElement('span');
+  arrow.setAttribute('aria-hidden', 'true');
+  arrow.textContent = '→';
+  connector.append(label, arrow);
+  return connector;
+}
+
+function createResourceRelationshipEdge(relationship, incoming) {
+  const edge = document.createElement('div');
+  edge.className = 'resource-relationship-edge';
+  edge.dataset.direction = incoming ? 'incoming' : 'outgoing';
+  const reference = incoming ? relationship.source : relationship.target;
+  const node = createResourceRelationshipNode(reference);
+  const connector = createResourceRelationshipConnector(relationship);
+  if (incoming) edge.append(node, connector);
+  else edge.append(connector, node);
+  return edge;
+}
+
+function createResourceRelationshipColumn(title, relationships, incoming) {
+  const column = document.createElement('section');
+  column.className = 'resource-relationship-column';
+  const heading = document.createElement('h3');
+  heading.textContent = title;
+  column.append(heading);
+  if (!relationships.length) {
+    const empty = document.createElement('div');
+    empty.className = 'resource-relationship-empty';
+    empty.textContent = incoming ? 'No incoming relationships' : 'No outgoing relationships';
+    column.append(empty);
+    return column;
+  }
+  const edges = document.createElement('div');
+  edges.className = 'resource-relationship-edges';
+  for (const relationship of relationships) edges.append(createResourceRelationshipEdge(relationship, incoming));
+  column.append(edges);
+  return column;
+}
+
+function resourceRelationshipsForFocus(relationships, focusKey) {
+  return {
+    incoming: relationships.filter(relationship => resourceReferenceKey(relationship.target) === focusKey),
+    outgoing: relationships.filter(relationship => resourceReferenceKey(relationship.source) === focusKey),
+  };
+}
+
+function renderResourceDiagram() {
+  const focusKey = elements.resourceRelationshipFocus.value;
+  if (!focusKey) {
+    const empty = document.createElement('div');
+    empty.className = 'resource-empty';
+    empty.textContent = `No resources in ${state.namespace}.`;
+    elements.resourceDiagram.replaceChildren(empty);
+    return;
+  }
+  const {incoming, outgoing} = resourceRelationshipsForFocus(state.resourceRelationships, focusKey);
+  const [resource, name] = focusKey.split('/', 2);
+  const focusEntry = resourceEntryForReference({resource, name});
+  const center = document.createElement('section');
+  center.className = 'resource-relationship-focus-node';
+  const heading = document.createElement('h3');
+  heading.textContent = 'Selected resource';
+  center.append(heading, createResourceRelationshipNode({resource, kind: focusEntry.collection.kind, name}, true));
+
+  const graph = document.createElement('div');
+  graph.className = 'resource-relationship-graph';
+  graph.append(
+    createResourceRelationshipColumn('Related from', incoming, true),
+    center,
+    createResourceRelationshipColumn('Connects to', outgoing, false),
+  );
+  elements.resourceDiagram.replaceChildren(graph);
+}
+
+function createResourceTypeButton(resource, label, count) {
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.dataset.resource = resource;
+  const name = document.createElement('span');
+  name.textContent = label;
+  const badge = document.createElement('span');
+  badge.textContent = String(count);
+  button.append(name, badge);
+  button.addEventListener('click', () => selectResourceKind(resource));
+  return button;
+}
+
+function renderResourceTypeNavigation() {
   const collections = resourceCollections();
-  if (collections.some(collection => collection.resource === selected)) elements.resourceKind.value = selected;
+  const total = collections.reduce((count, collection) => count + collection.items.length, 0);
+  elements.resourceTotalCount.textContent = String(total);
+  elements.resourceTypeList.replaceChildren(createResourceTypeButton(allResourceKind, 'All resources', total));
+
+  for (const group of state.resourceGroups) {
+    const section = document.createElement('section');
+    section.className = 'resource-type-group';
+    const heading = document.createElement('h3');
+    heading.textContent = group.name;
+    section.append(heading);
+    for (const collection of group.resources) {
+      section.append(createResourceTypeButton(collection.resource, collection.label, collection.items.length));
+    }
+    elements.resourceTypeList.append(section);
+  }
+}
+
+function resourceEntries(collections, resource) {
+  const selected = collections.find(collection => collection.resource === resource);
+  const sources = selected ? [selected] : collections;
+  const entries = sources.flatMap(collection => collection.items.map(item => ({collection, item})));
+  if (!selected) {
+    entries.sort((left, right) => {
+      const created = String(right.item.createdAt || '').localeCompare(String(left.item.createdAt || ''));
+      if (created) return created;
+      return `${left.collection.kind}/${left.item.name}`.localeCompare(`${right.collection.kind}/${right.item.name}`);
+    });
+  }
+  return entries;
+}
+
+function filterResourceEntries(entries, query) {
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) return entries;
+  return entries.filter(({collection, item}) => [
+    item.name,
+    collection.kind,
+    collection.label,
+    resourceStatus(item),
+    item.message,
+  ].some(value => String(value || '').toLowerCase().includes(normalized)));
+}
+
+function selectResourceKind(resource) {
+  elements.resourceKind.value = resource;
+  renderResources();
 }
 
 function renderResources() {
   const collections = resourceCollections();
-  const collection = collections.find(item => item.resource === elements.resourceKind.value) || collections[0];
-  if (collection && elements.resourceKind.value !== collection.resource) elements.resourceKind.value = collection.resource;
-  const entries = collection ? collection.items.map(item => ({collection, item})) : [];
-  elements.resourceList.replaceChildren(createResourceTable(entries));
+  let resource = elements.resourceKind.value;
+  let collection = collections.find(item => item.resource === resource);
+  if (resource !== allResourceKind && !collection) {
+    resource = allResourceKind;
+    elements.resourceKind.value = resource;
+  }
+
+  const entries = resourceEntries(collections, resource);
+  const filteredEntries = filterResourceEntries(entries, elements.resourceSearch.value);
+  const query = elements.resourceSearch.value.trim();
+  elements.resourceListTitle.textContent = collection?.label || 'All resources';
+  elements.resourceListCount.textContent = String(entries.length);
+  elements.resourceListSummary.textContent = query
+    ? `${filteredEntries.length} of ${entries.length} resources match “${query}”.`
+    : resourceDescriptions[collection?.resource] || 'Every Kelos object in this namespace.';
+  for (const button of elements.resourceTypeList.querySelectorAll('button')) {
+    if (button.dataset.resource === resource) button.setAttribute('aria-current', 'true');
+    else button.removeAttribute('aria-current');
+  }
+  const emptyMessage = query
+    ? `No resources match “${query}”.`
+    : `No ${collection?.label.toLowerCase() || 'resources'} in ${state.namespace}.`;
+  elements.resourceList.replaceChildren(createResourceTable(filteredEntries, emptyMessage));
 }
 
 async function loadResources({quiet = false} = {}) {
@@ -368,6 +696,7 @@ async function loadResources({quiet = false} = {}) {
     const inventory = await api(`/api/resources?namespace=${encodeURIComponent(namespace)}`);
     if (generation !== state.namespaceGeneration || listGeneration !== state.resourceListGeneration) return;
     state.resourceGroups = inventory.groups || [];
+    state.resourceRelationships = inventory.relationships || [];
     renderResourceKindOptions();
     renderOverview();
     renderResources();
@@ -1588,6 +1917,7 @@ async function switchNamespace(namespace) {
   state.namespaceGeneration += 1;
   state.sessions = [];
   state.resourceGroups = [];
+  state.resourceRelationships = [];
   state.options = {credentials: [], workspaces: [], agentConfigs: [], sessions: []};
   window.localStorage.setItem('kelos-console-namespace', namespace);
   elements.activeNamespace.value = namespace;
@@ -4476,7 +4806,12 @@ function interruptActiveTurn() {
 elements.overviewButton.addEventListener('click', () => setConsoleView('overview'));
 elements.sessionsButton.addEventListener('click', () => setConsoleView('sessions'));
 elements.resourcesButton.addEventListener('click', () => setConsoleView('resources'));
+elements.resourceDiagramTab.addEventListener('click', () => setResourceView('diagram'));
+elements.resourceInventoryTab.addEventListener('click', () => setResourceView('inventory'));
+document.querySelector('.resource-view-tabs').addEventListener('keydown', handleResourceViewTabKeydown);
+elements.resourceRelationshipFocus.addEventListener('change', renderResourceDiagram);
 elements.resourceKind.addEventListener('change', renderResources);
+elements.resourceSearch.addEventListener('input', renderResources);
 document.querySelectorAll('.close-resource-detail').forEach(button => {
   button.addEventListener('click', () => elements.resourceDetailDialog.close());
 });

--- a/internal/consoleserver/web/index.html
+++ b/internal/consoleserver/web/index.html
@@ -79,11 +79,58 @@
         </div>
       </header>
       <section class="console-page-body">
-        <div class="resource-toolbar">
-          <label for="resource-kind">Resource type</label>
-          <select id="resource-kind"></select>
+        <div class="mode-switch resource-view-tabs" role="tablist" aria-label="Resource view">
+          <button id="resource-diagram-tab" type="button" role="tab" aria-selected="true" aria-controls="resource-diagram-panel">Relationships</button>
+          <button id="resource-inventory-tab" type="button" role="tab" aria-selected="false" aria-controls="resource-inventory-panel" tabindex="-1">Inventory</button>
         </div>
-        <div class="resource-table-wrap" id="resource-list" aria-live="polite"></div>
+        <section class="resource-diagram-panel" id="resource-diagram-panel" role="tabpanel" aria-labelledby="resource-diagram-tab">
+          <div class="resource-diagram-heading">
+            <div>
+              <h2>Resource relationships</h2>
+              <p>Follow the resources connected to one object.</p>
+            </div>
+            <label class="resource-relationship-focus" for="resource-relationship-focus">
+              <span>Focus resource</span>
+              <select id="resource-relationship-focus"></select>
+            </label>
+          </div>
+          <div class="resource-diagram" id="resource-diagram" aria-live="polite"></div>
+          <div class="resource-relationship-legend">
+            <span><i></i> Explicit reference</span>
+            <span><i data-inferred="true"></i> Selector or label match</span>
+          </div>
+        </section>
+        <section id="resource-inventory-panel" role="tabpanel" aria-labelledby="resource-inventory-tab" hidden>
+          <label class="resource-mobile-kind" for="resource-kind">
+            <span>Resource type</span>
+            <select id="resource-kind"></select>
+          </label>
+          <div class="resource-browser">
+            <aside class="resource-type-panel" aria-label="Resource types">
+              <div class="resource-type-panel-heading">
+                <span>Resource types</span>
+                <span id="resource-total-count">0</span>
+              </div>
+              <nav class="resource-type-list" id="resource-type-list"></nav>
+            </aside>
+            <section class="resource-inventory" aria-labelledby="resource-list-title">
+              <div class="resource-inventory-heading">
+                <div>
+                  <div class="resource-inventory-title-row">
+                    <h2 id="resource-list-title">All resources</h2>
+                    <span id="resource-list-count">0</span>
+                  </div>
+                  <p id="resource-list-summary">Every Kelos object in this namespace.</p>
+                </div>
+                <label class="resource-search" for="resource-search">
+                  <span>Search resources</span>
+                  <input id="resource-search" type="search" placeholder="Name, kind, or status" autocomplete="off">
+                </label>
+              </div>
+              <div class="resource-table-wrap" id="resource-list" aria-live="polite"></div>
+            </section>
+          </div>
+        </section>
       </section>
     </main>
 

--- a/internal/consoleserver/web/styles.css
+++ b/internal/consoleserver/web/styles.css
@@ -140,23 +140,86 @@ button { color: inherit; }
 .console-section-heading { display: flex; align-items: flex-end; justify-content: space-between; gap: 20px; margin-bottom: 13px; }
 .console-section-heading h2 { margin: 0; font: 600 21px/1.2 Georgia,"Times New Roman",serif; }
 .console-section-heading p { margin: 5px 0 0; color: var(--muted); font-size: 11px; }
-.resource-toolbar { display: flex; align-items: center; gap: 12px; margin-bottom: 15px; }
-.resource-toolbar label { color: var(--muted); font-size: 11px; font-weight: 700; }
-.resource-toolbar select { min-width: 220px; padding: 9px 11px; border: 1px solid var(--line); border-radius: 9px; outline: 0; background: var(--card); color: var(--ink); font-size: 12px; }
+.resource-view-tabs { width: fit-content; margin-bottom: 22px; }
+.resource-diagram-panel[hidden], #resource-inventory-panel[hidden] { display: none; }
+.resource-diagram-heading { display: flex; align-items: flex-end; justify-content: space-between; gap: 18px; margin-bottom: 17px; }
+.resource-diagram-heading h2 { margin: 0; font: 600 21px/1.2 Georgia,"Times New Roman",serif; }
+.resource-diagram-heading p { margin: 5px 0 0; color: var(--muted); font-size: 11px; }
+.resource-relationship-focus { width: min(340px, 42%); display: grid; gap: 5px; color: var(--muted); font-size: 10px; font-weight: 700; }
+.resource-relationship-focus select { width: 100%; min-width: 0; padding: 9px 11px; border: 1px solid var(--line); border-radius: 9px; outline: 0; background: var(--card); color: var(--ink); font-size: 12px; }
+.resource-relationship-focus select:focus { border-color: #779b88; box-shadow: 0 0 0 3px rgba(56,114,88,.08); }
+.resource-diagram { min-width: 0; min-height: 360px; padding: 26px; overflow-x: auto; border: 1px solid var(--line); border-radius: 16px; background-color: var(--card); background-image: radial-gradient(var(--line-soft) .8px, transparent .8px); background-size: 17px 17px; box-shadow: 0 4px 14px rgba(31,46,38,.035); }
+.resource-relationship-graph { min-width: 720px; display: grid; grid-template-columns: minmax(0, 1fr) minmax(180px, .72fr) minmax(0, 1fr); align-items: center; gap: 18px; }
+.resource-relationship-column, .resource-relationship-focus-node { min-width: 0; }
+.resource-relationship-column > h3, .resource-relationship-focus-node > h3 { margin: 0 0 10px; color: var(--faint); font-size: 8.5px; font-weight: 800; letter-spacing: .11em; text-align: center; text-transform: uppercase; }
+.resource-relationship-edges { max-height: 510px; display: grid; gap: 13px; overflow-y: auto; padding: 3px; scrollbar-width: thin; }
+.resource-relationship-edge { min-width: 0; display: grid; align-items: center; }
+.resource-relationship-edge[data-direction="incoming"] { grid-template-columns: minmax(0, 1fr) 78px; }
+.resource-relationship-edge[data-direction="outgoing"] { grid-template-columns: 78px minmax(0, 1fr); }
+.resource-relationship-node { --node-border:#aebbb3; --node-tint:#f2f5f2; width: 100%; min-width: 0; display: grid; gap: 6px; padding: 11px 12px; overflow: hidden; border: 1px solid var(--node-border); border-radius: 12px; background: var(--node-tint); color: var(--ink); text-align: left; box-shadow: 0 5px 15px rgba(31,46,38,.05); cursor: pointer; }
+.resource-relationship-node:hover:not(:disabled) { transform: translateY(-1px); box-shadow: 0 8px 20px rgba(31,46,38,.09); }
+.resource-relationship-node[data-selected="true"] { outline: 3px solid color-mix(in srgb, var(--node-border) 24%, transparent); outline-offset: 3px; }
+.resource-relationship-node:disabled { opacity: .68; cursor: not-allowed; }
+.resource-relationship-node[data-resource="taskspawners"], .resource-relationship-node[data-resource="sessionspawners"] { --node-border:#9d89dc; --node-tint:#f0ecff; }
+.resource-relationship-node[data-resource="tasks"] { --node-border:#d99a3b; --node-tint:#fff5d8; }
+.resource-relationship-node[data-resource="sessions"] { --node-border:#58aeba; --node-tint:#e1f7f8; }
+.resource-relationship-node[data-resource="workspaces"] { --node-border:#709de0; --node-tint:#eaf0ff; }
+.resource-relationship-node[data-resource="agentconfigs"] { --node-border:#67ac72; --node-tint:#e7f7e8; }
+.resource-relationship-node[data-resource="workerpools"], .resource-relationship-node[data-resource="taskbudgets"] { --node-border:#c88e6d; --node-tint:#fff0e8; }
+.resource-relationship-node-heading { min-width: 0; display: flex; align-items: center; justify-content: space-between; gap: 8px; color: var(--muted); font-size: 8.5px; font-weight: 750; }
+.resource-relationship-node-heading span:last-child[data-state="pending"], .resource-relationship-node-heading span:last-child[data-state="waiting"], .resource-relationship-node-heading span:last-child[data-state="running"], .resource-relationship-node-heading span:last-child[data-state="active"] { color: var(--warning); }
+.resource-relationship-node-heading span:last-child[data-state="ready"], .resource-relationship-node-heading span:last-child[data-state="succeeded"] { color: var(--accent-2); }
+.resource-relationship-node-heading span:last-child[data-state="failed"], .resource-relationship-node-heading span:last-child[data-state="missing"] { color: var(--danger); }
+.resource-relationship-node strong { overflow: hidden; font: 600 11px/1.3 ui-monospace,SFMono-Regular,Menlo,monospace; text-overflow: ellipsis; white-space: nowrap; }
+.resource-relationship-node-message { overflow: hidden; color: var(--faint); font-size: 8.5px; text-overflow: ellipsis; white-space: nowrap; }
+.resource-relationship-connector { position: relative; min-width: 0; height: 32px; display: grid; place-items: center; color: var(--accent-2); }
+.resource-relationship-connector::before { position: absolute; right: 4px; left: 4px; border-top: 1px solid currentColor; content: ''; }
+.resource-relationship-connector[data-inferred="true"]::before { border-top-style: dashed; }
+.resource-relationship-connector span:first-child { position: relative; z-index: 1; max-width: 72px; overflow: hidden; padding: 2px 4px; border-radius: 999px; background: var(--card); color: var(--muted); font-size: 7.5px; font-weight: 750; text-overflow: ellipsis; white-space: nowrap; }
+.resource-relationship-connector span:last-child { position: absolute; right: 0; padding-left: 2px; background: var(--card); font: 17px/1 Georgia,"Times New Roman",serif; }
+.resource-relationship-empty { min-height: 80px; display: grid; place-items: center; padding: 12px; border: 1px dashed var(--line); border-radius: 11px; color: var(--faint); font-size: 9px; text-align: center; }
+.resource-relationship-legend { display: flex; justify-content: flex-end; gap: 14px; margin-top: 9px; color: var(--faint); font-size: 8.5px; }
+.resource-relationship-legend span { display: flex; align-items: center; gap: 5px; }
+.resource-relationship-legend i { width: 22px; border-top: 1px solid var(--accent-2); }
+.resource-relationship-legend i[data-inferred="true"] { border-top-style: dashed; }
+.resource-mobile-kind { display: none; }
+.resource-browser { min-height: 0; display: grid; grid-template-columns: 220px minmax(0, 1fr); align-items: start; gap: 18px; }
+.resource-type-panel { overflow: hidden; border: 1px solid var(--line); border-radius: 14px; background: var(--card); box-shadow: 0 4px 14px rgba(31,46,38,.035); }
+.resource-type-panel-heading { display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 13px 14px; border-bottom: 1px solid var(--line); color: var(--faint); font-size: 9px; font-weight: 800; letter-spacing: .1em; text-transform: uppercase; }
+.resource-type-panel-heading span:last-child { min-width: 22px; padding: 3px 6px; border-radius: 999px; background: var(--line-soft); font-size: 8.5px; letter-spacing: 0; text-align: center; }
+.resource-type-list { padding: 7px; }
+.resource-type-list > button, .resource-type-group button { width: 100%; display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 8px 9px; border: 0; border-radius: 8px; background: transparent; color: var(--muted); font-size: 11px; font-weight: 650; text-align: left; cursor: pointer; }
+.resource-type-list button:hover { background: var(--line-soft); color: var(--ink); }
+.resource-type-list button[aria-current="true"] { background: var(--accent-soft); color: var(--accent); }
+.resource-type-list button span:first-child { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.resource-type-list button span:last-child { flex: none; color: var(--faint); font-size: 9.5px; font-variant-numeric: tabular-nums; }
+.resource-type-group { margin-top: 7px; padding-top: 7px; border-top: 1px solid var(--line-soft); }
+.resource-type-group h3 { margin: 0; padding: 5px 9px 3px; color: var(--faint); font-size: 8.5px; font-weight: 800; letter-spacing: .1em; text-transform: uppercase; }
+.resource-inventory { min-width: 0; }
+.resource-inventory-heading { min-height: 58px; display: flex; align-items: flex-end; justify-content: space-between; gap: 18px; margin-bottom: 13px; }
+.resource-inventory-title-row { display: flex; align-items: center; gap: 8px; }
+.resource-inventory-title-row h2 { margin: 0; font: 600 21px/1.2 Georgia,"Times New Roman",serif; }
+.resource-inventory-title-row > span { min-width: 22px; padding: 3px 7px; border-radius: 999px; background: var(--line-soft); color: var(--muted); font-size: 9px; font-weight: 750; text-align: center; }
+.resource-inventory-heading p { margin: 5px 0 0; color: var(--muted); font-size: 11px; }
+.resource-search { width: min(290px, 42%); display: grid; gap: 5px; color: var(--muted); font-size: 10px; font-weight: 700; }
+.resource-search input, .resource-mobile-kind select { width: 100%; min-width: 0; padding: 9px 11px; border: 1px solid var(--line); border-radius: 9px; outline: 0; background: var(--card); color: var(--ink); font-size: 12px; }
+.resource-search input:focus, .resource-mobile-kind select:focus { border-color: #779b88; box-shadow: 0 0 0 3px rgba(56,114,88,.08); }
 .resource-table-wrap { overflow: hidden; border: 1px solid var(--line); border-radius: 14px; background: var(--card); box-shadow: 0 4px 14px rgba(31,46,38,.035); }
 .resource-table { width: 100%; border-collapse: collapse; table-layout: fixed; }
 .resource-table th { padding: 10px 13px; border-bottom: 1px solid var(--line); background: var(--panel); color: var(--faint); font-size: 9px; font-weight: 800; letter-spacing: .1em; text-align: left; text-transform: uppercase; }
-.resource-table th:nth-child(1) { width: 24%; }
-.resource-table th:nth-child(2) { width: 18%; }
-.resource-table th:nth-child(3) { width: 18%; }
-.resource-table td { padding: 0; border-bottom: 1px solid var(--line-soft); }
+.resource-table th:nth-child(1) { width: 40%; }
+.resource-table th:nth-child(2) { width: 21%; }
+.resource-table th:nth-child(3) { width: 21%; }
+.resource-table td { padding: 11px 13px; border-bottom: 1px solid var(--line-soft); vertical-align: middle; }
 .resource-table tr:last-child td { border-bottom: 0; }
-.resource-row-button { width: 100%; display: grid; grid-template-columns: 24% 18% 18% minmax(0, 1fr); align-items: center; padding: 11px 13px; border: 0; background: transparent; color: var(--ink); text-align: left; cursor: pointer; }
-.resource-row-button:hover { background: var(--accent-soft); }
-.resource-row-name { overflow: hidden; font: 600 11.5px/1.4 ui-monospace,SFMono-Regular,Menlo,monospace; text-overflow: ellipsis; white-space: nowrap; }
+.resource-table tbody tr:hover { background: var(--accent-soft); }
+.resource-name-button { max-width: 100%; overflow: hidden; padding: 0; border: 0; background: transparent; color: var(--ink); font: 600 11.5px/1.4 ui-monospace,SFMono-Regular,Menlo,monospace; text-align: left; text-overflow: ellipsis; white-space: nowrap; cursor: pointer; }
+.resource-name-button:hover { color: var(--accent-2); text-decoration: underline; }
+.resource-name-button:focus-visible { border-radius: 3px; outline: 2px solid var(--accent-2); outline-offset: 2px; }
 .resource-row-kind, .resource-row-age, .resource-row-message { overflow: hidden; color: var(--muted); font-size: 10.5px; text-overflow: ellipsis; white-space: nowrap; }
+.resource-row-message { margin-top: 3px; color: var(--faint); font-size: 9.5px; }
 .resource-row-phase { width: fit-content; max-width: calc(100% - 8px); overflow: hidden; padding: 4px 7px; border-radius: 999px; background: var(--line-soft); color: var(--muted); font-size: 9px; font-weight: 750; text-overflow: ellipsis; white-space: nowrap; }
-.resource-row-phase[data-state="running"], .resource-row-phase[data-state="active"], .resource-row-phase[data-state="scaling"] { background: #f6ead9; color: var(--warning); }
+.resource-row-phase[data-state="pending"], .resource-row-phase[data-state="waiting"], .resource-row-phase[data-state="running"], .resource-row-phase[data-state="active"], .resource-row-phase[data-state="scaling"] { background: #f6ead9; color: var(--warning); }
 .resource-row-phase[data-state="ready"], .resource-row-phase[data-state="succeeded"] { background: var(--accent-soft); color: var(--accent-2); }
 .resource-row-phase[data-state="failed"] { background: #f8e8e8; color: var(--danger); }
 .resource-empty { min-height: 210px; display: grid; place-items: center; padding: 28px; color: var(--muted); font-size: 12px; text-align: center; }
@@ -467,10 +530,31 @@ button { color: inherit; }
   .console-page-header h1 { font-size: 24px; }
   .console-page-body { padding: 20px calc(14px + env(safe-area-inset-right)) 32px calc(14px + env(safe-area-inset-left)); overscroll-behavior: contain; }
   .resource-summary-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-  .resource-toolbar { align-items: stretch; flex-direction: column; gap: 6px; }
-  .resource-toolbar select { width: 100%; min-width: 0; font-size: 16px; }
-  .resource-table-wrap { overflow-x: auto; }
-  .resource-table { min-width: 680px; }
+  .resource-view-tabs { width: 100%; }
+  .resource-view-tabs button { flex: 1; min-height: 44px; }
+  .resource-diagram-heading { align-items: flex-start; flex-direction: column; gap: 8px; }
+  .resource-relationship-focus { width: 100%; }
+  .resource-relationship-focus select { font-size: 16px; }
+  .resource-diagram { min-height: 0; padding: 14px; background-size: 15px 15px; }
+  .resource-relationship-graph { min-width: 0; display: flex; flex-direction: column; gap: 20px; }
+  .resource-relationship-column, .resource-relationship-focus-node { width: 100%; }
+  .resource-relationship-focus-node { order: -1; }
+  .resource-relationship-edges { max-height: none; }
+  .resource-relationship-legend { justify-content: flex-start; flex-wrap: wrap; }
+  .resource-mobile-kind { display: grid; gap: 6px; margin-bottom: 18px; color: var(--muted); font-size: 11px; font-weight: 700; }
+  .resource-mobile-kind select, .resource-search input { font-size: 16px; }
+  .resource-browser { display: block; }
+  .resource-type-panel { display: none; }
+  .resource-inventory-heading { align-items: stretch; flex-direction: column; gap: 13px; }
+  .resource-search { width: 100%; }
+  .resource-table { table-layout: auto; }
+  .resource-table thead { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; }
+  .resource-table, .resource-table tbody, .resource-table tr, .resource-table td { display: block; width: 100%; }
+  .resource-table tr { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 10px 12px; padding: 13px; border-bottom: 1px solid var(--line-soft); }
+  .resource-table tr:last-child { border-bottom: 0; }
+  .resource-table td { min-width: 0; display: grid; align-content: start; gap: 5px; padding: 0; border: 0; }
+  .resource-table td:first-child { grid-column: 1 / -1; }
+  .resource-table td:not(:first-child)::before { color: var(--faint); font-size: 8px; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; content: attr(data-label); }
   .session-item-actions { top: 5px; right: 1px; width: 44px; height: 44px; }
   .session-actions-menu button { min-height: 44px; font-size: 14px; }
   .conversation { height: 100%; height: 100dvh; }
@@ -516,7 +600,13 @@ button { color: inherit; }
   .goal-card { background: #1e2923; }
   .diff-lines { background: #121915; }
   .icon-button.danger:not(:disabled):hover { background: #2d1e1e; }
-  .resource-row-phase[data-state="running"], .resource-row-phase[data-state="active"], .resource-row-phase[data-state="scaling"] { background: #392d1d; }
+  .resource-relationship-node[data-resource="taskspawners"], .resource-relationship-node[data-resource="sessionspawners"] { --node-border:#7564ad; --node-tint:#28223a; }
+  .resource-relationship-node[data-resource="tasks"] { --node-border:#89662e; --node-tint:#342b19; }
+  .resource-relationship-node[data-resource="sessions"] { --node-border:#3d7880; --node-tint:#192f31; }
+  .resource-relationship-node[data-resource="workspaces"] { --node-border:#526f9b; --node-tint:#1d293b; }
+  .resource-relationship-node[data-resource="agentconfigs"] { --node-border:#477c50; --node-tint:#1d3021; }
+  .resource-relationship-node[data-resource="workerpools"], .resource-relationship-node[data-resource="taskbudgets"] { --node-border:#865e48; --node-tint:#34251d; }
+  .resource-row-phase[data-state="pending"], .resource-row-phase[data-state="waiting"], .resource-row-phase[data-state="running"], .resource-row-phase[data-state="active"], .resource-row-phase[data-state="scaling"] { background: #392d1d; }
   .resource-row-phase[data-state="failed"] { background: #3a2020; }
   .welcome-orbit { background: linear-gradient(145deg,#26312b,#18201c); border-color:#38483f; }
   .form-grid input, .form-grid select, .form-grid textarea, .source-picker select, .section-field input, .session-section-control input, .session-section-control select { border-color: #3a4740; }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

- adds a focused resource relationship explorer to the Kelos Console, showing incoming and outgoing links for a selected object
- derives links from worker references, dependencies, owner references, origin metadata, TaskRecord references, and TaskBudget selectors
- distinguishes explicit references from selector and legacy-label matches, and keeps missing referenced resources visible
- retains a responsive, searchable inventory grouped by resource category for full namespace inspection
- documents the Resources page behavior

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Validation:

- `make verify`
- `make build WHAT=cmd/kelos-console-server`
- `make test TEST_FLAGS='-run=Test.*Console.*Resource'`
- `node internal/consoleserver/testdata/console_resources_test.js`

`make test` passes the console packages but encounters two unrelated environment-sensitive failures in `internal/controller`: `TestCodexEntrypointUsesPersistentSessionHome` observes the session's configured `cli_auth_credentials_store`, and the Codex case in `TestAgentEntrypointsPreserveSkillReferenceFiles` references a skill path absent from its temporary home. This PR does not modify controller entrypoint code or fixtures.

#### Does this PR introduce a user-facing change?

```release-note
The Kelos Console Resources page now visualizes the incoming and outgoing relationships of each resource and includes a grouped, searchable inventory.
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Visualizes incoming and outgoing resource relationships in the Console and adds a searchable, grouped Resources inventory. Previously the Resources page only listed objects; now it also shows how one object connects to others, including inferred links and missing references, to speed debugging and impact analysis.

- Backend/API: `/api/resources` now includes a `relationships` array derived from worker references (Workspace, AgentConfig, WorkerPool), Task `dependsOn`, owner references and origin annotations for Task/Session creators, TaskRecord `TaskRef`, and TaskBudget selector matches to Tasks and TaskRecords; `inferred: true` marks selector/label-based links. Change is additive; existing consumers continue to work.
- UI: Adds Relationships/Inventory tabs with keyboard navigation (Arrow/Home/End). Relationships view provides a focus selector, clickable nodes to focus or inspect, and a legend for explicit vs inferred links; missing targets render as disabled “Missing” nodes. Inventory gains an “All resources” view, grouped type navigation with counts, search across name/kind/status/message, clearer status/messages in the table, and responsive mobile layout.
- Tests/docs: Extends `internal/consoleserver` server and web tests for relationships, search, and tab behavior; updates `docs/reference.md` to describe the new Resources behavior.

<sup>Written for commit 7715bf0168bf98f688aa3d3d7d136c75f0bb6c5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

