### PR TITLE
Redesign console with responsive chat UI

### DIFF
--- a/internal/consoleserver/frontend/app.ts
+++ b/internal/consoleserver/frontend/app.ts
@@ -337,6 +337,7 @@ const elements = requireElements({
   saveDisplayNameButton: document.querySelector('#save-session-display-name'),
   sessionActionsMenu: document.querySelector('#session-actions-menu'),
   sessionActionRename: document.querySelector('#session-action-rename'),
+  sessionActionSection: document.querySelector('#session-action-section'),
   sessionActionLifecycle: document.querySelector('#session-action-lifecycle'),
   sessionActionReset: document.querySelector('#session-action-reset'),
   sessionActionDelete: document.querySelector('#session-action-delete'),
@@ -382,6 +383,7 @@ const elements = requireElements({
   sectionChoice: document.querySelector('#session-section-choice'),
   sectionChoiceCustom: document.querySelector('#session-section-choice-custom'),
   saveSectionButton: document.querySelector('#save-session-section'),
+  cancelSectionButton: document.querySelector('#cancel-session-section'),
   messages: document.querySelector('#messages'),
   changes: document.querySelector('#changes-view'),
   changesList: document.querySelector('#changes-list'),
@@ -2577,6 +2579,7 @@ async function loadSessionSource(name: string) {
 
 function selectSession(session: SessionSummary | null, resumeIdle = false) {
   savePromptDraft(state.selected);
+  closeSessionSectionEditor();
   closeSocket();
   saveCurrentSessionView();
   state.selected = session;
@@ -4769,6 +4772,7 @@ async function openDialog() {
     showToast(errorMessage(error));
     return;
   }
+  setConsoleView('sessions');
   elements.dialogError.textContent = '';
   setCreationMode(state.creationMode);
   elements.dialog.showModal();
@@ -4994,6 +4998,17 @@ function updateSelectedSectionField() {
   elements.saveSectionButton.hidden = elements.sectionChoiceCustom.hidden;
 }
 
+function closeSessionSectionEditor() {
+  elements.sectionForm.classList.remove('mobile-open');
+}
+
+function openSessionSectionEditor(session: SessionSummary) {
+  closeSessionActionsMenu();
+  if (!state.selected || sessionKey(state.selected) !== sessionKey(session)) selectSession(session);
+  elements.sectionForm.classList.add('mobile-open');
+  elements.sectionChoice.focus();
+}
+
 function renderSelectedSessionSection(session: SessionSummary | null, preserveEditing = true) {
   elements.sectionForm.hidden = !session;
   if (!session) {
@@ -5033,6 +5048,7 @@ async function saveSelectedSessionSection(section: string) {
   if (!session || state.sectionSaving) return;
   if (section === (session.section || '')) {
     renderSelectedSessionSection(session, false);
+    closeSessionSectionEditor();
     return;
   }
 
@@ -5043,6 +5059,7 @@ async function saveSelectedSessionSection(section: string) {
     if (state.selected && sessionKey(state.selected) === sessionKey(session)) {
       renderSelectedSessionSection(state.selected, false);
     }
+    closeSessionSectionEditor();
     showToast(section ? `Moved Session to ${section}` : 'Moved Session to Unsectioned');
   } catch (error) {
     if (!creating && state.selected && sessionKey(state.selected) === sessionKey(session)) {
@@ -5065,6 +5082,7 @@ elements.sectionChoice.addEventListener('change', () => {
 elements.sectionChoiceCustom.addEventListener('input', () => {
   validateCustomSectionField(elements.sectionChoice, elements.sectionChoiceCustom);
 });
+elements.cancelSectionButton.addEventListener('click', closeSessionSectionEditor);
 
 elements.sectionForm.addEventListener('submit', async event => {
   event.preventDefault();
@@ -5117,6 +5135,10 @@ elements.sessionActionRename.addEventListener('click', () => {
   const session = sessionActionsTarget();
   closeSessionActionsMenu();
   openDisplayNameDialog(session);
+});
+elements.sessionActionSection.addEventListener('click', () => {
+  const session = sessionActionsTarget();
+  if (session) openSessionSectionEditor(session);
 });
 elements.sessionActionLifecycle.addEventListener('click', event => {
   void runSessionMenuAction(event, toggleSessionSuspension);

--- a/internal/consoleserver/server_test.go
+++ b/internal/consoleserver/server_test.go
@@ -952,8 +952,8 @@ func TestApplicationRendersMarkdownSafely(t *testing.T) {
 		`.message-bubble .code-copy-button {`,
 		`.message-bubble pre {`,
 		`overflow-x: auto`,
-		`--code-bg:#0d1410`,
-		`--code-ink:#e3ebe5`,
+		`--code-bg:#171717`,
+		`--code-ink:#ececec`,
 	} {
 		if !strings.Contains(string(styles), expected) {
 			t.Errorf("Markdown rendering styles do not contain %q", expected)
@@ -1517,24 +1517,25 @@ func TestSessionUIAdaptsToPhoneViewport(t *testing.T) {
 		}
 	}
 	for description, expected := range map[string]string{
-		"dynamic viewport height":      `height: 100dvh`,
-		"desktop sidebar width":        `grid-template-columns: 286px minmax(0, 1fr)`,
-		"landscape phone breakpoint":   `(max-height: 500px) and (pointer: coarse)`,
-		"phone sidebar width":          `width: min(86vw, 310px)`,
-		"single-row phone navigation":  `grid-template-columns: repeat(3, minmax(0, 1fr))`,
-		"compact phone session row":    `.session-item-select { min-height: 60px; padding: 7px 48px 7px 8px; }`,
-		"phone create touch target":    `.new-session-button { min-height: 44px; padding: 6px 10px; }`,
-		"section reorder touch target": `.session-section-order-button { width: 44px; height: 44px; }`,
-		"two-row phone header":         `grid-template-areas: "menu heading reset delete" "tabs tabs connection connection"`,
-		"phone lifecycle action slot":  `.conversation-header:has(.session-lifecycle-action:not([hidden])) { grid-template-areas: "menu heading lifecycle reset delete"`,
-		"48-pixel touch targets":       `.icon-button { width: 48px; height: 48px; }`,
-		"Session action touch target":  `.session-item-actions { top: 5px; right: 1px; width: 44px; height: 44px; }`,
-		"phone safe-area padding":      `env(safe-area-inset-bottom)`,
-		"non-zooming form fields":      `.composer textarea, .pending-message-input, .yaml-panel textarea, .form-grid input`,
-		"desktop composer alignment":   `.composer textarea { flex: 1; min-height: 36px;`,
-		"mobile composer alignment":    `.composer textarea { min-height: 48px; padding: 12px 0; line-height: 24px; }`,
-		"phone-sized dialog":           `max-height: calc(100dvh - 16px`,
-		"shrinking composer content":   `.composer-wrap { min-width: 0;`,
+		"dynamic viewport height":            `height: 100dvh`,
+		"desktop sidebar width":              `grid-template-columns: 260px minmax(0, 1fr)`,
+		"landscape phone breakpoint":         `(max-height: 500px) and (pointer: coarse)`,
+		"phone sidebar width":                `width: min(88vw, 320px)`,
+		"phone navigation touch target":      `.console-nav button { min-height: 44px; padding: 8px 10px; font-size: 14px; }`,
+		"compact phone session row":          `.session-item-select { min-height: 60px; padding: 7px 48px 7px 8px; }`,
+		"phone create touch target":          `.new-session-button { min-height: 44px; margin-top: 4px; padding: 8px 10px; }`,
+		"section reorder touch target":       `.session-section-order-button { width: 44px; height: 44px; }`,
+		"single-row phone header":            `grid-template-areas: "menu heading actions"`,
+		"phone lifecycle actions in sidebar": `.session-lifecycle-action, #reset-session, #delete-session { display: none !important; }`,
+		"44-pixel touch targets":             `.icon-button { width: 44px; height: 44px; }`,
+		"44-pixel view tabs":                 `.view-tabs button { min-height: 44px; padding: 5px 8px; }`,
+		"Session action touch target":        `.session-item-actions { top: 5px; right: 1px; width: 44px; height: 44px; }`,
+		"phone safe-area padding":            `env(safe-area-inset-bottom)`,
+		"non-zooming form fields":            `.composer textarea, .pending-message-input, .yaml-panel textarea, .form-grid input`,
+		"desktop composer alignment":         `.composer textarea { flex: 1; min-height: 36px;`,
+		"mobile composer alignment":          `.composer textarea { min-height: 44px; padding: 10px 2px; line-height: 24px; }`,
+		"phone-sized dialog":                 `max-height: calc(100dvh - 16px`,
+		"shrinking composer content":         `z-index: 2; min-width: 0;`,
 	} {
 		if !strings.Contains(string(styles), expected) {
 			t.Errorf("Session styles are missing %s: %s", description, expected)
@@ -2222,6 +2223,8 @@ func TestSessionUISections(t *testing.T) {
 		"selected Session section control":       `id="session-section-form"`,
 		"selected Session section chooser":       `id="session-section-choice" aria-label="Section"`,
 		"selected Session new section field":     `id="session-section-choice-custom" maxlength="64"`,
+		"selected Session section menu action":   `id="session-action-section" type="button" role="menuitem"`,
+		"selected Session section editor close":  `id="cancel-session-section" type="button"`,
 		"new Session section chooser":            `name="section" id="session-section-select"`,
 		"new Session new section creation field": `name="sectionCustom" id="session-section-custom" maxlength="64"`,
 	} {
@@ -2242,6 +2245,7 @@ func TestSessionUISections(t *testing.T) {
 		"unsectioned ordering":  "if (!available.includes(''))\n            available.push('');",
 		"browser order storage": `window.localStorage.setItem(sectionOrderStorageKey(namespace), JSON.stringify(normalized));`,
 		"order focus restore":   "if (focusDirection)\n            focusSectionOrderControl(section, focusDirection);",
+		"mobile section editor": `function openSessionSectionEditor(session)`,
 	} {
 		if !strings.Contains(string(javascript), expected) {
 			t.Errorf("Session behavior is missing %s: %s", description, expected)
@@ -2255,6 +2259,7 @@ func TestSessionUISections(t *testing.T) {
 	for description, expected := range map[string]string{
 		"section headings":       `.session-section-heading {`,
 		"inline section control": `.session-section-control {`,
+		"mobile section control": `.session-section-control.mobile-open {`,
 		"Session drop target":    `.session-section-group.session-drop-target {`,
 		"section order controls": `.session-section-order-button { width: 28px; height: 28px;`,
 	} {

--- a/internal/consoleserver/testdata/section_chooser_test.js
+++ b/internal/consoleserver/testdata/section_chooser_test.js
@@ -20,6 +20,12 @@ class TestNode {
     this._value = '';
     this._text = '';
     this.validationMessage = '';
+    this.classes = new Set();
+    this.classList = {
+      add: (...names) => names.forEach(name => this.classes.add(name)),
+      remove: (...names) => names.forEach(name => this.classes.delete(name)),
+      contains: name => this.classes.has(name),
+    };
   }
 
   append(...nodes) {
@@ -162,6 +168,7 @@ function resetHarness() {
     sectionChoiceCustom: new TestNode('input'),
     sectionForm: new TestNode('form'),
     saveSectionButton: new TestNode('button'),
+    cancelSectionButton: new TestNode('button'),
   };
   elements.sectionForm.reportValidity = () => true;
   global.state = {

--- a/internal/consoleserver/testdata/session_actions_test.js
+++ b/internal/consoleserver/testdata/session_actions_test.js
@@ -77,7 +77,11 @@ class TestNode {
   }
 
   get classList() {
-    return {add: (...names) => names.forEach(name => this.classes.add(name))};
+    return {
+      add: (...names) => names.forEach(name => this.classes.add(name)),
+      remove: (...names) => names.forEach(name => this.classes.delete(name)),
+      contains: name => this.classes.has(name),
+    };
   }
 
   set textContent(value) {
@@ -117,6 +121,7 @@ vm.runInThisContext(applicationSlice('function errorMessage', 'function requireE
 vm.runInThisContext(applicationSlice('function sessionKey', 'function sessionViewKey'), {filename: 'app.js'});
 vm.runInThisContext(applicationSlice('function createSessionListItem', 'function sectionLabel'), {filename: 'app.js'});
 vm.runInThisContext(applicationSlice('async function requestSessionLifecycleAction', 'function createWelcome'), {filename: 'app.js'});
+vm.runInThisContext(applicationSlice('function closeSessionSectionEditor', 'function renderSelectedSessionSection'), {filename: 'app.js'});
 vm.runInThisContext(applicationSlice('async function deleteSession', 'elements.resumeButton.addEventListener'), {filename: 'app.js'});
 
 global.sessionDisplayStatus = () => 'Ready';
@@ -131,11 +136,14 @@ function resetHarness() {
     list: new TestNode('div'),
     sessionActionsMenu: new TestNode('div', {top: 0, right: 0, bottom: 0, width: 176, height: 160}),
     sessionActionRename: new TestNode('button'),
+    sessionActionSection: new TestNode('button'),
     sessionActionLifecycle: new TestNode('button'),
     sessionActionReset: new TestNode('button'),
+    sectionForm: new TestNode('form'),
+    sectionChoice: new TestNode('select'),
     newSessionButton: new TestNode('button'),
   };
-  elements.sessionActionsMenu.append(elements.sessionActionRename, elements.sessionActionLifecycle, elements.sessionActionReset);
+  elements.sessionActionsMenu.append(elements.sessionActionRename, elements.sessionActionSection, elements.sessionActionLifecycle, elements.sessionActionReset);
   elements.sessionActionsMenu.hidden = true;
   document.activeElement = null;
   global.state = {
@@ -410,13 +418,37 @@ async function testTouchActionRunsBeforeMenuCloses() {
   assert.equal(elements.sessionActionsMenu.hidden, true);
 }
 
+function testSectionActionOpensTouchEditorForTargetSession() {
+  resetHarness();
+  const selected = {namespace: 'default', name: 'selected', provider: 'codex'};
+  const target = {namespace: 'team-a', name: 'target', provider: 'codex'};
+  state.sessions = [selected, target];
+  state.selected = selected;
+  state.sessionActionKey = sessionKey(target);
+  state.sessionActionTrigger = new TestNode('button');
+  elements.sessionActionsMenu.hidden = false;
+  global.selectSession = session => { state.selected = session; };
+
+  openSessionSectionEditor(target);
+
+  assert.equal(state.selected, target);
+  assert.equal(elements.sessionActionsMenu.hidden, true);
+  assert.equal(elements.sectionForm.classList.contains('mobile-open'), true);
+  assert.equal(document.activeElement, elements.sectionChoice);
+
+  closeSessionSectionEditor();
+  assert.equal(elements.sectionForm.classList.contains('mobile-open'), false);
+}
+
 assert.match(index, /id="session-actions-menu" role="menu"/);
 assert.match(index, /id="session-action-rename"[^>]+role="menuitem"/);
+assert.match(index, /id="session-action-section"[^>]+role="menuitem"/);
 assert.match(index, /id="session-action-lifecycle"[^>]+role="menuitem"/);
 assert.match(index, /id="session-action-reset"[^>]+role="menuitem"/);
 assert.match(index, /id="session-action-delete"[^>]+role="menuitem"/);
 assert.match(styles, /\.session-actions-menu button:focus-visible \{[^}]*outline: 2px solid var\(--accent-2\)/);
 assert.match(application, /sessionActionLifecycle\.addEventListener\('click'/);
+assert.match(application, /sessionActionSection\.addEventListener\('click'/);
 assert.match(application, /sessionActionsMenu\.addEventListener\('focusout'/);
 
 testEverySessionRowHasActionsMenu()
@@ -432,5 +464,6 @@ testEverySessionRowHasActionsMenu()
   .then(() => testTouchActionRunsBeforeMenuCloses())
   .then(() => {
     testMenuClosesWhenFocusLeaves();
+    testSectionActionOpensTouchEditorForTargetSession();
     process.stdout.write('Session actions tests passed\n');
   });

--- a/internal/consoleserver/testdata/session_history_test.js
+++ b/internal/consoleserver/testdata/session_history_test.js
@@ -262,6 +262,7 @@ global.resolveInputCard = () => {};
 global.scrollToBottom = () => {};
 global.interruptActiveTurn = () => { interruptRequests++; };
 global.showToast = (message) => { toasts.push(message); };
+global.closeSessionSectionEditor = () => {};
 
 const application = fs.readFileSync(path.join(__dirname, '..', 'web', 'app.js'), 'utf8');
 

--- a/internal/consoleserver/web/app.js
+++ b/internal/consoleserver/web/app.js
@@ -29,6 +29,7 @@
         saveDisplayNameButton: document.querySelector('#save-session-display-name'),
         sessionActionsMenu: document.querySelector('#session-actions-menu'),
         sessionActionRename: document.querySelector('#session-action-rename'),
+        sessionActionSection: document.querySelector('#session-action-section'),
         sessionActionLifecycle: document.querySelector('#session-action-lifecycle'),
         sessionActionReset: document.querySelector('#session-action-reset'),
         sessionActionDelete: document.querySelector('#session-action-delete'),
@@ -74,6 +75,7 @@
         sectionChoice: document.querySelector('#session-section-choice'),
         sectionChoiceCustom: document.querySelector('#session-section-choice-custom'),
         saveSectionButton: document.querySelector('#save-session-section'),
+        cancelSectionButton: document.querySelector('#cancel-session-section'),
         messages: document.querySelector('#messages'),
         changes: document.querySelector('#changes-view'),
         changesList: document.querySelector('#changes-list'),
@@ -2263,6 +2265,7 @@ spec:
     }
     function selectSession(session, resumeIdle = false) {
         savePromptDraft(state.selected);
+        closeSessionSectionEditor();
         closeSocket();
         saveCurrentSessionView();
         state.selected = session;
@@ -4466,6 +4469,7 @@ spec:
             showToast(errorMessage(error));
             return;
         }
+        setConsoleView('sessions');
         elements.dialogError.textContent = '';
         setCreationMode(state.creationMode);
         elements.dialog.showModal();
@@ -4699,6 +4703,16 @@ spec:
         updateCustomSectionField(elements.sectionChoice, elements.sectionChoiceCustom);
         elements.saveSectionButton.hidden = elements.sectionChoiceCustom.hidden;
     }
+    function closeSessionSectionEditor() {
+        elements.sectionForm.classList.remove('mobile-open');
+    }
+    function openSessionSectionEditor(session) {
+        closeSessionActionsMenu();
+        if (!state.selected || sessionKey(state.selected) !== sessionKey(session))
+            selectSession(session);
+        elements.sectionForm.classList.add('mobile-open');
+        elements.sectionChoice.focus();
+    }
     function renderSelectedSessionSection(session, preserveEditing = true) {
         elements.sectionForm.hidden = !session;
         if (!session) {
@@ -4736,6 +4750,7 @@ spec:
             return;
         if (section === (session.section || '')) {
             renderSelectedSessionSection(session, false);
+            closeSessionSectionEditor();
             return;
         }
         const creating = createsNewSection(elements.sectionChoice);
@@ -4745,6 +4760,7 @@ spec:
             if (state.selected && sessionKey(state.selected) === sessionKey(session)) {
                 renderSelectedSessionSection(state.selected, false);
             }
+            closeSessionSectionEditor();
             showToast(section ? `Moved Session to ${section}` : 'Moved Session to Unsectioned');
         }
         catch (error) {
@@ -4768,6 +4784,7 @@ spec:
     elements.sectionChoiceCustom.addEventListener('input', () => {
         validateCustomSectionField(elements.sectionChoice, elements.sectionChoiceCustom);
     });
+    elements.cancelSectionButton.addEventListener('click', closeSessionSectionEditor);
     elements.sectionForm.addEventListener('submit', async (event) => {
         event.preventDefault();
         if (state.sectionSaving || !createsNewSection(elements.sectionChoice))
@@ -4823,6 +4840,11 @@ spec:
         const session = sessionActionsTarget();
         closeSessionActionsMenu();
         openDisplayNameDialog(session);
+    });
+    elements.sessionActionSection.addEventListener('click', () => {
+        const session = sessionActionsTarget();
+        if (session)
+            openSessionSectionEditor(session);
     });
     elements.sessionActionLifecycle.addEventListener('click', event => {
         void runSessionMenuAction(event, toggleSessionSuspension);

--- a/internal/consoleserver/web/index.html
+++ b/internal/consoleserver/web/index.html
@@ -14,10 +14,13 @@
         <div class="brand-mark" aria-hidden="true">K</div>
         <div>
           <div class="brand">Kelos</div>
-          <div class="brand-subtitle">Console</div>
+          <div class="brand-subtitle">AI workspace</div>
         </div>
         <button class="icon-button mobile-only" id="close-sidebar" aria-label="Close navigation">×</button>
       </div>
+      <button class="new-session-button" id="new-session" type="button">
+        <span aria-hidden="true">＋</span> New session
+      </button>
       <form class="namespace-form" id="namespace-form">
         <label for="active-namespace">Namespace</label>
         <div>
@@ -33,9 +36,6 @@
       <div class="session-sidebar" id="session-sidebar" hidden>
         <div class="session-sidebar-header">
           <div class="sidebar-label">Conversations</div>
-          <button class="new-session-button" id="new-session" type="button">
-            <span aria-hidden="true">＋</span> New session
-          </button>
         </div>
         <div class="session-list" id="session-list" aria-live="polite"></div>
       </div>
@@ -50,7 +50,6 @@
       <header class="console-page-header">
         <button class="icon-button mobile-only open-sidebar-button" type="button" aria-label="Open navigation" aria-controls="sidebar" aria-expanded="false">☰</button>
         <div>
-          <div class="console-eyebrow">Kelos Console</div>
           <h1>Overview</h1>
           <p>Resources in <span class="console-namespace">default</span></p>
         </div>
@@ -73,7 +72,6 @@
       <header class="console-page-header">
         <button class="icon-button mobile-only open-sidebar-button" type="button" aria-label="Open navigation" aria-controls="sidebar" aria-expanded="false">☰</button>
         <div>
-          <div class="console-eyebrow">Kelos Console</div>
           <h1>Resources</h1>
           <p>Inspect Kelos manifests in <span class="console-namespace">default</span></p>
         </div>
@@ -153,6 +151,7 @@
             </select>
             <input id="session-section-choice-custom" maxlength="64" placeholder="New section name" aria-label="New section name" autocomplete="off" hidden>
             <button id="save-session-section" type="submit" hidden>Add</button>
+            <button class="session-section-cancel" id="cancel-session-section" type="button" aria-label="Close section editor">×</button>
           </form>
         </div>
         <div class="header-actions">
@@ -171,8 +170,8 @@
       <section class="messages" id="messages" role="tabpanel" aria-labelledby="conversation-tab" aria-live="polite">
         <div class="welcome" id="welcome">
           <div class="welcome-orbit"><span>K</span></div>
-          <h1>A workspace that keeps the thread</h1>
-          <p>Start with Claude Code, Codex, or OpenCode, then continue the same conversation here or from your terminal.</p>
+          <h1>What should we work on?</h1>
+          <p>Start an agent session, keep the full thread, and continue the same conversation here or from your terminal.</p>
           <button class="primary-button" id="welcome-new">Create your first session</button>
         </div>
       </section>
@@ -405,6 +404,7 @@
 
   <div class="session-actions-menu" id="session-actions-menu" role="menu" hidden>
     <button id="session-action-rename" type="button" role="menuitem">Rename</button>
+    <button id="session-action-section" type="button" role="menuitem">Move to section…</button>
     <button id="session-action-lifecycle" type="button" role="menuitem">Suspend</button>
     <button id="session-action-reset" type="button" role="menuitem">Reset</button>
     <div class="session-actions-separator" role="separator"></div>

--- a/internal/consoleserver/web/login.css
+++ b/internal/consoleserver/web/login.css
@@ -1,8 +1,8 @@
 :root {
   color-scheme: light;
-  font-family: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  color: #18201d;
-  background: #f2f4ee;
+  font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #0d0d0d;
+  background: #fff;
 }
 
 * { box-sizing: border-box; }
@@ -15,56 +15,43 @@ body { margin: 0; min-height: 100vh; min-height: 100dvh; }
   display: grid;
   place-items: center;
   padding: calc(32px + env(safe-area-inset-top)) calc(20px + env(safe-area-inset-right)) calc(32px + env(safe-area-inset-bottom)) calc(20px + env(safe-area-inset-left));
-  overflow: hidden;
-  position: relative;
-  background:
-    radial-gradient(circle at 12% 14%, rgba(89, 126, 106, .13), transparent 28%),
-    linear-gradient(145deg, #f8f8f3 0%, #eef1e8 100%);
+  overflow-y: auto;
+  background: #fff;
 }
 
 .login-card {
-  position: relative;
-  z-index: 2;
-  width: min(100%, 440px);
-  padding: 44px;
-  border: 1px solid rgba(31, 54, 43, .12);
-  border-radius: 28px;
-  background: rgba(255, 255, 252, .9);
-  box-shadow: 0 28px 80px rgba(32, 48, 40, .13), inset 0 1px rgba(255, 255, 255, .8);
-  backdrop-filter: blur(18px);
+  width: min(100%, 400px);
+  padding: 32px;
 }
 
 .brand-mark {
-  width: 46px;
-  height: 46px;
+  width: 40px;
+  height: 40px;
   display: grid;
   place-items: center;
-  border-radius: 15px;
+  margin: 0 auto;
+  border-radius: 50%;
   color: white;
-  font: 700 21px/1 ui-monospace, SFMono-Regular, Menlo, monospace;
-  background: #173d2d;
-  box-shadow: 0 10px 24px rgba(23, 61, 45, .25);
+  font: 700 17px/1 ui-monospace, SFMono-Regular, Menlo, monospace;
+  background: #0d0d0d;
 }
 
-.eyebrow { margin: 30px 0 10px; color: #668073; font-size: 11px; font-weight: 750; letter-spacing: .16em; }
-h1 { margin: 0; font-family: Georgia, "Times New Roman", serif; font-size: clamp(34px, 7vw, 47px); font-weight: 500; line-height: 1.04; letter-spacing: -.035em; }
-.intro { margin: 18px 0 31px; color: #66706b; font-size: 15px; line-height: 1.6; }
-label { display: block; margin-bottom: 9px; color: #38443e; font-size: 13px; font-weight: 650; }
-.token-field { display: flex; border: 1px solid #ccd3cd; border-radius: 13px; background: #fff; transition: border-color .2s, box-shadow .2s; }
-.token-field:focus-within { border-color: #387258; box-shadow: 0 0 0 4px rgba(56, 114, 88, .11); }
-input { min-width: 0; flex: 1; padding: 14px 15px; border: 0; outline: 0; border-radius: inherit; background: transparent; color: #17201c; font: inherit; }
-.token-field button { border: 0; padding: 0 14px; background: transparent; color: #617068; font: 650 12px/1 inherit; cursor: pointer; }
-.error { min-height: 22px; padding-top: 7px; color: #a93636; font-size: 12px; }
-.sign-in { width: 100%; margin-top: 8px; padding: 14px 18px; border: 0; border-radius: 13px; background: #173d2d; color: white; font: 700 14px/1 inherit; cursor: pointer; box-shadow: 0 9px 24px rgba(23, 61, 45, .19); transition: transform .15s, background .15s; }
-.sign-in:hover { background: #214d39; transform: translateY(-1px); }
+.eyebrow { margin: 24px 0 8px; color: #6b6b6b; font-size: 12px; font-weight: 600; text-align: center; }
+h1 { margin: 0; font-size: clamp(28px, 7vw, 34px); font-weight: 600; line-height: 1.15; letter-spacing: -.035em; text-align: center; }
+.intro { margin: 14px 0 30px; color: #6b6b6b; font-size: 14px; line-height: 1.55; text-align: center; }
+label { display: block; margin-bottom: 9px; color: #333; font-size: 13px; font-weight: 600; }
+.token-field { display: flex; border: 1px solid #c7c7c7; border-radius: 10px; background: #fff; transition: border-color .2s, box-shadow .2s; }
+.token-field:focus-within { border-color: #0d0d0d; box-shadow: 0 0 0 1px #0d0d0d; }
+input { min-width: 0; flex: 1; padding: 14px 15px; border: 0; outline: 0; border-radius: inherit; background: transparent; color: #0d0d0d; font: inherit; }
+.token-field button { border: 0; padding: 0 14px; background: transparent; color: #6b6b6b; font: 600 12px/1 inherit; cursor: pointer; }
+.error { min-height: 22px; padding-top: 7px; color: #c2413a; font-size: 12px; }
+.sign-in { width: 100%; margin-top: 8px; padding: 14px 18px; border: 0; border-radius: 999px; background: #0d0d0d; color: white; font: 600 14px/1 inherit; cursor: pointer; transition: background .15s; }
+.sign-in:hover { background: #333; }
 .sign-in:disabled { opacity: .65; transform: none; cursor: wait; }
-.footnote { margin: 25px 0 0; padding-top: 21px; border-top: 1px solid #e5e8e3; color: #839087; font-size: 12px; line-height: 1.5; }
-.ambient { position: absolute; border-radius: 999px; filter: blur(2px); opacity: .65; }
-.ambient-one { width: 350px; height: 350px; left: -120px; bottom: -150px; background: rgba(189, 207, 188, .45); }
-.ambient-two { width: 260px; height: 260px; right: -85px; top: -95px; background: rgba(225, 208, 165, .36); }
-
+.footnote { margin: 25px 0 0; padding-top: 21px; border-top: 1px solid #e5e5e5; color: #8f8f8f; font-size: 12px; line-height: 1.5; text-align: center; }
 @media (max-width: 520px) {
-  .login-card { padding: 34px 25px; border-radius: 22px; }
+  .login-shell { place-items: start center; }
+  .login-card { padding: max(40px, 10vh) 20px 28px; }
 }
 
 @media (max-height: 620px) {
@@ -75,12 +62,15 @@ input { min-width: 0; flex: 1; padding: 14px 15px; border: 0; outline: 0; border
 }
 
 @media (prefers-color-scheme: dark) {
-  :root { color: #eef4ef; background: #101713; }
-  .login-shell { background: radial-gradient(circle at 12% 14%, rgba(90, 146, 112, .17), transparent 30%), linear-gradient(145deg, #111814, #0b100d); }
-  .login-card { border-color: rgba(211, 228, 216, .11); background: rgba(22, 31, 26, .92); box-shadow: 0 28px 80px rgba(0,0,0,.35); }
-  .intro, .footnote { color: #9ba9a0; }
-  label { color: #cbd5ce; }
-  .token-field { border-color: #3a4840; background: #101713; }
-  input { color: #f2f6f3; }
-  .footnote { border-color: #334039; }
+  :root { color: #ececec; background: #212121; }
+  .login-shell { background: #212121; }
+  .brand-mark, .sign-in { color: #171717; background: #ececec; }
+  .sign-in:hover { background: #d4d4d4; }
+  .eyebrow, .intro, .footnote { color: #a9a9a9; }
+  label { color: #dedede; }
+  .token-field { border-color: #555; background: #2f2f2f; }
+  .token-field button { color: #c5c5c5; }
+  .token-field:focus-within { border-color: #ececec; box-shadow: 0 0 0 1px #ececec; }
+  input { color: #ececec; }
+  .footnote { border-color: #383838; }
 }

--- a/internal/consoleserver/web/login.html
+++ b/internal/consoleserver/web/login.html
@@ -25,8 +25,6 @@
       </form>
       <p class="footnote">One token grants access to all Kelos resources visible to this server.</p>
     </section>
-    <div class="ambient ambient-one"></div>
-    <div class="ambient ambient-two"></div>
   </main>
   <script src="/public/login.js" defer></script>
 </body>

--- a/internal/consoleserver/web/styles.css
+++ b/internal/consoleserver/web/styles.css
@@ -1,18 +1,18 @@
 :root {
   color-scheme: light;
-  --ink: #1d2521;
-  --muted: #69766f;
-  --faint: #8b968f;
-  --line: #dde2dd;
-  --line-soft: #e9ece8;
-  --canvas: #f8f9f5;
-  --panel: #f0f2ec;
+  --ink: #0d0d0d;
+  --muted: #5d5d5d;
+  --faint: #8f8f8f;
+  --line: #e3e3e3;
+  --line-soft: #ececec;
+  --canvas: #ffffff;
+  --panel: #f9f9f9;
   --card: #ffffff;
-  --accent: #1d513b;
-  --accent-2: #337257;
-  --accent-soft: #e2eee7;
-  --danger: #a73f3f;
-  --warning: #a16922;
+  --accent: #0d0d0d;
+  --accent-2: #424242;
+  --accent-soft: #f2f2f2;
+  --danger: #c2413a;
+  --warning: #a66a16;
   --pr-open: #287a4b;
   --pr-merged: #8250df;
   --pr-closed: #ad4545;
@@ -20,11 +20,11 @@
   --diff-added-bg: #e7f3ea;
   --diff-removed: #9b3f3f;
   --diff-removed-bg: #f8e8e8;
-  --code-bg: #f1f4f1;
-  --code-border: #d5ddd7;
-  --code-ink: #243129;
-  --shadow: 0 18px 55px rgba(28, 45, 36, .09);
-  font-family: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --code-bg: #f7f7f7;
+  --code-border: #e3e3e3;
+  --code-ink: #181818;
+  --shadow: 0 8px 30px rgba(0, 0, 0, .08);
+  font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
 * { box-sizing: border-box; }
@@ -32,33 +32,34 @@ html, body { height: 100%; }
 body { margin: 0; overflow: hidden; color: var(--ink); background: var(--canvas); }
 button, input, select, textarea { font: inherit; }
 button { color: inherit; }
-.app-shell { height: 100%; height: 100dvh; display: grid; grid-template-columns: 286px minmax(0, 1fr); }
-.sidebar { position: relative; z-index: 5; min-height: 0; display: flex; flex-direction: column; padding: 20px 13px 11px; border-right: 1px solid var(--line); background: var(--panel); }
-.brand-row { display: flex; align-items: center; gap: 11px; padding: 0 5px; }
-.brand-mark { width: 37px; height: 37px; display: grid; place-items: center; border-radius: 12px; background: var(--accent); color: #fff; font: 700 17px/1 ui-monospace, SFMono-Regular, Menlo, monospace; box-shadow: 0 7px 16px rgba(29, 81, 59, .2); }
-.brand { font: 600 17px/1.05 Georgia, "Times New Roman", serif; letter-spacing: -.015em; }
-.brand-subtitle { margin-top: 4px; color: var(--muted); font-size: 11px; font-weight: 650; letter-spacing: .11em; text-transform: uppercase; }
-.new-session-button { min-height: 32px; display: flex; align-items: center; justify-content: center; gap: 5px; margin: 0; padding: 5px 9px; border: 1px solid #cbd4cd; border-radius: 9px; background: rgba(255,255,255,.7); font-size: 11px; font-weight: 700; cursor: pointer; transition: background .15s, transform .15s, box-shadow .15s; }
-.new-session-button:hover { background: #fff; transform: translateY(-1px); box-shadow: 0 7px 18px rgba(32,51,41,.08); }
-.namespace-form { margin: 18px 0 10px; padding: 0 3px; }
-.namespace-form label { display: block; margin: 0 5px 6px; color: var(--faint); font-size: 9px; font-weight: 800; letter-spacing: .11em; text-transform: uppercase; }
+.app-shell { height: 100%; height: 100dvh; display: grid; grid-template-columns: 260px minmax(0, 1fr); }
+.sidebar { position: relative; z-index: 5; min-height: 0; display: flex; flex-direction: column; padding: 10px 8px 8px; background: var(--panel); }
+.brand-row { min-height: 48px; display: flex; align-items: center; gap: 10px; padding: 4px 7px; }
+.brand-mark { width: 30px; height: 30px; display: grid; place-items: center; border-radius: 50%; background: var(--accent); color: #fff; font: 700 13px/1 ui-monospace, SFMono-Regular, Menlo, monospace; }
+.brand { font-size: 15px; font-weight: 650; letter-spacing: -.01em; }
+.brand-subtitle { margin-top: 1px; color: var(--muted); font-size: 11px; }
+.new-session-button { min-height: 40px; display: flex; align-items: center; justify-content: flex-start; gap: 9px; margin: 0; padding: 9px 10px; border: 0; border-radius: 9px; background: transparent; font-size: 13px; font-weight: 500; cursor: pointer; transition: background .15s; }
+.new-session-button:hover { background: var(--line-soft); }
+.new-session-button span { width: 20px; font-size: 18px; text-align: center; }
+.namespace-form { margin: 8px 0; padding: 0 3px; }
+.namespace-form label { display: block; margin: 0 7px 6px; color: var(--faint); font-size: 10px; font-weight: 600; }
 .namespace-form div { display: grid; grid-template-columns: minmax(0, 1fr) auto; }
-.namespace-form input { min-width: 0; padding: 8px 9px; border: 1px solid #cbd4cd; border-right: 0; border-radius: 9px 0 0 9px; outline: 0; background: var(--card); color: var(--ink); font-size: 11px; }
-.namespace-form input:focus { border-color: #779b88; box-shadow: 0 0 0 3px rgba(56,114,88,.08); }
-.namespace-form button { padding: 8px 9px; border: 1px solid #cbd4cd; border-radius: 0 9px 9px 0; background: var(--accent); color: white; font-size: 10px; font-weight: 700; cursor: pointer; }
-.console-nav { display: grid; gap: 3px; margin: 0 0 7px; padding-bottom: 8px; border-bottom: 1px solid var(--line); }
-.console-nav button { width: 100%; display: grid; grid-template-columns: 22px minmax(0, 1fr); align-items: center; gap: 7px; padding: 9px 10px; border: 0; border-radius: 9px; background: transparent; color: var(--muted); font-size: 12px; font-weight: 700; text-align: left; cursor: pointer; }
-.console-nav button:hover { background: rgba(255,255,255,.55); color: var(--ink); }
-.console-nav button[aria-current="page"] { background: var(--card); color: var(--ink); box-shadow: 0 4px 14px rgba(35,49,42,.06); }
-.console-nav button span { display: grid; place-items: center; color: var(--accent-2); font-size: 15px; }
+.namespace-form input { min-width: 0; padding: 8px 10px; border: 1px solid var(--line); border-right: 0; border-radius: 9px 0 0 9px; outline: 0; background: var(--card); color: var(--ink); font-size: 12px; }
+.namespace-form input:focus { border-color: #9b9b9b; box-shadow: 0 0 0 2px rgba(0,0,0,.05); }
+.namespace-form button { padding: 8px 10px; border: 1px solid var(--accent); border-radius: 0 9px 9px 0; background: var(--accent); color: white; font-size: 11px; font-weight: 600; cursor: pointer; }
+.console-nav { display: grid; gap: 2px; margin: 0 0 7px; padding-bottom: 7px; border-bottom: 1px solid var(--line); }
+.console-nav button { width: 100%; display: grid; grid-template-columns: 24px minmax(0, 1fr); align-items: center; gap: 8px; min-height: 40px; padding: 8px 10px; border: 0; border-radius: 9px; background: transparent; color: var(--ink); font-size: 13px; font-weight: 450; text-align: left; cursor: pointer; }
+.console-nav button:hover { background: var(--line-soft); }
+.console-nav button[aria-current="page"] { background: var(--line-soft); font-weight: 600; }
+.console-nav button span { display: grid; place-items: center; color: var(--ink); font-size: 17px; }
 .session-sidebar { flex: 1; min-height: 0; display: flex; flex-direction: column; }
 .session-sidebar[hidden] { display: none; }
-.session-sidebar-header { min-height: 38px; display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 2px 4px 4px 8px; }
-.sidebar-label { color: var(--faint); font-size: 10px; font-weight: 800; letter-spacing: .13em; text-transform: uppercase; }
+.session-sidebar-header { min-height: 42px; display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 2px 2px 4px 10px; }
+.sidebar-label { color: var(--muted); font-size: 12px; font-weight: 600; }
 .session-list { flex: 1; min-height: 0; overflow-y: auto; scrollbar-width: thin; }
 .session-section-group { position: relative; border-radius: 11px; transition: background .15s, outline-color .15s; }
 .session-section-group + .session-section-group { margin-top: 10px; }
-.session-section-heading { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin: 0; padding: 3px 8px 4px; color: var(--faint); font-size: 9px; font-weight: 800; letter-spacing: .1em; text-transform: uppercase; }
+.session-section-heading { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin: 0; padding: 6px 9px 4px; color: var(--faint); font-size: 11px; font-weight: 600; }
 .session-section-title { min-width: 0; display: flex; align-items: center; gap: 5px; overflow: hidden; cursor: grab; }
 .session-section-title:active { cursor: grabbing; }
 .session-section-title > span:last-child { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
@@ -74,9 +75,9 @@ button { color: inherit; }
 .session-section-group.section-drop-before::before { top: -8px; }
 .session-section-group.section-drop-after::after { bottom: -8px; }
 .session-section-group.dragging, .session-item.dragging { opacity: .45; }
-.session-item { position: relative; width: 100%; border-radius: 11px; background: transparent; transition: background .15s; }
-.session-item:hover { background: rgba(255,255,255,.55); }
-.session-item.active { background: #fff; box-shadow: 0 4px 14px rgba(35,49,42,.06); }
+.session-item { position: relative; width: 100%; border-radius: 9px; background: transparent; transition: background .15s; }
+.session-item:hover { background: var(--line-soft); }
+.session-item.active { background: var(--line-soft); }
 .session-item.section-saving { opacity: .55; }
 .session-item-select { width: 100%; display: grid; grid-template-columns: 9px minmax(0,1fr); gap: 8px; padding: 8px 38px 8px 8px; border: 0; background: transparent; text-align: left; cursor: pointer; }
 .session-item-select[draggable="true"] { cursor: grab; }
@@ -99,7 +100,7 @@ button { color: inherit; }
 .phase-dot.waiting-for-input { background: var(--danger); box-shadow: 0 0 0 3px rgba(167,63,63,.14); }
 .phase-dot.failed { background: #c55b5b; }
 .session-item-title-row { min-width: 0; display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: baseline; gap: 8px; }
-.session-item-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 13px; font-weight: 680; }
+.session-item-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 13px; font-weight: 500; }
 .session-item-time { color: var(--faint); font-size: 10px; font-variant-numeric: tabular-nums; white-space: nowrap; }
 .session-item-meta { display: flex; gap: 6px; margin-top: 3px; overflow: hidden; color: var(--faint); font-size: 10.5px; white-space: nowrap; }
 .session-item-namespace { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
@@ -120,35 +121,34 @@ button { color: inherit; }
 .provider-badge { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .session-model { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .sidebar-empty { padding: 14px 10px; color: var(--faint); font-size: 12px; line-height: 1.5; }
-.sidebar-footer { display: flex; justify-content: space-between; gap: 8px; padding: 9px 3px 0; border-top: 1px solid var(--line); }
+.sidebar-footer { display: flex; justify-content: space-between; gap: 8px; margin-top: auto; padding: 7px 3px 0; border-top: 1px solid var(--line); }
 .sidebar-scrim { display: none; }
-.quiet-button { padding: 7px 8px; border: 0; background: none; color: var(--muted); font-size: 11px; font-weight: 650; cursor: pointer; }
-.quiet-button:hover { color: var(--ink); }
+.quiet-button { min-height: 36px; padding: 7px 8px; border: 0; border-radius: 8px; background: none; color: var(--muted); font-size: 12px; font-weight: 500; cursor: pointer; }
+.quiet-button:hover { background: var(--line-soft); color: var(--ink); }
 .console-page { min-width: 0; min-height: 0; display: grid; grid-template-rows: auto minmax(0, 1fr); background: var(--canvas); }
 .console-page[hidden] { display: none; }
-.console-page-header { min-height: 105px; display: flex; align-items: center; gap: 14px; padding: 22px max(28px, calc((100% - 1120px) / 2)); border-bottom: 1px solid var(--line-soft); background: rgba(248,249,245,.88); backdrop-filter: blur(15px); }
-.console-page-header h1 { margin: 2px 0 0; font: 600 29px/1.15 Georgia,"Times New Roman",serif; letter-spacing: -.02em; }
-.console-page-header p { margin: 6px 0 0; color: var(--muted); font-size: 11px; }
-.console-eyebrow { color: var(--accent-2); font-size: 9px; font-weight: 800; letter-spacing: .13em; text-transform: uppercase; }
-.console-page-body { min-height: 0; overflow-y: auto; padding: 28px max(28px, calc((100% - 1120px) / 2)) 48px; }
-.resource-summary-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(170px, 1fr)); gap: 12px; }
-.resource-summary-card { min-width: 0; display: grid; gap: 11px; padding: 16px; border: 1px solid var(--line); border-radius: 14px; background: var(--card); box-shadow: 0 4px 14px rgba(31,46,38,.035); text-align: left; cursor: pointer; }
-.resource-summary-card:hover { border-color: #bfc9c1; transform: translateY(-1px); box-shadow: 0 8px 22px rgba(31,46,38,.07); }
-.resource-summary-card span { overflow: hidden; color: var(--muted); font-size: 11px; font-weight: 700; text-overflow: ellipsis; white-space: nowrap; }
-.resource-summary-card strong { font: 600 30px/1 Georgia,"Times New Roman",serif; }
+.console-page-header { min-height: 76px; display: flex; align-items: center; gap: 14px; padding: 14px max(24px, calc((100% - 1080px) / 2)); background: color-mix(in srgb, var(--canvas) 92%, transparent); backdrop-filter: blur(12px); }
+.console-page-header h1 { margin: 1px 0 0; font-size: 22px; font-weight: 600; line-height: 1.25; letter-spacing: -.02em; }
+.console-page-header p { margin: 3px 0 0; color: var(--muted); font-size: 12px; }
+.console-page-body { min-height: 0; overflow-y: auto; padding: 24px max(24px, calc((100% - 1080px) / 2)) 48px; }
+.resource-summary-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(170px, 1fr)); gap: 10px; }
+.resource-summary-card { min-width: 0; display: grid; gap: 10px; padding: 17px; border: 1px solid var(--line); border-radius: 12px; background: var(--card); text-align: left; cursor: pointer; transition: background .15s, border-color .15s; }
+.resource-summary-card:hover { border-color: #c9c9c9; background: var(--panel); }
+.resource-summary-card span { overflow: hidden; color: var(--muted); font-size: 12px; font-weight: 500; text-overflow: ellipsis; white-space: nowrap; }
+.resource-summary-card strong { font-size: 28px; font-weight: 600; line-height: 1; }
 .console-section { margin-top: 30px; }
 .console-section-heading { display: flex; align-items: flex-end; justify-content: space-between; gap: 20px; margin-bottom: 13px; }
-.console-section-heading h2 { margin: 0; font: 600 21px/1.2 Georgia,"Times New Roman",serif; }
-.console-section-heading p { margin: 5px 0 0; color: var(--muted); font-size: 11px; }
+.console-section-heading h2 { margin: 0; font-size: 18px; font-weight: 600; line-height: 1.3; letter-spacing: -.01em; }
+.console-section-heading p { margin: 4px 0 0; color: var(--muted); font-size: 12px; }
 .resource-view-tabs { width: fit-content; margin-bottom: 22px; }
 .resource-diagram-panel[hidden], #resource-inventory-panel[hidden] { display: none; }
 .resource-diagram-heading { display: flex; align-items: flex-end; justify-content: space-between; gap: 18px; margin-bottom: 17px; }
-.resource-diagram-heading h2 { margin: 0; font: 600 21px/1.2 Georgia,"Times New Roman",serif; }
-.resource-diagram-heading p { margin: 5px 0 0; color: var(--muted); font-size: 11px; }
+.resource-diagram-heading h2 { margin: 0; font-size: 18px; font-weight: 600; line-height: 1.3; letter-spacing: -.01em; }
+.resource-diagram-heading p { margin: 4px 0 0; color: var(--muted); font-size: 12px; }
 .resource-relationship-focus { width: min(340px, 42%); display: grid; gap: 5px; color: var(--muted); font-size: 10px; font-weight: 700; }
 .resource-relationship-focus select { width: 100%; min-width: 0; padding: 9px 11px; border: 1px solid var(--line); border-radius: 9px; outline: 0; background: var(--card); color: var(--ink); font-size: 12px; }
-.resource-relationship-focus select:focus { border-color: #779b88; box-shadow: 0 0 0 3px rgba(56,114,88,.08); }
-.resource-diagram { min-width: 0; min-height: 360px; padding: 26px; overflow-x: auto; border: 1px solid var(--line); border-radius: 16px; background-color: var(--card); background-image: radial-gradient(var(--line-soft) .8px, transparent .8px); background-size: 17px 17px; box-shadow: 0 4px 14px rgba(31,46,38,.035); }
+.resource-relationship-focus select:focus { border-color: #9b9b9b; box-shadow: 0 0 0 3px rgba(0,0,0,.06); }
+.resource-diagram { min-width: 0; min-height: 360px; padding: 26px; overflow-x: auto; border: 1px solid var(--line); border-radius: 12px; background-color: var(--card); background-image: radial-gradient(var(--line-soft) .8px, transparent .8px); background-size: 17px 17px; }
 .resource-relationship-graph { min-width: 720px; display: grid; grid-template-columns: minmax(0, 1fr) minmax(180px, .72fr) minmax(0, 1fr); align-items: center; gap: 18px; }
 .resource-relationship-column, .resource-relationship-focus-node { min-width: 0; }
 .resource-relationship-column > h3, .resource-relationship-focus-node > h3 { margin: 0 0 10px; color: var(--faint); font-size: 8.5px; font-weight: 800; letter-spacing: .11em; text-align: center; text-transform: uppercase; }
@@ -176,7 +176,7 @@ button { color: inherit; }
 .resource-relationship-connector::before { position: absolute; right: 4px; left: 4px; border-top: 1px solid currentColor; content: ''; }
 .resource-relationship-connector[data-inferred="true"]::before { border-top-style: dashed; }
 .resource-relationship-connector span:first-child { position: relative; z-index: 1; max-width: 72px; overflow: hidden; padding: 2px 4px; border-radius: 999px; background: var(--card); color: var(--muted); font-size: 7.5px; font-weight: 750; text-overflow: ellipsis; white-space: nowrap; }
-.resource-relationship-connector span:last-child { position: absolute; right: 0; padding-left: 2px; background: var(--card); font: 17px/1 Georgia,"Times New Roman",serif; }
+.resource-relationship-connector span:last-child { position: absolute; right: 0; padding-left: 2px; background: var(--card); font-size: 17px; line-height: 1; }
 .resource-relationship-empty { min-height: 80px; display: grid; place-items: center; padding: 12px; border: 1px dashed var(--line); border-radius: 11px; color: var(--faint); font-size: 9px; text-align: center; }
 .resource-relationship-legend { display: flex; justify-content: flex-end; gap: 14px; margin-top: 9px; color: var(--faint); font-size: 8.5px; }
 .resource-relationship-legend span { display: flex; align-items: center; gap: 5px; }
@@ -184,7 +184,7 @@ button { color: inherit; }
 .resource-relationship-legend i[data-inferred="true"] { border-top-style: dashed; }
 .resource-mobile-kind { display: none; }
 .resource-browser { min-height: 0; display: grid; grid-template-columns: 220px minmax(0, 1fr); align-items: start; gap: 18px; }
-.resource-type-panel { overflow: hidden; border: 1px solid var(--line); border-radius: 14px; background: var(--card); box-shadow: 0 4px 14px rgba(31,46,38,.035); }
+.resource-type-panel { overflow: hidden; border: 1px solid var(--line); border-radius: 12px; background: var(--card); }
 .resource-type-panel-heading { display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 13px 14px; border-bottom: 1px solid var(--line); color: var(--faint); font-size: 9px; font-weight: 800; letter-spacing: .1em; text-transform: uppercase; }
 .resource-type-panel-heading span:last-child { min-width: 22px; padding: 3px 6px; border-radius: 999px; background: var(--line-soft); font-size: 8.5px; letter-spacing: 0; text-align: center; }
 .resource-type-list { padding: 7px; }
@@ -198,13 +198,13 @@ button { color: inherit; }
 .resource-inventory { min-width: 0; }
 .resource-inventory-heading { min-height: 58px; display: flex; align-items: flex-end; justify-content: space-between; gap: 18px; margin-bottom: 13px; }
 .resource-inventory-title-row { display: flex; align-items: center; gap: 8px; }
-.resource-inventory-title-row h2 { margin: 0; font: 600 21px/1.2 Georgia,"Times New Roman",serif; }
+.resource-inventory-title-row h2 { margin: 0; font-size: 18px; font-weight: 600; line-height: 1.3; letter-spacing: -.01em; }
 .resource-inventory-title-row > span { min-width: 22px; padding: 3px 7px; border-radius: 999px; background: var(--line-soft); color: var(--muted); font-size: 9px; font-weight: 750; text-align: center; }
 .resource-inventory-heading p { margin: 5px 0 0; color: var(--muted); font-size: 11px; }
 .resource-search { width: min(290px, 42%); display: grid; gap: 5px; color: var(--muted); font-size: 10px; font-weight: 700; }
 .resource-search input, .resource-mobile-kind select { width: 100%; min-width: 0; padding: 9px 11px; border: 1px solid var(--line); border-radius: 9px; outline: 0; background: var(--card); color: var(--ink); font-size: 12px; }
-.resource-search input:focus, .resource-mobile-kind select:focus { border-color: #779b88; box-shadow: 0 0 0 3px rgba(56,114,88,.08); }
-.resource-table-wrap { overflow: hidden; border: 1px solid var(--line); border-radius: 14px; background: var(--card); box-shadow: 0 4px 14px rgba(31,46,38,.035); }
+.resource-search input:focus, .resource-mobile-kind select:focus { border-color: #9b9b9b; box-shadow: 0 0 0 3px rgba(0,0,0,.06); }
+.resource-table-wrap { overflow: hidden; border: 1px solid var(--line); border-radius: 12px; background: var(--card); }
 .resource-table { width: 100%; border-collapse: collapse; table-layout: fixed; }
 .resource-table th { padding: 10px 13px; border-bottom: 1px solid var(--line); background: var(--panel); color: var(--faint); font-size: 9px; font-weight: 800; letter-spacing: .1em; text-align: left; text-transform: uppercase; }
 .resource-table th:nth-child(1) { width: 40%; }
@@ -225,15 +225,15 @@ button { color: inherit; }
 .resource-empty { min-height: 210px; display: grid; place-items: center; padding: 28px; color: var(--muted); font-size: 12px; text-align: center; }
 .conversation { min-width: 0; min-height: 0; display: grid; grid-template-rows: auto minmax(0, 1fr) auto; background: var(--canvas); }
 .conversation[hidden] { display: none; }
-.conversation-header { min-height: 74px; display: flex; align-items: center; gap: 13px; padding: 13px 23px; border-bottom: 1px solid var(--line-soft); background: rgba(248,249,245,.88); backdrop-filter: blur(15px); }
+.conversation-header { position: relative; z-index: 3; min-height: 60px; display: flex; align-items: center; gap: 12px; padding: 8px 16px; background: color-mix(in srgb, var(--canvas) 92%, transparent); backdrop-filter: blur(12px); }
 .session-heading { flex: 1; min-width: 0; }
 .session-title-row { display: flex; align-items: center; gap: 7px; }
-.session-title { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font: 600 17px/1.2 Georgia, "Times New Roman", serif; }
+.session-title { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 15px; font-weight: 600; line-height: 1.25; }
 .session-display-name-button { flex: none; padding: 2px 6px; border: 0; border-radius: 6px; background: transparent; color: var(--faint); font-size: 9px; font-weight: 700; cursor: pointer; }
 .session-display-name-button:hover { background: var(--line-soft); color: var(--ink); }
 .session-display-name-button:disabled { opacity: .45; cursor: default; }
 .session-display-name-button[hidden] { display: none; }
-.session-meta { display: flex; align-items: center; gap: 5px; overflow: hidden; margin-top: 5px; color: var(--muted); font-size: 11px; white-space: nowrap; }
+.session-meta { display: flex; align-items: center; gap: 5px; overflow: hidden; margin-top: 2px; color: var(--muted); font-size: 11px; white-space: nowrap; }
 .session-meta-details { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .session-meta-separator, .session-meta a, .session-meta-time { flex: none; }
 .session-meta-time { font-variant-numeric: tabular-nums; }
@@ -243,43 +243,44 @@ button { color: inherit; }
 .session-section-control[hidden] { display: none; }
 .session-section-control select, .session-section-control input { min-width: 0; max-width: 190px; padding: 3px 7px; border: 1px solid var(--line); border-radius: 999px; outline: none; background: var(--card); color: var(--muted); font: inherit; }
 .session-section-control input { width: 150px; }
-.session-section-control select:focus, .session-section-control input:focus { border-color: #779b88; box-shadow: 0 0 0 3px rgba(56,114,88,.08); color: var(--ink); }
+.session-section-control select:focus, .session-section-control input:focus { border-color: #9b9b9b; box-shadow: 0 0 0 3px rgba(0,0,0,.06); color: var(--ink); }
 .session-section-control button { padding: 3px 8px; border: 1px solid var(--accent); border-radius: 999px; background: var(--accent); color: white; font: inherit; cursor: pointer; }
+.session-section-control .session-section-cancel { display: none; }
 .session-section-control :disabled { opacity: .55; cursor: wait; }
 .header-actions { display: flex; align-items: center; gap: 8px; }
-.view-tabs { display: flex; padding: 3px; border: 1px solid var(--line); border-radius: 10px; background: var(--panel); }
-.view-tabs button { padding: 6px 9px; border: 0; border-radius: 7px; background: transparent; color: var(--muted); font-size: 10.5px; font-weight: 700; cursor: pointer; }
-.view-tabs button[aria-selected="true"] { background: var(--card); color: var(--ink); box-shadow: 0 2px 7px rgba(31,46,38,.08); }
+.view-tabs { display: flex; padding: 2px; border-radius: 9px; background: var(--panel); }
+.view-tabs button { padding: 6px 9px; border: 0; border-radius: 7px; background: transparent; color: var(--muted); font-size: 11px; font-weight: 500; cursor: pointer; }
+.view-tabs button[aria-selected="true"] { background: var(--card); color: var(--ink); box-shadow: 0 1px 3px rgba(0,0,0,.08); }
 .view-tabs button:disabled { opacity: .45; cursor: default; }
 .view-tabs span { display: inline-grid; min-width: 17px; height: 17px; place-items: center; margin-left: 3px; padding: 0 4px; border-radius: 999px; background: var(--line-soft); font-size: 9px; }
-.connection-pill { display: inline-flex; align-items: center; gap: 7px; padding: 7px 10px; border: 1px solid var(--line); border-radius: 999px; background: var(--card); color: var(--muted); font-size: 10.5px; font-weight: 700; }
+.connection-pill { display: inline-flex; align-items: center; gap: 7px; padding: 7px 9px; border-radius: 999px; background: var(--panel); color: var(--muted); font-size: 10.5px; font-weight: 500; }
 .connection-pill span { width: 6px; height: 6px; border-radius: 50%; background: #9ba59f; }
 .connection-pill[data-state="connected"] span { background: #4b9a6f; box-shadow: 0 0 0 3px rgba(75,154,111,.12); }
 .connection-pill[data-state="connecting"] span { background: #c58a3e; animation: pulse 1.1s infinite; }
 .connection-pill[data-state="error"] span { background: #c45555; }
 @keyframes pulse { 50% { opacity: .35; } }
-.icon-button { width: 35px; height: 35px; display: grid; place-items: center; border: 1px solid var(--line); border-radius: 10px; background: var(--card); cursor: pointer; }
+.icon-button { width: 36px; height: 36px; display: grid; place-items: center; border: 0; border-radius: 9px; background: transparent; cursor: pointer; }
 .icon-button[hidden] { display: none; }
-.icon-button:hover { border-color: #c5ccc6; }
+.icon-button:hover { background: var(--line-soft); }
 .icon-button:disabled { opacity: .38; cursor: default; }
 .icon-button.danger:not(:disabled):hover { color: var(--danger); border-color: rgba(167,63,63,.3); background: #fff6f6; }
-.messages { min-height: 0; overflow-y: auto; padding: 35px max(24px, calc((100% - 850px) / 2)); scroll-behavior: smooth; }
+.messages { min-height: 0; overflow-y: auto; padding: 28px max(24px, calc((100% - 768px) / 2)) 36px; scroll-behavior: smooth; }
 .history-page-control { display: flex; justify-content: center; margin: -12px 0 24px; }
 .history-page-control button { padding: 7px 12px; border: 1px solid var(--line); border-radius: 999px; background: var(--card); color: var(--muted); font-size: 10.5px; font-weight: 700; cursor: pointer; }
 .history-page-control button:hover:not(:disabled) { border-color: #c5ccc6; color: var(--ink); }
 .history-page-control button:disabled { cursor: default; opacity: .6; }
 .welcome { height: 100%; min-height: 410px; display: flex; flex-direction: column; align-items: center; justify-content: center; text-align: center; }
-.welcome-orbit { width: 72px; height: 72px; display: grid; place-items: center; border: 1px solid #ccd8cf; border-radius: 50%; background: linear-gradient(145deg,#fff,#e7eee8); box-shadow: var(--shadow); }
-.welcome-orbit span { width: 42px; height: 42px; display: grid; place-items: center; border-radius: 14px; background: var(--accent); color: white; font: 700 18px/1 ui-monospace, monospace; }
-.welcome h1 { max-width: 600px; margin: 25px 0 10px; font: 500 clamp(31px,5vw,46px)/1.08 Georgia,"Times New Roman",serif; letter-spacing: -.035em; }
-.welcome p { max-width: 520px; margin: 0; color: var(--muted); font-size: 14px; line-height: 1.65; }
+.welcome-orbit { width: 56px; height: 56px; display: grid; place-items: center; border-radius: 50%; background: var(--accent); }
+.welcome-orbit span { display: grid; place-items: center; color: white; font: 700 18px/1 ui-monospace, monospace; }
+.welcome h1 { max-width: 600px; margin: 22px 0 9px; font-size: clamp(28px,4vw,36px); font-weight: 600; line-height: 1.12; letter-spacing: -.035em; }
+.welcome p { max-width: 510px; margin: 0; color: var(--muted); font-size: 14px; line-height: 1.55; }
 .welcome .primary-button { margin-top: 24px; }
-.event-row { width: 100%; display: flex; margin: 0 0 22px; animation: event-in .2s ease-out; }
+.event-row { width: 100%; display: flex; margin: 0 0 26px; animation: event-in .2s ease-out; }
 @keyframes event-in { from { opacity: 0; transform: translateY(4px); } }
 .event-row.user { justify-content: flex-end; }
-.user-message { max-width: min(78%, 700px); display: flex; flex-direction: column; align-items: flex-end; gap: 5px; }
+.user-message { max-width: min(80%, 680px); display: flex; flex-direction: column; align-items: flex-end; gap: 5px; }
 .user-message .message-bubble { max-width: 100%; }
-.message-bubble { max-width: min(78%, 700px); padding: 13px 16px; border-radius: 18px; font-size: 14px; line-height: 1.62; white-space: pre-wrap; overflow-wrap: anywhere; }
+.message-bubble { max-width: min(80%, 680px); padding: 11px 16px; border-radius: 18px; font-size: 15px; line-height: 1.6; white-space: pre-wrap; overflow-wrap: anywhere; }
 .message-bubble a { color: var(--accent-2); text-decoration: underline; text-underline-offset: 2px; }
 .message-bubble > :first-child { margin-top: 0; }
 .message-bubble > :last-child { margin-bottom: 0; }
@@ -315,15 +316,15 @@ button { color: inherit; }
 .message-bubble .code-copy-button:disabled { opacity: .75; cursor: default; }
 .message-bubble pre { max-width: 100%; margin: 0; overflow-x: auto; border: 0; background: var(--code-bg); color: var(--code-ink); white-space: pre; overflow-wrap: normal; }
 .message-bubble pre code { display: block; min-width: max-content; padding: 12px 14px; font: 12px/1.55 ui-monospace,SFMono-Regular,Menlo,monospace; white-space: inherit; }
-.user .message-bubble { border-bottom-right-radius: 5px; background: #dfe9e2; }
+.user .message-bubble { background: var(--accent-soft); }
 .message-attachments { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 9px; }
-.message-attachment { display: inline-flex; max-width: 260px; flex-direction: column; gap: 5px; padding: 6px 8px; border: 1px solid rgba(57,112,84,.2); border-radius: 9px; color: var(--accent-2); font-size: 11px; text-decoration: none !important; }
+.message-attachment { display: inline-flex; max-width: 260px; flex-direction: column; gap: 5px; padding: 6px 8px; border: 1px solid var(--line); border-radius: 9px; color: var(--accent-2); font-size: 11px; text-decoration: none !important; }
 .message-attachment img { display: block; max-width: 240px; max-height: 180px; border-radius: 6px; object-fit: contain; }
-.assistant { gap: 11px; align-items: flex-start; }
-.agent-avatar { flex: 0 0 auto; width: 29px; height: 29px; display: grid; place-items: center; margin-top: 2px; border-radius: 9px; background: var(--accent); color: white; font: 700 11px/1 ui-monospace, monospace; }
-.assistant .message-bubble { max-width: calc(100% - 45px); padding: 2px 2px 3px; border-radius: 0; background: transparent; }
+.assistant { gap: 12px; align-items: flex-start; }
+.agent-avatar { flex: 0 0 auto; width: 28px; height: 28px; display: grid; place-items: center; margin-top: 2px; border-radius: 50%; background: var(--accent); color: white; font: 700 10px/1 ui-monospace, monospace; }
+.assistant .message-bubble { max-width: calc(100% - 40px); padding: 2px 0 3px; border-radius: 0; background: transparent; }
 .assistant .message-bubble:empty::after { content: "Thinking…"; color: var(--faint); animation: pulse 1.1s infinite; }
-.tool-card, .input-card, .diff-card, .error-card, .recovery-card, .goal-card { margin: -7px 0 19px 40px; border: 1px solid var(--line); border-radius: 13px; background: var(--card); box-shadow: 0 4px 14px rgba(31,46,38,.035); }
+.tool-card, .input-card, .diff-card, .error-card, .recovery-card, .goal-card { margin: -9px 0 21px 40px; border: 1px solid var(--line); border-radius: 12px; background: var(--card); }
 .tool-card { padding: 10px 13px; color: var(--muted); font-size: 12px; }
 .tool-card-header { display: flex; align-items: center; gap: 10px; }
 .tool-icon { width: 25px; height: 25px; display: grid; place-items: center; border-radius: 8px; background: var(--panel); font-size: 12px; }
@@ -346,7 +347,7 @@ button { color: inherit; }
 .input-option strong { font-size: 11.5px; }
 .input-option small { color: var(--muted); font-size: 10.5px; line-height: 1.4; }
 .input-other { width: 100%; margin-top: 8px; padding: 9px 10px; border: 1px solid var(--line); border-radius: 9px; outline: 0; background: var(--card); color: var(--ink); font-size: 12px; }
-.input-other:focus { border-color: #779b88; box-shadow: 0 0 0 3px rgba(56,114,88,.08); }
+.input-other:focus { border-color: #9b9b9b; box-shadow: 0 0 0 3px rgba(0,0,0,.06); }
 .input-actions { display: flex; justify-content: flex-end; gap: 7px; margin-top: 13px; }
 .input-actions button { padding: 7px 10px; border: 1px solid var(--line); border-radius: 8px; background: var(--card); font-size: 11px; font-weight: 700; cursor: pointer; }
 .input-actions button:last-child { border-color: var(--accent); background: var(--accent); color: white; }
@@ -357,14 +358,14 @@ button { color: inherit; }
 .diff-card .changes-list { gap: 0; }
 .diff-card .file-change { border: 0; border-top: 1px solid var(--line); border-radius: 0; box-shadow: none; }
 .diff-card .diff-lines { max-height: 430px; }
-.changes-view { min-height: 0; overflow-y: auto; padding: 28px max(24px, calc((100% - 1050px) / 2)) 40px; }
+.changes-view { min-height: 0; overflow-y: auto; padding: 28px max(24px, calc((100% - 980px) / 2)) 40px; }
 .changes-view[hidden], .messages[hidden], .composer-wrap[hidden] { display: none; }
 .changes-header { display: flex; align-items: flex-end; justify-content: space-between; gap: 20px; margin-bottom: 18px; }
-.changes-header h2 { margin: 0; font: 600 25px/1.2 Georgia,"Times New Roman",serif; }
-.changes-header p { margin: 6px 0 0; color: var(--muted); font-size: 11px; }
+.changes-header h2 { margin: 0; font-size: 20px; font-weight: 600; line-height: 1.3; letter-spacing: -.01em; }
+.changes-header p { margin: 4px 0 0; color: var(--muted); font-size: 12px; }
 .changes-list { display: grid; gap: 11px; }
 .changes-empty { min-height: 250px; display: grid; place-items: center; padding: 30px; border: 1px dashed var(--line); border-radius: 14px; color: var(--muted); font-size: 13px; text-align: center; }
-.file-change { min-width: 0; overflow: hidden; border: 1px solid var(--line); border-radius: 13px; background: var(--card); box-shadow: 0 4px 14px rgba(31,46,38,.035); }
+.file-change { min-width: 0; overflow: hidden; border: 1px solid var(--line); border-radius: 12px; background: var(--card); }
 .file-change summary { display: grid; grid-template-columns: 10px minmax(0, 1fr) auto; align-items: center; gap: 10px; padding: 12px 14px; list-style: none; cursor: pointer; }
 .file-change summary::-webkit-details-marker { display: none; }
 .file-change summary::before { content: "›"; color: var(--faint); font-size: 17px; line-height: 1; transition: transform .12s; }
@@ -373,7 +374,7 @@ button { color: inherit; }
 .file-change-stat { display: flex; gap: 8px; font: 700 10px/1 ui-monospace,SFMono-Regular,Menlo,monospace; }
 .file-change-added { color: var(--diff-added); }
 .file-change-removed { color: var(--diff-removed); }
-.diff-lines { max-height: 520px; overflow: auto; padding: 10px 0; border-top: 1px solid var(--line); background: #f3f5f2; color: var(--ink); font: 11.5px/1.55 ui-monospace,SFMono-Regular,Menlo,monospace; }
+.diff-lines { max-height: 520px; overflow: auto; padding: 10px 0; border-top: 1px solid var(--line); background: var(--code-bg); color: var(--ink); font: 11.5px/1.55 ui-monospace,SFMono-Regular,Menlo,monospace; }
 .diff-line { min-width: max-content; padding: 0 14px; white-space: pre; }
 .diff-line.added { background: var(--diff-added-bg); color: var(--diff-added); }
 .diff-line.removed { background: var(--diff-removed-bg); color: var(--diff-removed); }
@@ -389,8 +390,8 @@ button { color: inherit; }
 .turn-divider:not(:empty)::before, .turn-divider:not(:empty)::after { height: 1px; background: var(--line); content: ""; }
 .turn-divider:not(:empty)::before { flex: 0 0 10px; }
 .turn-divider:not(:empty)::after { flex: 1; }
-.composer-wrap { min-width: 0; padding: 12px max(24px, calc((100% - 850px) / 2)) 19px; background: linear-gradient(transparent, var(--canvas) 20%); }
-.composer-wrap.attachment-drop-target .composer { border-color: var(--accent); box-shadow: 0 0 0 4px rgba(57,112,84,.12); }
+.composer-wrap { position: relative; z-index: 2; min-width: 0; padding: 12px max(24px, calc((100% - 768px) / 2)) 10px; background: linear-gradient(transparent, var(--canvas) 24%); }
+.composer-wrap.attachment-drop-target .composer { border-color: var(--accent); box-shadow: 0 0 0 3px rgba(0,0,0,.1); }
 .session-progress { display: flex; align-items: center; gap: 5px; min-height: 18px; margin: 0 4px 7px; color: var(--muted); font-size: 11px; font-weight: 650; font-variant-numeric: tabular-nums; }
 .session-progress[hidden] { display: none; }
 .session-progress-dot { color: var(--accent-2); animation: pulse 1.1s infinite; }
@@ -404,7 +405,7 @@ button { color: inherit; }
 .pending-message-text { overflow: hidden; overflow-wrap: anywhere; color: var(--ink); font-size: 11.5px; line-height: 1.4; white-space: pre-wrap; }
 .pending-message-card.editing .pending-message-text { overflow: visible; white-space: normal; }
 .pending-message-input { width: 100%; min-height: 58px; resize: vertical; padding: 7px 8px; border: 1px solid var(--line); border-radius: 8px; outline: 0; background: var(--card); color: var(--ink); font-size: 12px; line-height: 1.4; }
-.pending-message-input:focus { border-color: #779b88; box-shadow: 0 0 0 3px rgba(56,114,88,.08); }
+.pending-message-input:focus { border-color: #9b9b9b; box-shadow: 0 0 0 3px rgba(0,0,0,.06); }
 .pending-message-actions { display: flex; align-items: center; gap: 7px; }
 .pending-message-status { color: var(--accent-2); font-size: 9px; font-weight: 800; letter-spacing: .06em; text-transform: uppercase; }
 .pending-message-edit, .pending-message-save, .pending-message-remove { padding: 3px 6px; border: 0; border-radius: 6px; background: transparent; color: var(--muted); font-size: 9.5px; font-weight: 700; cursor: pointer; }
@@ -415,24 +416,25 @@ button { color: inherit; }
 .pending-attachments[hidden] { display: none; }
 .pending-attachment { display: inline-flex; max-width: 220px; align-items: center; gap: 5px; padding: 5px 8px; border: 1px solid var(--line); border-radius: 8px; background: var(--accent-soft); font-size: 11px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .pending-attachment button { flex: none; padding: 0; border: 0; background: transparent; color: var(--muted); cursor: pointer; }
-.composer { display: flex; align-items: flex-end; gap: 10px; padding: 9px 9px 9px 16px; border: 1px solid #d1d8d2; border-radius: 17px; background: var(--card); box-shadow: 0 12px 38px rgba(28,45,36,.08); transition: border .15s, box-shadow .15s; }
-.composer:focus-within { border-color: #85a493; box-shadow: 0 12px 38px rgba(28,45,36,.1), 0 0 0 3px rgba(57,112,84,.08); }
-.composer textarea { flex: 1; min-height: 36px; max-height: 160px; resize: none; border: 0; outline: 0; padding: 8px 0; background: transparent; color: var(--ink); font-size: 14px; line-height: 20px; }
-.composer textarea::placeholder { color: #99a19c; }
-.attach-button { flex: none; width: 30px; height: 36px; padding: 0; border: 0; background: transparent; color: var(--accent-2); font-size: 22px; cursor: pointer; }
+.composer { display: flex; align-items: flex-end; gap: 8px; padding: 10px; border: 1px solid var(--line); border-radius: 26px; background: var(--card); box-shadow: 0 4px 18px rgba(0,0,0,.08); transition: border .15s, box-shadow .15s; }
+.composer:focus-within { border-color: #c5c5c5; box-shadow: 0 4px 20px rgba(0,0,0,.1); }
+.composer textarea { flex: 1; min-height: 36px; max-height: 160px; resize: none; border: 0; outline: 0; padding: 8px 2px; background: transparent; color: var(--ink); font-size: 15px; line-height: 20px; }
+.composer textarea::placeholder { color: var(--faint); }
+.attach-button { flex: none; width: 36px; height: 36px; padding: 0; border: 0; border-radius: 50%; background: transparent; color: var(--ink); font-size: 22px; cursor: pointer; }
+.attach-button:hover:not(:disabled) { background: var(--line-soft); }
 .attach-button:disabled { color: var(--faint); cursor: default; }
-.send-button { flex: 0 0 auto; width: 36px; height: 36px; border: 0; border-radius: 11px; background: var(--accent); color: white; font-size: 20px; font-weight: 500; cursor: pointer; }
+.send-button { flex: 0 0 auto; width: 36px; height: 36px; border: 0; border-radius: 50%; background: var(--accent); color: white; font-size: 20px; font-weight: 500; cursor: pointer; }
 .send-button[data-action="interrupt"] { background: var(--warning); font-size: 11px; }
-.send-button:disabled { background: #c8ceca; cursor: default; }
+.send-button:disabled { background: var(--line); color: var(--faint); cursor: default; }
 .session-runtime-status { padding-top: 8px; overflow: hidden; color: var(--muted); font: 10px/1.4 ui-monospace,SFMono-Regular,Menlo,monospace; text-align: center; text-overflow: ellipsis; white-space: nowrap; }
-.composer-hint { padding-top: 7px; text-align: center; color: var(--faint); font-size: 9.5px; }
-.primary-button, .secondary-button { padding: 10px 15px; border-radius: 10px; font-size: 12px; font-weight: 750; cursor: pointer; }
+.composer-hint { padding-top: 7px; text-align: center; color: var(--faint); font-size: 10px; }
+.primary-button, .secondary-button { padding: 10px 15px; border-radius: 999px; font-size: 12px; font-weight: 600; cursor: pointer; }
 .primary-button { border: 1px solid var(--accent); background: var(--accent); color: white; }
 .primary-button:hover { background: var(--accent-2); }
 .primary-button:disabled { opacity: .55; cursor: wait; }
 .secondary-button { border: 1px solid var(--line); background: var(--card); }
-.session-dialog { width: min(94vw, 610px); max-height: calc(100dvh - 32px); overflow-y: auto; padding: 0; border: 1px solid var(--line); border-radius: 20px; background: var(--card); color: var(--ink); box-shadow: 0 35px 110px rgba(18,31,24,.24); }
-.session-dialog::backdrop { background: rgba(25,35,30,.38); backdrop-filter: blur(4px); }
+.session-dialog { width: min(94vw, 610px); max-height: calc(100dvh - 32px); overflow-y: auto; padding: 0; border: 1px solid var(--line); border-radius: 16px; background: var(--card); color: var(--ink); box-shadow: 0 24px 70px rgba(0,0,0,.2); }
+.session-dialog::backdrop { background: rgba(0,0,0,.36); backdrop-filter: blur(3px); }
 .session-dialog form { padding: 23px; }
 .display-name-dialog { width: min(94vw, 420px); }
 .resource-detail-dialog { width: min(94vw, 820px); }
@@ -444,17 +446,17 @@ button { color: inherit; }
 .resource-detail-log-toolbar .quiet-button:disabled { cursor: wait; opacity: .55; }
 .resource-detail-logs-panel pre { margin-top: 8px; white-space: pre-wrap; overflow-wrap: anywhere; }
 .dialog-header { display: flex; justify-content: space-between; align-items: flex-start; gap: 20px; }
-.dialog-header h2 { margin: 0; font: 600 25px/1.2 Georgia,"Times New Roman",serif; }
+.dialog-header h2 { margin: 0; font-size: 21px; font-weight: 600; line-height: 1.25; letter-spacing: -.02em; }
 .dialog-header p { margin: 6px 0 0; color: var(--muted); font-size: 12px; }
-.mode-switch { width: fit-content; display: flex; margin-top: 20px; padding: 3px; border: 1px solid var(--line); border-radius: 10px; background: var(--panel); }
-.mode-switch button { padding: 6px 13px; border: 0; border-radius: 7px; background: transparent; color: var(--muted); font-size: 11px; font-weight: 700; cursor: pointer; }
-.mode-switch button[aria-selected="true"] { background: var(--card); color: var(--ink); box-shadow: 0 2px 7px rgba(31,46,38,.08); }
+.mode-switch { width: fit-content; display: flex; margin-top: 20px; padding: 3px; border-radius: 10px; background: var(--panel); }
+.mode-switch button { padding: 6px 13px; border: 0; border-radius: 7px; background: transparent; color: var(--muted); font-size: 11px; font-weight: 600; cursor: pointer; }
+.mode-switch button[aria-selected="true"] { background: var(--card); color: var(--ink); box-shadow: 0 1px 3px rgba(0,0,0,.08); }
 .mode-switch button:disabled { opacity: .45; cursor: not-allowed; }
 .source-picker { margin-top: 18px; }
 .source-picker > label { display: block; margin-bottom: 7px; font-size: 11px; font-weight: 700; }
 .source-picker em { color: var(--faint); font-size: 9px; font-style: normal; font-weight: 500; text-transform: uppercase; }
 .source-picker select { width: 100%; padding: 10px 11px; border: 1px solid #d4d9d5; border-radius: 9px; outline: none; background: var(--card); color: var(--ink); font-size: 12px; }
-.source-picker select:focus { border-color: #779b88; box-shadow: 0 0 0 3px rgba(56,114,88,.08); }
+.source-picker select:focus { border-color: #9b9b9b; box-shadow: 0 0 0 3px rgba(0,0,0,.06); }
 .source-picker small { display: block; margin-top: 5px; color: var(--faint); font-size: 9.5px; line-height: 1.4; }
 .source-status { margin-top: 9px; padding: 9px 11px; border: 1px solid var(--accent-soft); border-radius: 9px; background: var(--accent-soft); color: var(--accent-2); font-size: 10px; line-height: 1.45; }
 .mode-panel { min-width: 0; margin: 0; padding: 0; border: 0; }
@@ -465,13 +467,13 @@ button { color: inherit; }
 .form-grid em { color: var(--faint); font-size: 9px; font-style: normal; font-weight: 500; text-transform: uppercase; }
 .form-grid input, .form-grid select, .form-grid textarea { width: 100%; padding: 10px 11px; border: 1px solid #d4d9d5; border-radius: 9px; outline: none; background: var(--card); color: var(--ink); font-size: 12px; }
 .form-grid textarea { min-height: 90px; resize: vertical; line-height: 1.45; }
-.form-grid input:focus, .form-grid select:focus, .form-grid textarea:focus { border-color: #779b88; box-shadow: 0 0 0 3px rgba(56,114,88,.08); }
+.form-grid input:focus, .form-grid select:focus, .form-grid textarea:focus { border-color: #9b9b9b; box-shadow: 0 0 0 3px rgba(0,0,0,.06); }
 .form-grid small { display: block; margin-top: 5px; color: var(--faint); font-size: 9.5px; line-height: 1.4; }
 .form-grid select + input { margin-top: 8px; }
 .section-field { display: block; margin-top: 20px; }
 .section-field > span { display: block; margin-bottom: 7px; font-size: 11px; font-weight: 700; }
 .section-field input { width: 100%; padding: 10px 11px; border: 1px solid #d4d9d5; border-radius: 9px; outline: none; background: var(--card); color: var(--ink); font-size: 12px; }
-.section-field input:focus { border-color: #779b88; box-shadow: 0 0 0 3px rgba(56,114,88,.08); }
+.section-field input:focus { border-color: #9b9b9b; box-shadow: 0 0 0 3px rgba(0,0,0,.06); }
 .section-field small { display: block; margin-top: 5px; color: var(--faint); font-size: 9.5px; line-height: 1.4; }
 .option-picker { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 8px; }
 .secondary-button.compact { padding: 9px 13px; }
@@ -491,7 +493,7 @@ button { color: inherit; }
 .yaml-panel { margin-top: 18px; }
 .yaml-panel > label { display: block; margin-bottom: 7px; font-size: 11px; font-weight: 700; }
 .yaml-panel textarea { width: 100%; min-height: 360px; resize: vertical; padding: 13px; border: 1px solid #d4d9d5; border-radius: 10px; outline: none; background: var(--card); color: var(--ink); font: 11.5px/1.5 ui-monospace,SFMono-Regular,Menlo,monospace; tab-size: 2; }
-.yaml-panel textarea:focus { border-color: #779b88; box-shadow: 0 0 0 3px rgba(56,114,88,.08); }
+.yaml-panel textarea:focus { border-color: #9b9b9b; box-shadow: 0 0 0 3px rgba(0,0,0,.06); }
 .yaml-panel small { display: block; margin-top: 6px; color: var(--faint); font-size: 9.5px; }
 .dialog-error { min-height: 19px; padding-top: 10px; color: var(--danger); font-size: 11px; }
 .dialog-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 7px; }
@@ -499,24 +501,24 @@ button { color: inherit; }
 .toast.show { opacity: 1; transform: translateY(0); }
 .mobile-only { display: none; }
 
-@media (max-width: 760px), (max-height: 500px) and (pointer: coarse) {
+@media (max-width: 800px), (max-height: 500px) and (pointer: coarse) {
   .app-shell { display: block; }
-  .sidebar { position: fixed; inset: 0 auto 0 0; width: min(86vw, 310px); padding: calc(12px + env(safe-area-inset-top)) 12px calc(10px + env(safe-area-inset-bottom)) calc(12px + env(safe-area-inset-left)); visibility: hidden; transform: translateX(-103%); transition: transform .22s ease, visibility 0s linear .22s; box-shadow: 18px 0 60px rgba(25,39,31,.2); }
+  .sidebar { position: fixed; inset: 0 auto 0 0; width: min(88vw, 320px); padding: calc(8px + env(safe-area-inset-top)) 8px calc(8px + env(safe-area-inset-bottom)) calc(8px + env(safe-area-inset-left)); visibility: hidden; transform: translateX(-103%); transition: transform .22s ease, visibility 0s linear .22s; box-shadow: 16px 0 48px rgba(0,0,0,.16); }
   .sidebar.open { visibility: visible; transform: translateX(0); transition-delay: 0s; }
-  .sidebar-scrim { position: fixed; z-index: 4; inset: 0; display: block; padding: 0; border: 0; background: rgba(25,35,30,.34); opacity: 0; visibility: hidden; transition: opacity .22s ease, visibility 0s linear .22s; }
+  .sidebar-scrim { position: fixed; z-index: 4; inset: 0; display: block; padding: 0; border: 0; background: rgba(0,0,0,.35); opacity: 0; visibility: hidden; transition: opacity .22s ease, visibility 0s linear .22s; }
   .sidebar.open + .sidebar-scrim { opacity: 1; visibility: visible; transition-delay: 0s; }
   .mobile-only { display: grid; }
-  .brand-row { padding: 0 2px; }
+  .brand-row { padding: 0 4px; }
   .brand-row .mobile-only { width: 44px; height: 44px; margin-left: auto; }
-  .namespace-form { margin: 10px 0 7px; padding: 0; }
+  .new-session-button { min-height: 44px; margin-top: 4px; padding: 8px 10px; }
+  .namespace-form { margin: 8px 0; padding: 0 3px; }
   .namespace-form label { display: none; }
   .namespace-form input, .namespace-form button { min-height: 44px; }
   .namespace-form button { padding-right: 11px; padding-left: 11px; font-size: 11px; }
-  .console-nav { grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 4px; margin-bottom: 6px; padding-bottom: 7px; }
-  .console-nav button { min-height: 44px; display: flex; justify-content: center; gap: 4px; padding: 0 4px; font-size: 11px; text-align: center; }
-  .console-nav button span { font-size: 14px; }
+  .console-nav { gap: 2px; margin-bottom: 6px; padding-bottom: 7px; }
+  .console-nav button { min-height: 44px; padding: 8px 10px; font-size: 14px; }
+  .console-nav button span { font-size: 17px; }
   .session-sidebar-header { min-height: 44px; padding: 0 4px 0 8px; }
-  .new-session-button { min-height: 44px; padding: 6px 10px; }
   .session-section-group + .session-section-group { margin-top: 8px; }
   .session-section-heading { min-height: 44px; padding: 0 8px; }
   .session-section-order-button { width: 44px; height: 44px; }
@@ -526,9 +528,10 @@ button { color: inherit; }
   .sidebar-footer { padding: 5px 3px 0; }
   .sidebar-footer .quiet-button { min-height: 44px; }
   .console-page { height: 100%; height: 100dvh; }
-  .console-page-header { min-height: 92px; padding: calc(10px + env(safe-area-inset-top)) calc(14px + env(safe-area-inset-right)) 11px calc(14px + env(safe-area-inset-left)); }
-  .console-page-header h1 { font-size: 24px; }
-  .console-page-body { padding: 20px calc(14px + env(safe-area-inset-right)) 32px calc(14px + env(safe-area-inset-left)); overscroll-behavior: contain; }
+  .console-page-header { min-height: calc(58px + env(safe-area-inset-top)); padding: calc(7px + env(safe-area-inset-top)) calc(10px + env(safe-area-inset-right)) 7px calc(10px + env(safe-area-inset-left)); }
+  .console-page-header h1 { font-size: 18px; }
+  .console-page-header p { margin-top: 1px; font-size: 11px; }
+  .console-page-body { padding: 16px calc(12px + env(safe-area-inset-right)) 32px calc(12px + env(safe-area-inset-left)); overscroll-behavior: contain; }
   .resource-summary-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .resource-view-tabs { width: 100%; }
   .resource-view-tabs button { flex: 1; min-height: 44px; }
@@ -558,26 +561,32 @@ button { color: inherit; }
   .session-item-actions { top: 5px; right: 1px; width: 44px; height: 44px; }
   .session-actions-menu button { min-height: 44px; font-size: 14px; }
   .conversation { height: 100%; height: 100dvh; }
-  .conversation-header { display: grid; grid-template-areas: "menu heading reset delete" "tabs tabs connection connection"; grid-template-columns: 48px minmax(0, 1fr) 48px 48px; gap: 8px 10px; padding: calc(8px + env(safe-area-inset-top)) calc(10px + env(safe-area-inset-right)) 9px calc(10px + env(safe-area-inset-left)); }
-  .conversation-header:has(.session-lifecycle-action:not([hidden])) { grid-template-areas: "menu heading lifecycle reset delete" "tabs tabs connection connection connection"; grid-template-columns: 48px minmax(0, 1fr) 48px 48px 48px; }
+  .conversation-header { min-height: calc(58px + env(safe-area-inset-top)); display: grid; grid-template-areas: "menu heading actions"; grid-template-columns: 44px minmax(0, 1fr) auto; gap: 8px; padding: calc(7px + env(safe-area-inset-top)) calc(8px + env(safe-area-inset-right)) 7px calc(8px + env(safe-area-inset-left)); }
   #open-sidebar { grid-area: menu; }
   .session-heading { grid-area: heading; }
-  .header-actions { display: contents; }
-  .view-tabs { grid-area: tabs; width: fit-content; }
-  .session-lifecycle-action { grid-area: lifecycle; }
-  #reset-session { grid-area: reset; }
-  #delete-session { grid-area: delete; }
-  .connection-pill { grid-area: connection; width: 48px; height: 48px; max-width: 48px; justify-content: center; justify-self: end; overflow: hidden; padding: 0; color: transparent; font-size: 0; gap: 0; }
-  .icon-button { width: 48px; height: 48px; }
-  .view-tabs button { min-height: 48px; padding: 6px 9px; }
-  .messages { padding: 24px calc(14px + env(safe-area-inset-right)) 24px calc(14px + env(safe-area-inset-left)); overscroll-behavior: contain; }
-  .changes-view { padding: 22px calc(14px + env(safe-area-inset-right)) 32px calc(14px + env(safe-area-inset-left)); overscroll-behavior: contain; }
-  .composer-wrap { padding: 9px calc(10px + env(safe-area-inset-right)) calc(10px + env(safe-area-inset-bottom)) calc(10px + env(safe-area-inset-left)); }
-  .composer { padding-left: 13px; }
+  .session-heading { text-align: center; }
+  .session-title-row { justify-content: center; }
+  .session-meta, .session-section-control:not(.mobile-open), .session-display-name-button { display: none; }
+  .session-section-control.mobile-open { justify-content: center; margin-top: 7px; }
+  .session-section-control.mobile-open > label { display: none; }
+  .session-section-control.mobile-open select { max-width: min(100%, 220px); min-height: 36px; }
+  .session-section-control.mobile-open .session-section-cancel { width: 36px; height: 36px; display: grid; place-items: center; padding: 0; border: 0; background: transparent; color: var(--muted); font-size: 18px; }
+  .header-actions { grid-area: actions; gap: 4px; }
+  .session-lifecycle-action, #reset-session, #delete-session { display: none !important; }
+  .connection-pill { width: 36px; height: 36px; justify-content: center; overflow: hidden; padding: 0; color: transparent; font-size: 0; gap: 0; }
+  .connection-pill span { width: 7px; height: 7px; }
+  .icon-button { width: 44px; height: 44px; }
+  .view-tabs button { min-height: 44px; padding: 5px 8px; }
+  .messages { padding: 20px calc(12px + env(safe-area-inset-right)) 24px calc(12px + env(safe-area-inset-left)); overscroll-behavior: contain; }
+  .changes-view { padding: 20px calc(12px + env(safe-area-inset-right)) 32px calc(12px + env(safe-area-inset-left)); overscroll-behavior: contain; }
+  .composer-wrap { padding: 8px calc(8px + env(safe-area-inset-right)) calc(7px + env(safe-area-inset-bottom)) calc(8px + env(safe-area-inset-left)); }
+  .composer { padding: 8px; }
   .composer textarea, .pending-message-input, .yaml-panel textarea, .form-grid input, .form-grid select, .source-picker select, .section-field input, .session-section-control input, .session-section-control select, .namespace-form input, .input-other { font-size: 16px; }
-  .composer textarea { min-height: 48px; padding: 12px 0; line-height: 24px; }
-  .send-button { width: 48px; height: 48px; }
-  .message-bubble, .user-message { max-width: 90%; }
+  .composer textarea { min-height: 44px; padding: 10px 2px; line-height: 24px; }
+  .attach-button, .send-button { width: 44px; height: 44px; }
+  .message-bubble, .user-message { max-width: 92%; }
+  .assistant .message-bubble { max-width: calc(100% - 40px); }
+  .composer-hint { display: none; }
   .tool-card, .input-card, .diff-card, .error-card, .recovery-card, .goal-card { margin-left: 0; }
   .turn-divider { margin-left: 0; }
   .session-dialog { width: calc(100vw - 16px - env(safe-area-inset-left) - env(safe-area-inset-right)); max-width: none; max-height: calc(100dvh - 16px - env(safe-area-inset-top) - env(safe-area-inset-bottom)); border-radius: 16px; }
@@ -589,16 +598,16 @@ button { color: inherit; }
 }
 
 @media (prefers-color-scheme: dark) {
-  :root { color-scheme: dark; --ink:#edf2ee; --muted:#9ba9a0; --faint:#7f8e85; --line:#334039; --line-soft:#29342e; --canvas:#111814; --panel:#171f1a; --card:#1b241f; --accent:#3c8463; --accent-2:#4a9673; --accent-soft:#233a2e; --pr-open:#56b978; --pr-merged:#a371f7; --pr-closed:#ef7777; --diff-added:#8bd5a5; --diff-added-bg:#173424; --diff-removed:#ef9a9a; --diff-removed-bg:#3a2020; --code-bg:#0d1410; --code-border:#334039; --code-ink:#e3ebe5; --shadow:0 18px 55px rgba(0,0,0,.25); }
-  .new-session-button, .session-item.active { background: #202a24; }
-  .new-session-button:hover, .session-item:hover, .console-nav button:hover { background: #242f29; }
-  .console-nav button[aria-current="page"] { background: #202a24; }
-  .conversation-header, .console-page-header { background: rgba(17,24,20,.88); }
-  .user .message-bubble { background: #263b30; }
+  :root { color-scheme: dark; --ink:#ececec; --muted:#b4b4b4; --faint:#8b8b8b; --line:#383838; --line-soft:#303030; --canvas:#212121; --panel:#171717; --card:#2f2f2f; --accent:#ececec; --accent-2:#c5c5c5; --accent-soft:#303030; --pr-open:#57b777; --pr-merged:#a371f7; --pr-closed:#ef7777; --diff-added:#8bd5a5; --diff-added-bg:#173424; --diff-removed:#ef9a9a; --diff-removed-bg:#3a2020; --code-bg:#171717; --code-border:#3f3f3f; --code-ink:#ececec; --shadow:0 18px 55px rgba(0,0,0,.3); }
+  .brand-mark, .welcome-orbit, .agent-avatar, .send-button, .primary-button, .namespace-form button, .session-section-control button, .input-actions button:last-child, .pending-message-save { background: #ececec; color: #171717; }
+  .welcome-orbit span { color: #171717; }
+  .new-session-button:hover, .session-item:hover, .session-item.active, .console-nav button:hover, .console-nav button[aria-current="page"] { background: #2a2a2a; }
+  .conversation-header, .console-page-header { background: rgba(33,33,33,.9); }
+  .user .message-bubble { background: #2f2f2f; }
   .error-card { background: #2d1e1e; }
   .recovery-card { background: #2d281e; color: #e7bd78; }
-  .goal-card { background: #1e2923; }
-  .diff-lines { background: #121915; }
+  .goal-card { background: #262626; }
+  .diff-lines { background: #171717; }
   .icon-button.danger:not(:disabled):hover { background: #2d1e1e; }
   .resource-relationship-node[data-resource="taskspawners"], .resource-relationship-node[data-resource="sessionspawners"] { --node-border:#7564ad; --node-tint:#28223a; }
   .resource-relationship-node[data-resource="tasks"] { --node-border:#89662e; --node-tint:#342b19; }
@@ -608,6 +617,5 @@ button { color: inherit; }
   .resource-relationship-node[data-resource="workerpools"], .resource-relationship-node[data-resource="taskbudgets"] { --node-border:#865e48; --node-tint:#34251d; }
   .resource-row-phase[data-state="pending"], .resource-row-phase[data-state="waiting"], .resource-row-phase[data-state="running"], .resource-row-phase[data-state="active"], .resource-row-phase[data-state="scaling"] { background: #392d1d; }
   .resource-row-phase[data-state="failed"] { background: #3a2020; }
-  .welcome-orbit { background: linear-gradient(145deg,#26312b,#18201c); border-color:#38483f; }
-  .form-grid input, .form-grid select, .form-grid textarea, .source-picker select, .section-field input, .session-section-control input, .session-section-control select { border-color: #3a4740; }
+  .form-grid input, .form-grid select, .form-grid textarea, .source-picker select, .section-field input, .session-section-control input, .session-section-control select { border-color: #454545; }
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Redesigns the Kelos Console around a familiar, conversation-first responsive shell.

- uses a compact neutral sidebar and centered conversation column on desktop
- provides an off-canvas navigation drawer, single-row header, safe-area spacing, and 44px touch targets on mobile
- makes New session available from every Console view and routes it into the Sessions workspace
- aligns the overview, resources, dialogs, sign-in screen, and light/dark themes with the same visual system
- keeps the existing Session, resource, and authentication behavior intact

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Desktop layout:

```
┌──────────────────────┬──────────────────────────────────────────────────┐
│ ● Kelos              │ session-name                     Connected  ⋯   │
│   AI workspace       ├──────────────────────────────────────────────────┤
│ + New session        │                                                  │
│ Namespace [default]  │                     ┌───────────────────────┐    │
│ ⌂ Overview           │                     │ User message          │    │
│ ○ Sessions           │                     └───────────────────────┘    │
│ ◇ Resources          │                                                  │
│                      │  ●  Agent response in a centered reading column  │
│ Conversations        │                                                  │
│  • review API        │                                                  │
│  • fix tests         ├──────────────────────────────────────────────────┤
│                      │      [ +  Message the agent…              ↑ ]    │
│ Refresh     Sign out │                                                  │
└──────────────────────┴──────────────────────────────────────────────────┘
```

Mobile layout:

```
Closed                                  Navigation drawer open
┌────────────────────────┐              ┌────────────────────┬───────────
│ ☰    session-name   ●  │              │ ● Kelos          × │
├────────────────────────┤              │ + New session      │
│                        │              │ Namespace [default]│
│       ┌──────────────┐ │              │ ⌂ Overview         │
│       │ User message │ │              │ ○ Sessions         │
│       └──────────────┘ │              │ ◇ Resources        │
│                        │              │                    │
│ ●  Agent response     │              │ Conversations      │
│                        │              │  • review API      │
├────────────────────────┤              │  • fix tests       │
│ [ + Message…       ↑ ] │              │ Refresh   Sign out │
└────────────────────────┘              └────────────────────┴───────────
```

Validation:

- `make verify`
- `env -u CODEX_AUTH_JSON -u CODEX_HOME make test` (removes values injected by the local Codex runner so entrypoint tests use the CI environment)

#### Does this PR introduce a user-facing change?

```release-note
The Kelos Console now uses a conversation-first responsive layout optimized for desktop and mobile browsers.
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigns the Kelos Console into a conversation‑first, responsive chat UI. Session creation now routes to the Sessions workspace (was: opened in‑place), the mobile header collapses to a single row, lifecycle buttons leave the header, and the connection status compresses to a pill.

- Desktop centers the conversation with a compact neutral sidebar; mobile uses an off‑canvas navigation drawer, safe‑area padding, and 44px touch targets.
- Moves New session into the global sidebar and updates welcome copy, login styling, and light/dark theme tokens (notably code bg/ink).
- Adds “Move to section…” to session actions; opens a mobile section editor with Cancel; saves or no‑op closes the editor. Behavior of sessions, resources, and auth remains unchanged.

**Review notes**
- Most changes are CSS/HTML in `internal/consoleserver/web/*`; tests update style assertions (desktop sidebar 260px, phone drawer min(88vw, 320px), single‑row conversation header “menu heading actions”, lifecycle buttons hidden on phone, 44px controls, updated code colors, composer sizing).
- `openDialog` now calls `setConsoleView('sessions')` to land creation flows in Sessions.
- Validate mobile drawer open/close, safe‑area spacing, non‑zooming inputs, and that the section editor opens via the new menu action and Cancel closes it; confirm New session appears in all views.

**Rollout**
- No backend changes or migrations. Rebuild static assets and run: make verify and env -u CODEX_AUTH_JSON -u CODEX_HOME make test.

<sup>Written for commit fb8b165aa7e3ff1a3714e5776f63b638cc9d053a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1686?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

