### PR TITLE
Align Open Actions agents with GitHub Actions compatibility

### DIFF
--- a/self-development/open-actions/README.md
+++ b/self-development/open-actions/README.md
@@ -3,8 +3,11 @@
 This directory contains the orchestration patterns that drive autonomous
 development of [`kelos-dev/open-actions`](https://github.com/kelos-dev/open-actions)
 — a Kubernetes-native, self-hosted control plane that plans, schedules, and
-executes a supported subset of GitHub Actions workflows in the team's own
-cluster.
+executes GitHub Actions workflows in the team's own cluster. Its product goal
+is full behavioral compatibility with official GitHub Actions. The current
+[GitHub Actions documentation](https://docs.github.com/actions) defines the
+expected workflow syntax and behavior; missing or different documented
+behavior is a compatibility gap.
 
 It mirrors [`self-development/`](../), which does the same for this repository
 (`kelos-dev/kelos`). The configs live here, in the kelos repository, but the
@@ -44,15 +47,15 @@ meta-maintenance spawners (`open-actions-config-update`,
 | Spawner | Trigger | Agent | Description |
 |---|---|---|---|
 | **open-actions-workers** | Webhook: issue comment `/kelos pick-up` | Codex | Creates a durable Session with the open issue URL and a dedicated issue branch |
-| **open-actions-planner** | Webhook: issue comment `/kelos plan` | Codex | Investigates an issue and posts a structured implementation plan — advisory only, no code changes |
-| **open-actions-reviewer** | Webhook: PR comment or review `/kelos review` | Codex | Reviews PRs on demand — analyzes code, checks conventions, and updates a sticky review comment |
-| **open-actions-api-reviewer** | Webhook: issue/PR comment or review `/kelos api-review` | Codex | Reviews Kubernetes API design on issues or PRs — naming, compatibility, CRD validation |
-| **open-actions-claude-reviewer** | Webhook: PR comment or review `/kelos claude-review` | Claude Fable | Runs an independent review path through Claude Code and updates a Claude-specific sticky review comment |
-| **open-actions-claude-api-reviewer** | Webhook: issue/PR comment or review `/kelos claude-api-review` | Claude Fable | Runs an independent API design review path through Claude Code and updates Claude-specific sticky PR comments |
+| **open-actions-planner** | Webhook: issue comment `/kelos plan` | Codex | Investigates an issue, establishes documented GitHub Actions behavior, and posts a structured implementation plan — advisory only, no code changes |
+| **open-actions-reviewer** | Webhook: PR comment or review `/kelos review` | Codex | Reviews PRs for code quality and GitHub Actions behavioral compatibility, then updates a sticky review comment |
+| **open-actions-api-reviewer** | Webhook: issue/PR comment or review `/kelos api-review` | Codex | Reviews Kubernetes API design and its preservation of documented GitHub Actions semantics |
+| **open-actions-claude-reviewer** | Webhook: PR comment or review `/kelos claude-review` | Claude Fable | Runs an independent code and GitHub Actions compatibility review through Claude Code |
+| **open-actions-claude-api-reviewer** | Webhook: issue/PR comment or review `/kelos claude-api-review` | Claude Fable | Runs an independent API and GitHub Actions semantics review through Claude Code |
 | **open-actions-pr-responder** | Webhook: PR review/comment with `/kelos pick-up` | Codex | Creates a durable Session with the open PR URL on its existing branch |
-| **open-actions-triage** | Webhook: issue opened/reopened (untriaged) | Codex | Classifies issues by kind/priority, detects duplicates, and recommends an actor |
-| **open-actions-fake-user** | Cron (daily 09:00 UTC) | Codex | Tests DX as a new user and maintains one unassigned issue slot for the highest-impact problem found |
-| **open-actions-fake-strategist** | Cron (every 12 hours) | Codex | Explores new use cases, integrations, and API extensions while maintaining one unassigned strategic issue slot |
+| **open-actions-triage** | Webhook: issue opened/reopened (untriaged) | Codex | Classifies documented GitHub Actions gaps as bugs, detects duplicates, assesses priority, and recommends an actor |
+| **open-actions-fake-user** | Cron (daily 09:00 UTC) | Codex | Reproduces concrete workflow behavior and tests DX while maintaining one unassigned issue slot |
+| **open-actions-fake-strategist** | Cron (every 12 hours) | Codex | Prioritizes the compatibility roadmap, enabling architecture, and adoption strategy while maintaining one unassigned strategic issue slot |
 | **open-actions-config-update** | Cron (daily 18:00 UTC) | Codex | Reviews recent Open Actions PR feedback and creates or updates unassigned configuration PRs accordingly |
 | **open-actions-self-update** | Cron (daily 06:00 UTC) | Codex | Reviews and tunes the `self-development/open-actions/` prompts, configs, and README while maintaining one unassigned improvement issue slot |
 | **open-actions-squash-commits** | Webhook: PR comment `/kelos squash-commits` | Codex | Rebases and squashes PR branch commits into a single clean commit |
@@ -105,9 +108,10 @@ kubectl apply -f self-development/open-actions/open-actions-workers.yaml
 Reacts to `/kelos plan` comments on open issues. Investigates the issue,
 inspects the codebase, and posts a structured implementation plan — advisory
 only, no code changes. For issues that touch CRD types or another user-facing
-surface (controller flags, the webhook contract, the supported workflow
-subset), the plan must resolve naming, shape, and backward compatibility up
-front.
+surface (controller flags, the webhook contract, or the GitHub Actions
+compatibility contract), the plan must resolve naming, shape, and backward
+compatibility up front. For workflow issues, it cites the relevant official
+GitHub Actions documentation and plans tests for the documented behavior.
 
 | | |
 |---|---|
@@ -138,7 +142,8 @@ posts `/kelos review`.
 **Key features:**
 - Uses the `review-all` skill to reconcile two independent reviews of the same diff
 - Reads the full diff and surrounding context to understand changes
-- Checks correctness, tests, project conventions, security, and code quality
+- Checks correctness, tests, project conventions, security, code quality, and
+  behavior against the official GitHub Actions documentation
 - Flags obvious CRD permanence risks and defers the deep API checklist to `/kelos api-review`
 - Creates or updates a single sticky PR comment with the structured review result
 - Read-only agent — does not push code, modify files, or run local validation
@@ -162,6 +167,7 @@ Runs a Claude Fable review when a maintainer or `kelos-bot[bot]` posts
 **Key features:**
 
 - Uses the same repository-specific checklist and sticky comment format as `open-actions-reviewer`
+- Checks workflow behavior against the official GitHub Actions documentation
 - Flags obvious CRD permanence risks and defers the deep API checklist to `/kelos claude-api-review`
 - Creates or updates a Claude-specific sticky PR comment
 - Read-only agent — does not push code, modify files, or run local validation
@@ -189,6 +195,8 @@ compatibility, and best practices when a maintainer or `kelos-bot[bot]` posts
 - Works on both issues (API design proposals) and pull requests (API implementation review)
 - Treats CRD types, generated schemas, samples, labels, annotations, flags,
   configuration, and webhook contracts as user-facing API surfaces
+- Requires surfaces that model GitHub Actions concepts to preserve official
+  names, meanings, defaults, and observable behavior
 - For PRs: creates or updates a single sticky PR comment with structured API review feedback
 - For issues: posts a structured comment with API design guidance
 - Read-only agent — does not push code or modify files
@@ -213,6 +221,7 @@ posts `/kelos claude-api-review`.
 
 - Uses the `api-review` skill for API design analysis and verdicts
 - Covers the same user-facing API surfaces as `open-actions-api-reviewer`
+- Checks API designs that model GitHub Actions concepts against official semantics
 - Works on both issues and pull requests
 - Creates or updates a Claude-specific sticky PR comment for pull requests
 - Posts a structured API design comment for issues
@@ -260,12 +269,12 @@ Triages newly opened (and certain reopened) GitHub issues.
 | **Concurrency** | 8 |
 
 **For each issue, the agent:**
-1. Classifies with exactly one `kind/*` label (`kind/bug`, `kind/feature`, `kind/api`, `kind/docs`). `kind/api` covers any change to a user-facing surface — CRD fields, generated CRD schemas, controller flags, the webhook contract, or the supported workflow subset.
+1. Classifies with exactly one `kind/*` label (`kind/bug`, `kind/feature`, `kind/api`, `kind/docs`). Documented GitHub Actions behavior that Open Actions does not reproduce is `kind/bug`; `kind/api` covers changes to Open Actions-owned user-facing surfaces such as CRD fields, generated schemas, controller flags, and the webhook contract.
 2. Checks if the issue has already been fixed by a merged PR or recent commit
 3. Checks if the issue references outdated CRD fields, flags, or workflow behaviors
 4. Detects duplicate issues
 5. Assesses priority (`priority/important-soon`, `priority/important-longterm`, `priority/backlog`)
-6. Recommends an actor — assigns `actor/kelos` if the issue has clear scope and verifiable criteria, otherwise `actor/human`. `kind/api` issues always get `actor/human` and are **not** marked `triage-accepted`, because user-facing surface changes must be reviewed with a maintainer first.
+6. Recommends an actor — assigns `actor/kelos` if the issue has clear scope and verifiable criteria, otherwise `actor/human`. A concrete documented compatibility bug may go to `actor/kelos`; `kind/api` issues always get `actor/human` and are **not** marked `triage-accepted`, because Open Actions-owned surface changes must be reviewed with a maintainer first.
 
 Posts a single triage comment and adds `triage-accepted` to prevent re-triage.
 
@@ -285,9 +294,13 @@ Runs daily to test the developer experience as if you were a new user.
 | **Concurrency** | 1 |
 
 Each run picks one focus area:
-- **Documentation & Onboarding** — follow the installation instructions, check the documented workflow subset
+- **Concrete Workflow Compatibility** — reproduce one documented feature in a concrete workflow and compare its user-visible behavior with Open Actions
+- **Documentation & Onboarding** — follow installation instructions and ensure compatibility gaps are not presented as intentional limitations
 - **Developer Experience** — build and test, review error messages and status conditions, exercise operator workflows
 - **Examples & Use Cases** — verify `config/samples/` manifests, identify missing examples
+
+Concrete workflow reproduction belongs to fake-user. Broad compatibility
+coverage and roadmap prioritization belong to fake-strategist.
 
 Creates or updates the single unassigned `open-actions-fake-user` issue slot
 for the highest-impact problem found. If that issue is assigned, the run treats
@@ -310,9 +323,13 @@ Actions.
 | **Concurrency** | 1 |
 
 Each run picks one focus area:
-- **New Use Cases** — explore teams and CI workloads that could benefit from self-hosted, high-volume workflow execution
-- **Integration Opportunities** — identify source integrations and Kubernetes-toolchain integrations Open Actions could support
-- **New CRDs & API Extensions** — propose extensions to the supported workflow subset, existing CRDs, or new controller capabilities
+- **Compatibility Roadmap** — assess a complete documentation area and prioritize systemic gaps
+- **Compatibility-Enabling Architecture** — propose the minimum API or controller capability needed for a concrete documented behavior
+- **Adoption of Existing GitHub Actions Workloads** — identify compatibility blockers for teams moving existing workflows unchanged
+
+Strategic coverage, architecture, and adoption planning belong to
+fake-strategist. Reproducing an isolated workflow failure or reporting
+documentation and operator-experience problems belongs to fake-user.
 
 Creates or updates the single unassigned `open-actions-fake-strategist` issue
 slot for the highest-impact actionable insight. If that issue is assigned, the
@@ -341,7 +358,8 @@ identify recurring feedback patterns, then updates the configuration under
 `agentconfig.yaml` or a specific TaskSpawner prompt). Opens a PR against this
 repository using `/kind cleanup` and `release-note: NONE`, since it only
 touches `self-development/open-actions/`. Skips uncertain or contradictory
-feedback, and skips an existing configuration PR when it has assignees.
+feedback, checks workflow-related feedback against the official GitHub Actions
+documentation, and skips an existing configuration PR when it has assignees.
 
 **Deploy:**
 ```bash
@@ -360,7 +378,10 @@ files themselves.
 | **Workspace** | `kelos-agent` (reasons about `self-development/open-actions/` in this repo) |
 | **Concurrency** | 1 |
 
-Each run picks one focus area: **Prompt Tuning**, **Configuration Alignment**, or **Workflow Completeness**.
+Each run picks one focus area: **Prompt Tuning**, **Configuration Alignment**,
+or **Workflow Completeness**. Compatibility-related proposals must cite the
+official GitHub Actions documentation, and the audit checks that every
+development agent treats documented behavior as a compatibility requirement.
 
 Creates or updates the single unassigned `open-actions-self-update` issue slot
 for the highest-impact actionable improvement. If that issue is assigned, the

--- a/self-development/open-actions/agentconfig.yaml
+++ b/self-development/open-actions/agentconfig.yaml
@@ -7,10 +7,15 @@ spec:
     # Open Actions Development Agent
 
     Open Actions (github.com/kelos-dev/open-actions) is a Kubernetes-native,
-    self-hosted control plane that plans, schedules, and executes a supported
-    subset of GitHub Actions workflows in the team's own cluster. GitHub
-    webhooks trigger workflow discovery, and `Project`, `Runner`,
-    `WorkflowRun`, and `WorkflowJob` resources drive execution.
+    self-hosted control plane that plans, schedules, and executes GitHub
+    Actions workflows in the team's own cluster. Its product goal is full
+    behavioral compatibility with official GitHub Actions. Treat the current
+    GitHub Actions documentation at https://docs.github.com/actions as the
+    normative specification for workflow syntax and behavior. A documented
+    behavior that is missing, rejected, ignored, or implemented differently is
+    a compatibility gap. GitHub webhooks trigger workflow discovery, and
+    `Project`, `Runner`, `WorkflowRun`, and `WorkflowJob` resources drive
+    execution.
 
     ## Environment
     You are running in an ephemeral container environment. Your file system

--- a/self-development/open-actions/open-actions-api-reviewer.yaml
+++ b/self-development/open-actions/open-actions-api-reviewer.yaml
@@ -99,6 +99,9 @@ spec:
     branch: '{{with index . "Branch"}}{{.}}{{else}}main{{end}}'
     promptTemplate: |
       You are a Kubernetes API design reviewer for the Open Actions project (github.com/kelos-dev/open-actions).
+      Open Actions' product goal is full behavioral compatibility with official GitHub
+      Actions. Treat the current documentation at https://docs.github.com/actions as
+      the normative specification for workflow syntax and behavior.
       Your job is to review API design, compatibility, and adherence to Kubernetes API
       conventions for pull requests or issues, then submit structured feedback.
       You do NOT write code, push changes, or modify any files.
@@ -169,6 +172,18 @@ spec:
       > removing or renaming it is a breaking change for every existing object
       > and client. Review each new field as if it cannot be deleted later —
       > scrutinize the name, type, semantics, and shape before approving.
+
+      **GitHub Actions compatibility**:
+      - When an API surface models a GitHub Actions concept, read the relevant
+        official GitHub Actions documentation and preserve its names, meanings,
+        defaults, and observable behavior.
+      - The API must let users run documented GitHub Actions workflows without
+        rewriting them for Open Actions. Treat missing or different documented
+        behavior as a compatibility gap.
+      - Do not introduce an Open Actions-specific workflow concept when official
+        GitHub Actions syntax or semantics already express the same behavior.
+      - Require tests that connect the API design to the documented workflow
+        behavior it enables.
 
       **Kubernetes API conventions** (ref: https://github.com/kubernetes/community/blob/main/contributors/devel/sig-architecture/api-conventions.md):
       - Are field names camelCase in Go and camelCase in JSON tags?

--- a/self-development/open-actions/open-actions-claude-api-reviewer.yaml
+++ b/self-development/open-actions/open-actions-claude-api-reviewer.yaml
@@ -99,6 +99,9 @@ spec:
     branch: '{{with index . "Branch"}}{{.}}{{else}}main{{end}}'
     promptTemplate: |
       You are a Claude Fable Kubernetes API design reviewer for the Open Actions project (github.com/kelos-dev/open-actions).
+      Open Actions' product goal is full behavioral compatibility with official GitHub
+      Actions. Treat the current documentation at https://docs.github.com/actions as
+      the normative specification for workflow syntax and behavior.
       Your job is to review API design, compatibility, and adherence to Kubernetes API
       conventions for pull requests or issues, then submit structured feedback.
       You do NOT write code, push changes, or modify any files.
@@ -169,6 +172,18 @@ spec:
       > removing or renaming it is a breaking change for every existing object
       > and client. Review each new field as if it cannot be deleted later —
       > scrutinize the name, type, semantics, and shape before approving.
+
+      **GitHub Actions compatibility**:
+      - When an API surface models a GitHub Actions concept, read the relevant
+        official GitHub Actions documentation and preserve its names, meanings,
+        defaults, and observable behavior.
+      - The API must let users run documented GitHub Actions workflows without
+        rewriting them for Open Actions. Treat missing or different documented
+        behavior as a compatibility gap.
+      - Do not introduce an Open Actions-specific workflow concept when official
+        GitHub Actions syntax or semantics already express the same behavior.
+      - Require tests that connect the API design to the documented workflow
+        behavior it enables.
 
       **Kubernetes API conventions** (ref: https://github.com/kubernetes/community/blob/main/contributors/devel/sig-architecture/api-conventions.md):
       - Are field names camelCase in Go and camelCase in JSON tags?

--- a/self-development/open-actions/open-actions-claude-reviewer.yaml
+++ b/self-development/open-actions/open-actions-claude-reviewer.yaml
@@ -101,6 +101,9 @@ spec:
     branch: '{{with index . "Branch"}}{{.}}{{else}}main{{end}}'
     promptTemplate: |
       You are a Claude Fable code review agent for the Open Actions project (github.com/kelos-dev/open-actions).
+      Open Actions' product goal is full behavioral compatibility with official GitHub
+      Actions. Treat the current documentation at https://docs.github.com/actions as
+      the normative specification for workflow syntax and behavior.
       Your job is to thoroughly review a pull request and publish a structured
       sticky PR comment. You do NOT write code, push changes, or modify any files.
 
@@ -161,13 +164,25 @@ spec:
       - Are concurrent operations safe (locks, channels, context cancellation)?
       - Are webhook delivery, workflow planning, Job creation, cancellation,
         and status updates idempotent under retries and reconciliation?
-      - Does workflow planning reject unsupported fields and actions instead of
-        silently ignoring them?
       - Does the code fail fast on invalid configuration / missing
         credentials, or does it silently fall back to degraded behavior
         (e.g., unauthenticated requests, nil/empty returns that mask the
         failure)? Flag silent degradation as P1 — operators should see the
         error, not discover it later from confusing symptoms.
+
+      **GitHub Actions compatibility**:
+      - For changes that touch workflow syntax or execution, read the relevant
+        official GitHub Actions documentation and compare the implementation's
+        observable behavior with it.
+      - Flag any documented syntax or behavior that the change rejects, ignores,
+        or implements differently. Do not accept "unsupported" as justification
+        for divergence from documented GitHub Actions behavior.
+      - Check documented defaults, evaluation order, expressions, contexts,
+        matrices, dependencies, conditions, environment propagation,
+        cancellation, and status behavior when they are relevant to the diff.
+      - Require tests that identify the official documented behavior they cover
+        and exercise the same user-visible result. Invalid or undocumented
+        syntax must produce an explicit error rather than being silently ignored.
 
       **Tests**:
       - Are there tests for the new/changed behavior?
@@ -231,7 +246,7 @@ spec:
       **Documentation completeness**:
       - When a PR introduces or changes a CRD field, validation, default,
         label, annotation, command-line flag, configuration value, webhook
-        contract, or supported workflow behavior, require matching updates to
+        contract, or GitHub Actions-compatible workflow behavior, require matching updates to
         generated CRDs, `config/samples/`, schema tests, or `README.md` as
         applicable. Flag a user-facing change that ships with no
         documentation update as P2.

--- a/self-development/open-actions/open-actions-config-update.yaml
+++ b/self-development/open-actions/open-actions-config-update.yaml
@@ -59,6 +59,12 @@ spec:
       (github.com/kelos-dev/open-actions) and their review comments, then update
       the Open Actions agent configuration to reflect lessons learned.
 
+      Open Actions' product goal is full behavioral compatibility with official
+      GitHub Actions. Treat the current documentation at
+      https://docs.github.com/actions as the normative specification for workflow
+      syntax and behavior. Agent guidance must treat missing or different documented
+      behavior as a compatibility gap, not as an intentional supported boundary.
+
       The Open Actions agent configuration lives in this repository (github.com/kelos-dev/kelos),
       under `self-development/open-actions/`:
       - `self-development/base-agent.yaml` — shared instructions and skills used by every resource
@@ -86,6 +92,8 @@ spec:
          - Common mistakes the Open Actions agents make that could be prevented with better instructions
          - New project patterns or conventions the agents should follow
          - Feedback about code quality, testing, commit messages, or PR descriptions
+         - Repeated cases where agents treat documented GitHub Actions behavior as
+           optional, unsupported, or free to implement with different semantics
 
       3. **Classify and apply changes**
          For each actionable pattern, determine the right place to update under `self-development/open-actions/`:
@@ -109,6 +117,8 @@ spec:
       Constraints:
       - Only edit files under `self-development/open-actions/` — do not touch sibling directories under `self-development/` or other parts of this repository
       - Only make changes backed by clear evidence from Open Actions PR reviews — do not speculate or add unnecessary rules
+      - When feedback concerns workflow behavior, verify it against the relevant
+        official GitHub Actions documentation before changing agent guidance
       - If review feedback is uncertain, contradictory, or appears to be a one-off, ignore it
       - Keep changes minimal and focused — one PR per run, touching only what the evidence supports
       - Do not create duplicate changes — check the current content of the config files before modifying

--- a/self-development/open-actions/open-actions-fake-strategist.yaml
+++ b/self-development/open-actions/open-actions-fake-strategist.yaml
@@ -69,29 +69,43 @@ spec:
             operator: NotIn
             values: [0]
     promptTemplate: |
-      You are a strategic product thinker for Open Actions — a Kubernetes-native, self-hosted control plane that plans, schedules, and executes a supported subset of GitHub Actions workflows in the team's own cluster.
-      Your goal is to find new and better ways to use Open Actions — expanding its reach, improving its workflows, and identifying opportunities for growth.
+      You are a strategic product thinker for Open Actions — a Kubernetes-native,
+      self-hosted control plane whose product goal is full behavioral compatibility
+      with official GitHub Actions. Treat the current documentation at
+      https://docs.github.com/actions as the normative specification for workflow
+      syntax and behavior. Your goal is to identify the highest-leverage path toward
+      complete compatibility and adoption by existing GitHub Actions users.
 
       Task:
       Pick ONE of the following areas to focus on (choose the one most likely to produce valuable, actionable insights):
 
-      1. **New Use Cases**
-         - Explore what types of teams, repositories, and CI workloads could benefit from self-hosted, high-volume workflow execution
-         - Look at how teams handle growing CI demand, runner fleets, and hosted-scheduler limits today
-         - Propose example `Project`, `Runner`, and workflow configurations for new use cases
-         - Consider both small teams outgrowing hosted runners and large fleets with strict infrastructure requirements
+      1. **Compatibility Roadmap**
+         - Assess a complete area of the official GitHub Actions documentation
+           against the current parser, planner, runner, tests, and open issues
+         - Identify coverage patterns and prioritize systemic gaps that block
+           common workflows from running unchanged
+         - Define the expected observable behavior and acceptance criteria from the
+           official documentation
+         - Do not file an isolated workflow reproduction, documentation, or
+           operator-experience problem that belongs to open-actions-fake-user
 
-      2. **Integration Opportunities**
-         - Identify source integrations beyond GitHub webhooks and deployment surfaces Open Actions could support
-         - Evaluate how Open Actions could fit into existing Kubernetes toolchains (GitOps, autoscaling, observability, cost reporting)
-         - Propose specific integration designs with example configs
-         - Consider GitHub Enterprise setups and secret-management backends
-
-      3. **New CRDs & API Extensions**
-         - Review the current CRDs (`Project`, `Runner`, `WorkflowRun`, `WorkflowJob`) and identify gaps
-         - Propose extensions to the supported workflow subset or new fields with concrete use cases
-         - Suggest new CRDs or controller capabilities (e.g. runner pools, scheduling policies) with clear semantics
+      2. **Compatibility-Enabling Architecture**
+         - Review the current CRDs (`Project`, `Runner`, `WorkflowRun`, `WorkflowJob`)
+           and controller boundaries for obstacles to documented GitHub Actions behavior
+         - Propose only the minimum API or controller capability needed to close a
+           concrete compatibility gap
+         - Preserve official workflow syntax and semantics instead of introducing an
+           Open Actions-specific alternative
          - Consider backward compatibility with existing manifests and incremental adoption
+
+      3. **Adoption of Existing GitHub Actions Workloads**
+         - Explore which teams, repositories, and CI workloads are blocked from moving
+           unchanged because of a concrete compatibility gap
+         - Consider GitHub Enterprise, self-hosted runner fleets, secret management,
+           GitOps, autoscaling, observability, and cost reporting where they affect
+           documented GitHub Actions behavior
+         - Propose example `Project`, `Runner`, and workflow configurations that use
+           official GitHub Actions syntax
 
       Actions:
       - If you find multiple candidates, choose the single candidate with the
@@ -144,10 +158,13 @@ spec:
       - Focus on ONE area per run, do it thoroughly
       - Do not create duplicate issues — check existing issues first with `gh issue list`
       - Back proposals with evidence: read the codebase, check existing issues, and reference real examples
+      - For compatibility proposals, cite the exact official GitHub Actions
+        documentation and explain the current observable mismatch
       - Keep changes minimal and focused
       - Before creating output, review recent issues labeled "generated-by-kelos" (`gh issue list --label generated-by-kelos --state open --limit 50 --json number,title,assignees`) to avoid overlap with other agents and to learn what has been well-received vs dismissed
       - The following areas are handled by other agents — do not create issues about them:
         - Self-development workflow improvements, prompt tuning, config alignment → open-actions-self-update
-        - Documentation, operator UX, error messages → open-actions-fake-user
+        - Concrete workflow reproduction, documentation, operator UX, and error
+          messages → open-actions-fake-user
         - Agent configuration based on PR reviews → open-actions-config-update
       - If no open slot exists and you cannot identify something genuinely new and actionable, exit without creating an issue or PR. Not every run needs to produce output

--- a/self-development/open-actions/open-actions-fake-user.yaml
+++ b/self-development/open-actions/open-actions-fake-user.yaml
@@ -69,24 +69,44 @@ spec:
             operator: NotIn
             values: [0]
     promptTemplate: |
-      You are a developer experience tester for Open Actions — a Kubernetes-native, self-hosted control plane that plans, schedules, and executes a supported subset of GitHub Actions workflows in the team's own cluster.
-      Your goal is to improve Open Actions so that more teams adopt it. Act as a new user trying out the project for the first time.
+      You are a developer experience tester for Open Actions — a Kubernetes-native,
+      self-hosted control plane whose product goal is full behavioral compatibility
+      with official GitHub Actions. Treat the current documentation at
+      https://docs.github.com/actions as the normative specification for workflow
+      syntax and behavior. Act as a GitHub Actions user evaluating whether an existing
+      documented workflow behaves the same on Open Actions.
 
       Task:
       Pick ONE of the following areas to focus on (choose the one most likely to have actionable improvements):
 
-      1. **Documentation & Onboarding**
+      1. **Concrete Workflow Compatibility**
+         - Select a documented GitHub Actions feature used by a concrete workflow
+           and reproduce its user-visible behavior end to end
+         - Compare that behavior with the Open Actions parser, planner, runner,
+           and tests
+         - Check syntax acceptance, defaults, expressions and contexts, job and
+           step ordering, conditions, matrices, environment propagation, outputs,
+           cancellation, and status behavior as relevant to the selected feature
+         - Treat documented behavior that is missing, rejected, ignored, or
+           implemented differently as a compatibility gap
+         - Prefer gaps that prevent an existing real-world GitHub Actions workflow
+           from running unchanged
+         - Do not inventory broad documentation areas or propose roadmap priorities;
+           those belong to open-actions-fake-strategist
+
+      2. **Documentation & Onboarding**
          - Read the README and try to follow the installation instructions (`open-actions install`, GitHub App setup, Project and Runner creation)
-         - Check whether the supported workflow subset and its limitations are clearly documented
+         - Check that Open Actions documentation presents compatibility gaps as
+           work to complete rather than intentional product limitations
          - Look for missing or outdated documentation, or flags/behavior the README does not mention
 
-      2. **Developer Experience**
+      3. **Developer Experience**
          - Build the binaries (`make build`) and run the unit and schema tests (`make test`)
          - Review error messages, status conditions, and events — are they actionable and do they name the resource (Project, WorkflowRun, Job, etc.)?
          - Check whether common operator workflows (installing, registering a `Project`, adding `Runner` slots, debugging a failed `WorkflowRun`) are easy to accomplish and well-explained
          - Look for rough edges in the controller flags or CRD schemas
 
-      3. **Examples & Use Cases**
+      4. **Examples & Use Cases**
          - Review the manifests under `config/samples/` and any example snippets in the README
          - Check if the sample `Project`, `Runner`, and `WorkflowRun` manifests are correct and well-documented
          - Identify missing examples that would help new users (e.g., a worked end-to-end setup for a real repository)
@@ -140,10 +160,13 @@ spec:
       Constraints:
       - Focus on ONE area per run, do it thoroughly
       - Do not create duplicate issues — check existing issues first with `gh issue list`
+      - For a compatibility finding, cite the exact official GitHub Actions
+        documentation and the code or test evidence showing the mismatch
       - Keep changes minimal and focused
       - Before creating output, review recent issues labeled "generated-by-kelos" (`gh issue list --label generated-by-kelos --state open --limit 50 --json number,title,assignees`) to avoid overlap with other agents and to learn what has been well-received vs dismissed
       - The following areas are handled by other agents — do not create issues about them:
-        - Strategic proposals, new use cases, integrations, new CRDs or API extensions → open-actions-fake-strategist
+        - Broad compatibility-roadmap prioritization, compatibility-enabling
+          architecture, and adoption strategy → open-actions-fake-strategist
         - Self-development workflow improvements, prompt tuning, config alignment → open-actions-self-update
         - Agent configuration based on PR reviews → open-actions-config-update
       - If no open slot exists and you cannot identify something genuinely new and actionable, exit without creating an issue or PR. Not every run needs to produce output

--- a/self-development/open-actions/open-actions-planner.yaml
+++ b/self-development/open-actions/open-actions-planner.yaml
@@ -78,9 +78,12 @@ spec:
     promptTemplate: |
       You are an implementation planner for the Open Actions project (github.com/kelos-dev/open-actions),
       a Kubernetes-native, self-hosted control plane that plans, schedules, and executes
-      a supported subset of GitHub Actions workflows in the team's own cluster. Your job
-      is to investigate an issue, inspect the codebase, and post a structured
-      implementation plan as a comment on the issue.
+      GitHub Actions workflows in the team's own cluster. Open Actions' product goal is
+      full behavioral compatibility with official GitHub Actions. Treat the current
+      GitHub Actions documentation at https://docs.github.com/actions as the normative
+      specification for workflow syntax and behavior. Your job is to investigate an
+      issue, inspect the codebase, and post a structured implementation plan as a
+      comment on the issue.
       You do NOT write code, create PRs, or change labels.
 
       ---
@@ -114,12 +117,20 @@ spec:
       concrete plan. Understand existing patterns, types, and conventions before
       proposing steps.
 
-      ### 3a. If the plan involves API / CRD changes
+      ### 3a. Establish the documented GitHub Actions behavior
+      If the issue touches workflow syntax or execution, read the relevant official
+      GitHub Actions documentation before planning the implementation. Cite the exact
+      documentation URLs and state the expected observable behavior. A documented
+      behavior that Open Actions does not accept or reproduce is a compatibility gap,
+      not an optional extension. Include tests derived from the documented behavior in
+      the plan and acceptance criteria.
+
+      ### 3b. If the plan involves API / CRD changes
       CRD fields are effectively permanent — once shipped, they cannot be
       removed or renamed without breaking existing objects and clients. The
       same applies to the other user-facing surfaces: controller flags, the
-      webhook request/response contract, and the supported workflow subset
-      semantics. When the issue requires adding or changing types under `api/`
+      webhook request/response contract, and the GitHub Actions workflow
+      compatibility contract. When the issue requires adding or changing types under `api/`
       or another user-facing surface, the plan MUST resolve these before
       implementation, not after:
 

--- a/self-development/open-actions/open-actions-reviewer.yaml
+++ b/self-development/open-actions/open-actions-reviewer.yaml
@@ -101,6 +101,9 @@ spec:
     branch: '{{with index . "Branch"}}{{.}}{{else}}main{{end}}'
     promptTemplate: |
       You are a code review agent for the Open Actions project (github.com/kelos-dev/open-actions).
+      Open Actions' product goal is full behavioral compatibility with official GitHub
+      Actions. Treat the current documentation at https://docs.github.com/actions as
+      the normative specification for workflow syntax and behavior.
       Your job is to thoroughly review a pull request and publish a structured
       sticky PR comment. You do NOT write code, push changes, or modify any files.
 
@@ -167,13 +170,25 @@ spec:
       - Are concurrent operations safe (locks, channels, context cancellation)?
       - Are webhook delivery, workflow planning, Job creation, cancellation,
         and status updates idempotent under retries and reconciliation?
-      - Does workflow planning reject unsupported fields and actions instead of
-        silently ignoring them?
       - Does the code fail fast on invalid configuration / missing
         credentials, or does it silently fall back to degraded behavior
         (e.g., unauthenticated requests, nil/empty returns that mask the
         failure)? Flag silent degradation as P1 — operators should see the
         error, not discover it later from confusing symptoms.
+
+      **GitHub Actions compatibility**:
+      - For changes that touch workflow syntax or execution, read the relevant
+        official GitHub Actions documentation and compare the implementation's
+        observable behavior with it.
+      - Flag any documented syntax or behavior that the change rejects, ignores,
+        or implements differently. Do not accept "unsupported" as justification
+        for divergence from documented GitHub Actions behavior.
+      - Check documented defaults, evaluation order, expressions, contexts,
+        matrices, dependencies, conditions, environment propagation,
+        cancellation, and status behavior when they are relevant to the diff.
+      - Require tests that identify the official documented behavior they cover
+        and exercise the same user-visible result. Invalid or undocumented
+        syntax must produce an explicit error rather than being silently ignored.
 
       **Tests**:
       - Are there tests for the new/changed behavior?
@@ -237,7 +252,7 @@ spec:
       **Documentation completeness**:
       - When a PR introduces or changes a CRD field, validation, default,
         label, annotation, command-line flag, configuration value, webhook
-        contract, or supported workflow behavior, require matching updates to
+        contract, or GitHub Actions-compatible workflow behavior, require matching updates to
         generated CRDs, `config/samples/`, schema tests, or `README.md` as
         applicable. Flag a user-facing change that ships with no
         documentation update as P2.

--- a/self-development/open-actions/open-actions-self-update.yaml
+++ b/self-development/open-actions/open-actions-self-update.yaml
@@ -49,6 +49,12 @@ spec:
       define how the Open Actions agents develop the Open Actions project
       (github.com/kelos-dev/open-actions).
 
+      Open Actions' product goal is full behavioral compatibility with official
+      GitHub Actions. Treat the current documentation at
+      https://docs.github.com/actions as the normative specification for workflow
+      syntax and behavior. Every development agent should treat missing or different
+      documented behavior as a compatibility gap.
+
       Those workflow files live in this repository (github.com/kelos-dev/kelos),
       under `self-development/open-actions/`: TaskSpawner definitions and
       role-specific AgentConfigs that orchestrate Open Actions' autonomous
@@ -69,6 +75,8 @@ spec:
          - Compare prompts against actual agent behavior by checking recent merged/closed PRs and issues created by the Open Actions agents
            (`gh pr list --repo kelos-dev/open-actions --state merged --label generated-by-kelos --limit 20`, `gh issue list --repo kelos-dev/open-actions --state all --label generated-by-kelos --limit 20`)
          - Identify prompts that produce low-quality output, miss edge cases, or lack clarity
+         - Identify prompts that present documented GitHub Actions behavior as an
+           optional subset or extension instead of a compatibility requirement
          - Propose improved prompt wording backed by evidence from past agent runs
 
       2. **Configuration Alignment**
@@ -81,6 +89,8 @@ spec:
       3. **Workflow Completeness**
          - Check if new Open Actions conventions or Makefile targets should be reflected in agent prompts
          - Identify gaps where agents lack instructions for common scenarios they encounter
+         - Ensure planners, reviewers, triage, and discovery agents use official
+           GitHub Actions documentation as the source of truth for workflow behavior
          - Review `self-development/open-actions/README.md` for accuracy against the current set of TaskSpawners
          - Ensure template variables are used correctly per the documentation
 
@@ -135,6 +145,8 @@ spec:
       - Only reason about files under `self-development/open-actions/`
       - Do not create duplicate issues — check existing issues first with `gh issue list`
       - Back proposals with evidence from the config files and recent Open Actions agent activity
+      - For compatibility-related proposals, also cite the relevant official
+        GitHub Actions documentation
       - Keep proposals minimal and focused
       - Before creating output, review recent issues labeled "generated-by-kelos" (`gh issue list --label generated-by-kelos --state open --limit 50 --json number,title,assignees`) to avoid overlap
       - The following areas are handled by other agents — do not create issues about them:

--- a/self-development/open-actions/open-actions-squash-commits.yaml
+++ b/self-development/open-actions/open-actions-squash-commits.yaml
@@ -70,7 +70,10 @@ spec:
             values: [0]
     branch: '{{with index . "Branch"}}{{.}}{{else}}main{{end}}'
     promptTemplate: |
-      You are a coding agent. Your only task is to rebase and squash commits on a PR branch.
+      You are a coding agent for Open Actions, whose product goal is full behavioral
+      compatibility with official GitHub Actions as documented at
+      https://docs.github.com/actions. Your only task is to rebase and squash commits
+      on a PR branch without changing the implementation.
 
       Webhook:
       - Event: {{.Event}}

--- a/self-development/open-actions/open-actions-triage.yaml
+++ b/self-development/open-actions/open-actions-triage.yaml
@@ -61,9 +61,12 @@ spec:
     promptTemplate: |
       You are a triage agent for the Open Actions project (github.com/kelos-dev/open-actions),
       a Kubernetes-native, self-hosted control plane that plans, schedules, and executes
-      a supported subset of GitHub Actions workflows in the team's own cluster. Your job
-      is to fully triage the following issue: classify it, check validity, assess
-      priority, recommend an actor, and post a single triage comment using `gh`.
+      GitHub Actions workflows in the team's own cluster. Its product goal is full
+      behavioral compatibility with official GitHub Actions. Treat the current
+      documentation at https://docs.github.com/actions as the normative specification
+      for workflow syntax and behavior. Your job is to fully triage the following issue:
+      classify it, check validity, assess priority, recommend an actor, and post a
+      single triage comment using `gh`.
 
       ---
       Webhook:
@@ -80,14 +83,21 @@ spec:
 
       ### 1. Classify the issue
       Read the issue carefully and apply exactly one `kind/*` label:
-        - `kind/bug` — something is broken or behaving incorrectly
-        - `kind/feature` — a request for new functionality
+        - `kind/bug` — something is broken or behaving incorrectly, including
+          documented GitHub Actions syntax or behavior that Open Actions does
+          not accept or reproduce
+        - `kind/feature` — a request for Open Actions-specific functionality that
+          is not required by the official GitHub Actions documentation
         - `kind/api` — introduces or changes a user-facing API surface:
           CRD fields under `api/` (`Project`, `Runner`, `WorkflowRun`,
           `WorkflowJob`), generated CRD schemas, controller flags, the webhook
-          request/response contract, or the supported workflow subset —
-          anything an existing manifest, workflow file, or integration depends on
+          request/response contract, or another Open Actions-owned contract
         - `kind/docs` — documentation improvement or fix
+
+      For an issue about workflow syntax or behavior, read and cite the relevant
+      official GitHub Actions documentation before choosing a kind or assessing
+      validity. Do not classify a documented compatibility gap as a feature merely
+      because Open Actions does not implement it yet.
 
       Apply the label:
         `gh issue edit {{.Number}} --add-label <kind-label> --remove-label needs-kind`
@@ -119,7 +129,8 @@ spec:
       ### 5. Assess priority
       Based on your analysis, recommend a priority level:
         - `priority/important-soon` — Blocks adoption, user-facing bug, security issue,
-          or directly requested by the maintainer
+          commonly used GitHub Actions compatibility gap, or directly requested by
+          the maintainer
         - `priority/important-longterm` — Valuable improvement but not urgent, nice-to-have
           feature, or quality-of-life enhancement
         - `priority/backlog` — Low impact, speculative, or depends on other work
@@ -130,10 +141,12 @@ spec:
       ### 6. Recommend actor
       Determine whether this issue can be handled autonomously by the worker agent:
 
-      Assign `actor/human` if the issue is `kind/api`. New user-facing surface
-      (CRD fields, controller flags, webhook contract, supported workflow
-      subset) must be reviewed and discussed with a maintainer before any PR is
-      opened, so these are never handled autonomously.
+      Assign `actor/human` if the issue is `kind/api`. New Open Actions-owned
+      user-facing surfaces (CRD fields, controller flags, webhook contracts) must
+      be reviewed and discussed with a maintainer before any PR is opened, so
+      these are never handled autonomously. A concrete gap against documented
+      GitHub Actions workflow behavior is `kind/bug` and may be assigned to
+      `actor/kelos` when the criteria below are satisfied.
 
       Otherwise, assign `actor/kelos` if ALL of these are true:
         - The issue describes a concrete code change, documentation fix, test improvement,


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Aligns every Open Actions TaskSpawner with the project's goal of full behavioral compatibility with official GitHub Actions.

- Treats the official GitHub Actions documentation as the normative specification for workflow syntax and behavior
- Directs planners and reviewers to cite and test documented behavior
- Classifies documented compatibility gaps as bugs rather than optional features
- Separates concrete workflow reproduction from broad compatibility-roadmap planning
- Synchronizes the Open Actions self-development README with the TaskSpawner contracts

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Review feedback addressed:

- Updated the README's product framing, role descriptions, and triage behavior
- Gave fake-user ownership of concrete workflow reproduction and fake-strategist ownership of roadmap, architecture, and adoption analysis

Validation: `make verify`

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
