### PR TITLE
Include manual shell commands in session context

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -268,7 +268,10 @@ the Session is ready.
 Both terminal and web chat recognize `!COMMAND` and `/goal` before ordinary
 messages are submitted. `!COMMAND` runs `/bin/sh -lc COMMAND` directly in the
 Session working directory with the Session environment. It does not ask the
-agent for approval or send the command to the model. Its live and retained
+agent for approval or start a model turn. The command, exit code, duration, and
+retained output are added to the agent conversation context for subsequent
+turns. Claude Code includes pending command results with the next ordinary
+prompt; Codex and OpenCode record them immediately. Live and retained command
 output appears as tool activity, and interrupting the Session turn stops the
 command.
 

--- a/internal/sessionruntime/claude.go
+++ b/internal/sessionruntime/claude.go
@@ -43,6 +43,9 @@ type ClaudeProvider struct {
 	writeMu sync.Mutex
 	turnMu  sync.Mutex
 
+	shellContextMu       sync.Mutex
+	pendingShellCommands []shellCommandRecord
+
 	controlMu      sync.Mutex
 	controlPending map[string]chan error
 	nextControlID  atomic.Int64
@@ -184,21 +187,33 @@ func (p *ClaudeProvider) RunTurn(ctx context.Context, input TurnInput, sink Even
 	p.sessionMu.Lock()
 	sessionID := p.sessionID
 	p.sessionMu.Unlock()
+	p.shellContextMu.Lock()
+	content := make([]map[string]string, 0, len(p.pendingShellCommands)+1)
+	for _, record := range p.pendingShellCommands {
+		content = append(content, map[string]string{
+			"type": "text",
+			"text": formatShellCommandRecord(record),
+		})
+	}
+	content = append(content, map[string]string{
+		"type": "text",
+		"text": attachmentPrompt(input),
+	})
 	message := map[string]any{
 		"type": "user",
 		"message": map[string]any{
-			"role": "user",
-			"content": []map[string]string{{
-				"type": "text",
-				"text": attachmentPrompt(input),
-			}},
+			"role":    "user",
+			"content": content,
 		},
 		"parent_tool_use_id": nil,
 		"session_id":         sessionID,
 	}
 	if err := p.write(message); err != nil {
+		p.shellContextMu.Unlock()
 		return err
 	}
+	p.pendingShellCommands = nil
+	p.shellContextMu.Unlock()
 
 	select {
 	case result := <-done:
@@ -220,6 +235,13 @@ func (p *ClaudeProvider) RunTurn(ctx context.Context, input TurnInput, sink Even
 		}
 		return errors.New("Claude Code stopped")
 	}
+}
+
+func (p *ClaudeProvider) recordShellCommand(_ context.Context, record shellCommandRecord) error {
+	p.shellContextMu.Lock()
+	defer p.shellContextMu.Unlock()
+	p.pendingShellCommands = append(p.pendingShellCommands, record)
+	return nil
 }
 
 // Interrupt stops the active Claude Code turn without closing its session.

--- a/internal/sessionruntime/claude_test.go
+++ b/internal/sessionruntime/claude_test.go
@@ -1,11 +1,92 @@
 package sessionruntime
 
 import (
+	"context"
 	"encoding/json"
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 )
+
+type channelWriteCloser struct {
+	writes chan []byte
+}
+
+func (w *channelWriteCloser) Write(data []byte) (int, error) {
+	w.writes <- append([]byte(nil), data...)
+	return len(data), nil
+}
+
+func (w *channelWriteCloser) Close() error {
+	return nil
+}
+
+func TestClaudeProviderIncludesShellCommandWithNextPrompt(t *testing.T) {
+	stdin := &channelWriteCloser{writes: make(chan []byte, 1)}
+	provider := &ClaudeProvider{
+		ctx:       context.Background(),
+		stdin:     stdin,
+		sessionID: "session-1",
+	}
+	record := shellCommandRecord{
+		command:  "printf shell-output",
+		exitCode: 0,
+		duration: 1234 * time.Millisecond,
+		output:   "shell-output",
+	}
+	if err := provider.recordShellCommand(t.Context(), record); err != nil {
+		t.Fatalf("recordShellCommand() error = %v", err)
+	}
+	select {
+	case message := <-stdin.writes:
+		t.Fatalf("recordShellCommand() wrote a Claude message: %s", message)
+	default:
+	}
+
+	turnDone := make(chan error, 1)
+	go func() {
+		turnDone <- provider.RunTurn(t.Context(), TurnInput{Text: "continue"}, &collectingSink{})
+	}()
+
+	var message struct {
+		Message struct {
+			Content []struct {
+				Type string `json:"type"`
+				Text string `json:"text"`
+			} `json:"content"`
+		} `json:"message"`
+	}
+	select {
+	case data := <-stdin.writes:
+		if err := json.Unmarshal(data, &message); err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Claude prompt was not submitted")
+	}
+	wantContext := "<user_shell_command>\n<command>\nprintf shell-output\n</command>\n<result>\nExit code: 0\nDuration: 1.2340 seconds\nOutput:\nshell-output\n</result>\n</user_shell_command>"
+	if len(message.Message.Content) != 2 || message.Message.Content[0].Type != "text" || message.Message.Content[0].Text != wantContext || message.Message.Content[1].Text != "continue" {
+		t.Fatalf("Claude prompt content = %#v", message.Message.Content)
+	}
+	provider.activeMu.Lock()
+	done := provider.turnDone
+	provider.activeMu.Unlock()
+	done <- claudeTurnResult{}
+	select {
+	case err := <-turnDone:
+		if err != nil {
+			t.Fatalf("RunTurn() error = %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Claude turn did not finish")
+	}
+	provider.shellContextMu.Lock()
+	defer provider.shellContextMu.Unlock()
+	if len(provider.pendingShellCommands) != 0 {
+		t.Fatalf("pending shell commands = %#v", provider.pendingShellCommands)
+	}
+}
 
 // TestClaudeProviderClosesEachTextBlock verifies that a streamed turn with two
 // text blocks emits an assistant.message after each block's deltas, so clients

--- a/internal/sessionruntime/codex.go
+++ b/internal/sessionruntime/codex.go
@@ -332,6 +332,25 @@ func (p *CodexProvider) RunTurn(ctx context.Context, input TurnInput, sink Event
 	})
 }
 
+func (p *CodexProvider) recordShellCommand(ctx context.Context, record shellCommandRecord) error {
+	item := map[string]any{
+		"type": "message",
+		"role": "user",
+		"content": []map[string]string{{
+			"type": "input_text",
+			"text": formatShellCommandRecord(record),
+		}},
+	}
+	_, err := p.request(ctx, "thread/inject_items", map[string]any{
+		"threadId": p.threadID,
+		"items":    []any{item},
+	})
+	if err != nil {
+		return fmt.Errorf("recording shell command in Codex context: %w", err)
+	}
+	return nil
+}
+
 func (p *CodexProvider) RunGoal(ctx context.Context, command goalCommand, sink EventSink) error {
 	return p.runInteraction(ctx, sink, codexInteractionGoal, func() (bool, error) {
 		if err := p.applyGoalCommand(ctx, command, sink); err != nil {

--- a/internal/sessionruntime/opencode.go
+++ b/internal/sessionruntime/opencode.go
@@ -465,6 +465,20 @@ func (p *OpenCodeProvider) RunTurn(ctx context.Context, input TurnInput, sink Ev
 	}
 }
 
+func (p *OpenCodeProvider) recordShellCommand(ctx context.Context, record shellCommandRecord) error {
+	request := map[string]any{
+		"noReply": true,
+		"parts": []map[string]string{{
+			"type": "text",
+			"text": formatShellCommandRecord(record),
+		}},
+	}
+	if err := p.client.doJSON(ctx, http.MethodPost, "/session/"+url.PathEscape(p.currentSessionID())+"/message", true, request, nil); err != nil {
+		return fmt.Errorf("recording shell command in OpenCode context: %w", err)
+	}
+	return nil
+}
+
 // Interrupt stops the active OpenCode turn without deleting its session.
 func (p *OpenCodeProvider) Interrupt(ctx context.Context) error {
 	p.activeMu.Lock()

--- a/internal/sessionruntime/opencode_test.go
+++ b/internal/sessionruntime/opencode_test.go
@@ -98,6 +98,39 @@ func TestOpenCodeProviderStreamsOrderedEvents(t *testing.T) {
 	}
 }
 
+func TestOpenCodeProviderRecordsShellCommandWithoutReply(t *testing.T) {
+	fake := newFakeOpenCodeServer(t)
+	provider := newTestOpenCodeProvider(t, fake, ProviderConfig{WorkingDir: t.TempDir(), StateDir: t.TempDir()})
+	record := shellCommandRecord{
+		command:  "printf shell-output",
+		exitCode: 0,
+		duration: 1234 * time.Millisecond,
+		output:   "shell-output",
+	}
+	if err := provider.recordShellCommand(t.Context(), record); err != nil {
+		t.Fatalf("recordShellCommand() error = %v", err)
+	}
+
+	select {
+	case request := <-fake.contexts:
+		if request["noReply"] != true {
+			t.Fatalf("OpenCode shell context request = %#v", request)
+		}
+		parts, ok := request["parts"].([]any)
+		want := "<user_shell_command>\n<command>\nprintf shell-output\n</command>\n<result>\nExit code: 0\nDuration: 1.2340 seconds\nOutput:\nshell-output\n</result>\n</user_shell_command>"
+		if !ok || len(parts) != 1 || parts[0].(map[string]any)["type"] != "text" || parts[0].(map[string]any)["text"] != want {
+			t.Fatalf("OpenCode shell context parts = %#v", request["parts"])
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("OpenCode shell context was not submitted")
+	}
+	select {
+	case prompt := <-fake.prompts:
+		t.Fatalf("shell context started an OpenCode turn: %#v", prompt)
+	default:
+	}
+}
+
 func TestOpenCodeProviderAnswersQuestion(t *testing.T) {
 	fake := newFakeOpenCodeServer(t)
 	provider := newTestOpenCodeProvider(t, fake, ProviderConfig{WorkingDir: t.TempDir(), StateDir: t.TempDir()})
@@ -311,6 +344,7 @@ type fakeOpenCodeServer struct {
 	resumeFound       bool
 	events            chan string
 	prompts           chan map[string]any
+	contexts          chan map[string]any
 	questionReplies   chan [][]string
 	permissionReplies chan string
 	aborts            chan struct{}
@@ -328,6 +362,7 @@ func newFakeOpenCodeServer(t *testing.T) *fakeOpenCodeServer {
 		resumeFound:       true,
 		events:            make(chan string, 64),
 		prompts:           make(chan map[string]any, 4),
+		contexts:          make(chan map[string]any, 4),
 		questionReplies:   make(chan [][]string, 4),
 		permissionReplies: make(chan string, 4),
 		aborts:            make(chan struct{}, 4),
@@ -378,6 +413,16 @@ func (f *fakeOpenCodeServer) serveHTTP(response http.ResponseWriter, request *ht
 		}
 		f.prompts <- body
 		response.WriteHeader(http.StatusNoContent)
+	case request.Method == http.MethodPost && request.URL.Path == "/session/"+f.sessionID+"/message":
+		f.requireDirectory(request)
+		var body map[string]any
+		if err := json.NewDecoder(request.Body).Decode(&body); err != nil {
+			f.t.Errorf("decoding OpenCode context message: %v", err)
+			response.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		f.contexts <- body
+		writeOpenCodeJSON(response, map[string]any{"info": map[string]string{"role": "user"}, "parts": body["parts"]})
 	case request.Method == http.MethodPost && request.URL.Path == "/session/"+f.sessionID+"/abort":
 		f.requireDirectory(request)
 		f.aborts <- struct{}{}

--- a/internal/sessionruntime/provider.go
+++ b/internal/sessionruntime/provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 )
 
 var (
@@ -32,6 +33,33 @@ type Provider interface {
 	Interrupt(ctx context.Context) error
 	Done() <-chan struct{}
 	Close() error
+}
+
+type shellCommandRecord struct {
+	command  string
+	exitCode int
+	duration time.Duration
+	output   string
+}
+
+type shellCommandContextProvider interface {
+	recordShellCommand(context.Context, shellCommandRecord) error
+}
+
+var (
+	_ shellCommandContextProvider = (*ClaudeProvider)(nil)
+	_ shellCommandContextProvider = (*CodexProvider)(nil)
+	_ shellCommandContextProvider = (*OpenCodeProvider)(nil)
+)
+
+func formatShellCommandRecord(record shellCommandRecord) string {
+	return fmt.Sprintf(
+		"<user_shell_command>\n<command>\n%s\n</command>\n<result>\nExit code: %d\nDuration: %.4f seconds\nOutput:\n%s\n</result>\n</user_shell_command>",
+		record.command,
+		record.exitCode,
+		record.duration.Seconds(),
+		record.output,
+	)
 }
 
 type goalProvider interface {

--- a/internal/sessionruntime/server.go
+++ b/internal/sessionruntime/server.go
@@ -811,13 +811,25 @@ func (s *Server) runTurn(ctx context.Context, turn turnRequest) {
 	}
 	sink := &turnSink{server: s, turnID: turn.id}
 	if command.kind == sessionCommandShell {
-		runErr := s.runShellCommand(turnCtx, turn.id, command.text, sink)
+		record, runErr := s.runShellCommand(turnCtx, turn.id, command.text, sink)
 		sink.stop()
-		if errors.Is(runErr, ErrTurnInterrupted) || errors.Is(context.Cause(turnCtx), ErrTurnInterrupted) {
-			_ = s.journal.Append(Event{Type: EventTurnCompleted, TurnID: turn.id, Status: "interrupted"})
+		interrupted := errors.Is(runErr, ErrTurnInterrupted) || errors.Is(context.Cause(turnCtx), ErrTurnInterrupted)
+		if runErr != nil && turnCtx.Err() != nil && !interrupted {
 			return
 		}
-		if runErr != nil && turnCtx.Err() != nil {
+		if provider, ok := s.provider.(shellCommandContextProvider); ok {
+			recordCtx := turnCtx
+			if interrupted {
+				recordCtx = ctx
+			}
+			if err := provider.recordShellCommand(recordCtx, record); err != nil {
+				_ = s.journal.Append(Event{Type: EventError, TurnID: turn.id, Text: err.Error(), Status: "failed"})
+				_ = s.journal.Append(Event{Type: EventTurnCompleted, TurnID: turn.id, Status: "failed"})
+				return
+			}
+		}
+		if interrupted {
+			_ = s.journal.Append(Event{Type: EventTurnCompleted, TurnID: turn.id, Status: "interrupted"})
 			return
 		}
 		_ = s.journal.Append(Event{Type: EventTurnCompleted, TurnID: turn.id, Status: "completed"})
@@ -884,7 +896,7 @@ func (s *Server) runTurn(ctx context.Context, turn turnRequest) {
 	_ = s.journal.Append(Event{Type: EventTurnCompleted, TurnID: turn.id, Status: "completed"})
 }
 
-func (s *Server) runShellCommand(ctx context.Context, turnID, script string, sink EventSink) error {
+func (s *Server) runShellCommand(ctx context.Context, turnID, script string, sink EventSink) (shellCommandRecord, error) {
 	toolID := turnID + "-shell"
 	sink.Emit(Event{Type: EventToolStarted, ToolID: toolID, ToolName: script, Status: "running"})
 	command := exec.CommandContext(ctx, "/bin/sh", "-lc", script)
@@ -905,11 +917,12 @@ func (s *Server) runShellCommand(ctx context.Context, turnID, script string, sin
 	outputReader, outputWriter := io.Pipe()
 	command.Stdout = outputWriter
 	command.Stderr = outputWriter
+	started := time.Now()
 	if err := command.Start(); err != nil {
 		_ = outputReader.Close()
 		_ = outputWriter.Close()
 		sink.Emit(Event{Type: EventToolCompleted, ToolID: toolID, ToolName: script, Output: err.Error(), Status: "failed"})
-		return nil
+		return shellCommandRecord{command: script, exitCode: -1, duration: time.Since(started), output: err.Error()}, nil
 	}
 
 	output := newBoundedToolOutput(maxToolOutputBytes)
@@ -943,6 +956,7 @@ func (s *Server) runShellCommand(ctx context.Context, turnID, script string, sin
 		}
 	}()
 	waitErr := command.Wait()
+	duration := time.Since(started)
 	_ = outputWriter.Close()
 	readErr := <-readDone
 	if readErr != nil && waitErr == nil {
@@ -957,11 +971,16 @@ func (s *Server) runShellCommand(ctx context.Context, turnID, script string, sin
 			output.WriteString(waitErr.Error())
 		}
 	}
-	sink.Emit(Event{Type: EventToolCompleted, ToolID: toolID, ToolName: script, Output: output.String(), Status: status})
+	exitCode := command.ProcessState.ExitCode()
 	if ctx.Err() != nil {
-		return context.Cause(ctx)
+		exitCode = -1
 	}
-	return nil
+	record := shellCommandRecord{command: script, exitCode: exitCode, duration: duration, output: output.String()}
+	sink.Emit(Event{Type: EventToolCompleted, ToolID: toolID, ToolName: script, Output: record.output, Status: status})
+	if ctx.Err() != nil {
+		return record, context.Cause(ctx)
+	}
+	return record, nil
 }
 
 func workspaceDiff(ctx context.Context, workingDir string) string {

--- a/internal/sessionruntime/server_test.go
+++ b/internal/sessionruntime/server_test.go
@@ -27,14 +27,16 @@ import (
 )
 
 type fakeProvider struct {
-	mu        sync.Mutex
-	prompts   []string
-	inputs    []TurnInput
-	resume    chan struct{}
-	closed    bool
-	done      chan struct{}
-	doneOnce  sync.Once
-	closeOnce sync.Once
+	mu              sync.Mutex
+	prompts         []string
+	inputs          []TurnInput
+	shellCommands   []shellCommandRecord
+	shellCommandErr error
+	resume          chan struct{}
+	closed          bool
+	done            chan struct{}
+	doneOnce        sync.Once
+	closeOnce       sync.Once
 }
 
 type fakeGoalProvider struct {
@@ -258,6 +260,16 @@ func (p *fakeProvider) RunTurn(ctx context.Context, input TurnInput, sink EventS
 		}
 	}
 	sink.Emit(Event{Type: EventAssistantDelta, Text: " done"})
+	return nil
+}
+
+func (p *fakeProvider) recordShellCommand(_ context.Context, record shellCommandRecord) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.shellCommandErr != nil {
+		return p.shellCommandErr
+	}
+	p.shellCommands = append(p.shellCommands, record)
 	return nil
 }
 
@@ -531,6 +543,31 @@ func TestRunTurnExecutesShellCommandInWorkspace(t *testing.T) {
 	if len(provider.prompts) != 0 {
 		t.Fatalf("shell command was sent to provider: %#v", provider.prompts)
 	}
+	if len(provider.shellCommands) != 1 {
+		t.Fatalf("shell command context = %#v, want one record", provider.shellCommands)
+	}
+	record := provider.shellCommands[0]
+	if record.command != "printf 'shell output'" || record.exitCode != 0 || record.output != "shell output" || record.duration <= 0 {
+		t.Fatalf("shell command context = %#v", record)
+	}
+}
+
+func TestRunTurnFailsWhenShellContextRecordingFails(t *testing.T) {
+	journal := NewJournal()
+	t.Cleanup(journal.Close)
+	provider := &fakeProvider{shellCommandErr: errors.New("recording shell context failed")}
+	server := NewServer(Config{WorkingDir: t.TempDir(), Environment: os.Environ()}, journal, provider)
+
+	server.runTurn(t.Context(), turnRequest{id: "turn-1", command: sessionCommand{kind: sessionCommandShell, text: "printf output"}})
+
+	events := journal.Snapshot()
+	assertEventTypes(t, events, EventTurnStarted, EventToolStarted, EventToolDelta, EventToolCompleted, EventError, EventTurnCompleted)
+	if events[4].Text != "recording shell context failed" || events[4].Status != "failed" {
+		t.Fatalf("shell context error event = %#v", events[4])
+	}
+	if events[5].Status != "failed" {
+		t.Fatalf("shell command completion = %#v", events[5])
+	}
 }
 
 func TestServerInterruptsShellCommandWithoutStoppingProvider(t *testing.T) {
@@ -592,6 +629,12 @@ func TestServerInterruptsShellCommandWithoutStoppingProvider(t *testing.T) {
 	if completion := events[len(events)-1]; completion.Type != EventTurnCompleted || completion.Status != "interrupted" {
 		t.Fatalf("shell command completion = %#v", completion)
 	}
+	provider.mu.Lock()
+	if len(provider.shellCommands) != 1 || provider.shellCommands[0].exitCode != -1 {
+		provider.mu.Unlock()
+		t.Fatalf("interrupted shell command context = %#v", provider.shellCommands)
+	}
+	provider.mu.Unlock()
 	if err := syscall.Kill(shellPID, 0); !errors.Is(err, syscall.ESRCH) {
 		t.Fatalf("shell process %d remains after interrupt: %v", shellPID, err)
 	}
@@ -3375,6 +3418,60 @@ func TestCodexRequestOmitsNilParams(t *testing.T) {
 	pending <- codexResponse{Result: json.RawMessage(`{}`)}
 	if err := <-requestDone; err != nil {
 		t.Fatalf("Codex request error = %v", err)
+	}
+}
+
+func TestCodexRecordsShellCommandInContext(t *testing.T) {
+	reader, writer := io.Pipe()
+	defer reader.Close()
+	defer writer.Close()
+	provider := &CodexProvider{
+		stdin:    writer,
+		pending:  map[string]chan codexResponse{},
+		threadID: "thread-1",
+		done:     make(chan struct{}),
+	}
+	recordDone := make(chan error, 1)
+	go func() {
+		recordDone <- provider.recordShellCommand(t.Context(), shellCommandRecord{
+			command:  "printf shell-output",
+			exitCode: 0,
+			duration: 1234 * time.Millisecond,
+			output:   "shell-output",
+		})
+	}()
+
+	var request struct {
+		ID     int64  `json:"id"`
+		Method string `json:"method"`
+		Params struct {
+			ThreadID string `json:"threadId"`
+			Items    []struct {
+				Type    string `json:"type"`
+				Role    string `json:"role"`
+				Content []struct {
+					Type string `json:"type"`
+					Text string `json:"text"`
+				} `json:"content"`
+			} `json:"items"`
+		} `json:"params"`
+	}
+	if err := json.NewDecoder(reader).Decode(&request); err != nil {
+		t.Fatal(err)
+	}
+	if request.Method != "thread/inject_items" || request.Params.ThreadID != "thread-1" {
+		t.Fatalf("Codex shell context request = %#v", request)
+	}
+	if len(request.Params.Items) != 1 || request.Params.Items[0].Type != "message" || request.Params.Items[0].Role != "user" || len(request.Params.Items[0].Content) != 1 || request.Params.Items[0].Content[0].Type != "input_text" {
+		t.Fatalf("Codex shell context item = %#v", request.Params.Items)
+	}
+	want := "<user_shell_command>\n<command>\nprintf shell-output\n</command>\n<result>\nExit code: 0\nDuration: 1.2340 seconds\nOutput:\nshell-output\n</result>\n</user_shell_command>"
+	if got := request.Params.Items[0].Content[0].Text; got != want {
+		t.Fatalf("Codex shell context text = %q, want %q", got, want)
+	}
+	respondCodexRequest(t, provider, request.ID, `{}`)
+	if err := <-recordDone; err != nil {
+		t.Fatalf("recordShellCommand() error = %v", err)
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Session `!COMMAND` execution now records the command, exit code, duration, and retained output in agent context without starting an extra model turn.

- Codex appends the native `<user_shell_command>` item through `thread/inject_items`.
- OpenCode appends the same context through a message with `noReply: true`.
- Claude Code, which has no no-reply input operation, queues command records and includes them as separate text blocks in the next ordinary user message.
- Interrupted commands are recorded with exit code `-1`, matching Codex CLI behavior.

Provider-specific tests verify the payload and that context recording does not generate an extra turn.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Verification:

- `make update`
- `make verify`
- `make build`
- `make test` passes `internal/sessionruntime` but the repository-wide command is currently red on two unrelated `internal/controller` Codex entrypoint fixture tests: `TestCodexEntrypointUsesPersistentSessionHome` expects an empty config despite `cli_auth_credentials_store = "file"`, and `TestAgentEntrypointsPreserveSkillReferenceFiles/codex` cannot find its fixture skill reference.

#### Does this PR introduce a user-facing change?

```release-note
Session !COMMAND results are added to the agent conversation context without starting an extra model turn.
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Include manual `!COMMAND` results in the agent conversation context without starting a model turn. Previously `!COMMAND` ran outside the model; now we persist the command, exit code, duration, and retained output for subsequent turns.

- Server: captures output, formats a `<user_shell_command>` text block, and records it via the provider; records interrupted commands with exit code -1; if recording fails, emits an error and marks the turn failed; tool events unchanged and no model turn is created.
- Codex: injects an `input_text` item via `thread/inject_items`.
- OpenCode: posts a `noReply: true` session message containing the context.
- Claude Code: queues records and prefixes them as text blocks on the next user prompt; queue is cleared after send.
- Docs: updated to reflect the new behavior across providers.

<sup>Written for commit 30f84ea37c217ce0a3330f8140e4536abdcb974f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1687?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

