### PR TITLE
Make console sidebar controls scrollable

### DIFF
--- a/internal/consoleserver/frontend/app.ts
+++ b/internal/consoleserver/frontend/app.ts
@@ -438,6 +438,7 @@ const elements = requireElements({
   resetButton: document.querySelector('#reset-session'),
   deleteButton: document.querySelector('#delete-session'),
   sidebar: document.querySelector('#sidebar'),
+  sidebarScroll: document.querySelector('.sidebar-scroll'),
   openSidebar: document.querySelector('#open-sidebar'),
   closeSidebar: document.querySelector('#close-sidebar'),
   sidebarScrim: document.querySelector('#sidebar-scrim'),
@@ -5212,7 +5213,7 @@ document.querySelectorAll('.open-sidebar-button').forEach(button => {
 });
 elements.closeSidebar.addEventListener('click', () => setSidebarOpen(false));
 elements.sidebarScrim.addEventListener('click', () => setSidebarOpen(false));
-elements.list.addEventListener('scroll', () => closeSessionActionsMenu());
+elements.sidebarScroll.addEventListener('scroll', () => closeSessionActionsMenu());
 window.addEventListener('resize', () => closeSessionActionsMenu());
 document.addEventListener('pointerdown', event => {
   if (elements.sessionActionsMenu.hidden) return;

--- a/internal/consoleserver/server_test.go
+++ b/internal/consoleserver/server_test.go
@@ -1516,6 +1516,22 @@ func TestSessionUIAdaptsToPhoneViewport(t *testing.T) {
 			t.Errorf("Session page is missing %s: %s", description, expected)
 		}
 	}
+	scrollStart := bytes.Index(index, []byte(`<div class="sidebar-scroll">`))
+	scrollEnd := bytes.Index(index, []byte(`<div class="sidebar-footer">`))
+	if scrollStart < 0 || scrollEnd <= scrollStart {
+		t.Fatal("Session page does not define sidebar scrolling before the fixed footer")
+	}
+	scrollContent := string(index[scrollStart:scrollEnd])
+	for description, expected := range map[string]string{
+		"new Session action":    `id="new-session"`,
+		"namespace switcher":    `id="namespace-form"`,
+		"console navigation":    `class="console-nav"`,
+		"Session conversations": `id="session-list"`,
+	} {
+		if !strings.Contains(scrollContent, expected) {
+			t.Errorf("Scrollable sidebar is missing %s: %s", description, expected)
+		}
+	}
 	for description, expected := range map[string]string{
 		"dynamic viewport height":            `height: 100dvh`,
 		"desktop sidebar width":              `grid-template-columns: 260px minmax(0, 1fr)`,
@@ -1535,6 +1551,7 @@ func TestSessionUIAdaptsToPhoneViewport(t *testing.T) {
 		"desktop composer alignment":         `.composer textarea { flex: 1; min-height: 36px;`,
 		"mobile composer alignment":          `.composer textarea { min-height: 44px; padding: 10px 2px; line-height: 24px; }`,
 		"phone-sized dialog":                 `max-height: calc(100dvh - 16px`,
+		"scrolling sidebar controls":         `.sidebar-scroll { flex: 1; min-height: 0; overflow-y: auto;`,
 		"shrinking composer content":         `z-index: 2; min-width: 0;`,
 	} {
 		if !strings.Contains(string(styles), expected) {
@@ -1542,8 +1559,9 @@ func TestSessionUIAdaptsToPhoneViewport(t *testing.T) {
 		}
 	}
 	for description, expected := range map[string]string{
-		"sidebar backdrop action": `elements.sidebarScrim.addEventListener('click', () => setSidebarOpen(false))`,
-		"sidebar Escape action":   `event.key === 'Escape' && elements.sidebar.classList.contains('open')`,
+		"sidebar backdrop action":       `elements.sidebarScrim.addEventListener('click', () => setSidebarOpen(false))`,
+		"sidebar Escape action":         `event.key === 'Escape' && elements.sidebar.classList.contains('open')`,
+		"sidebar scroll menu dismissal": `elements.sidebarScroll.addEventListener('scroll', () => closeSessionActionsMenu())`,
 	} {
 		if !strings.Contains(string(javascript), expected) {
 			t.Errorf("Session behavior is missing %s: %s", description, expected)

--- a/internal/consoleserver/web/app.js
+++ b/internal/consoleserver/web/app.js
@@ -130,6 +130,7 @@
         resetButton: document.querySelector('#reset-session'),
         deleteButton: document.querySelector('#delete-session'),
         sidebar: document.querySelector('#sidebar'),
+        sidebarScroll: document.querySelector('.sidebar-scroll'),
         openSidebar: document.querySelector('#open-sidebar'),
         closeSidebar: document.querySelector('#close-sidebar'),
         sidebarScrim: document.querySelector('#sidebar-scrim'),
@@ -4923,7 +4924,7 @@ spec:
     });
     elements.closeSidebar.addEventListener('click', () => setSidebarOpen(false));
     elements.sidebarScrim.addEventListener('click', () => setSidebarOpen(false));
-    elements.list.addEventListener('scroll', () => closeSessionActionsMenu());
+    elements.sidebarScroll.addEventListener('scroll', () => closeSessionActionsMenu());
     window.addEventListener('resize', () => closeSessionActionsMenu());
     document.addEventListener('pointerdown', event => {
         if (elements.sessionActionsMenu.hidden)

--- a/internal/consoleserver/web/index.html
+++ b/internal/consoleserver/web/index.html
@@ -18,26 +18,28 @@
         </div>
         <button class="icon-button mobile-only" id="close-sidebar" aria-label="Close navigation">×</button>
       </div>
-      <button class="new-session-button" id="new-session" type="button">
-        <span aria-hidden="true">＋</span> New session
-      </button>
-      <form class="namespace-form" id="namespace-form">
-        <label for="active-namespace">Namespace</label>
-        <div>
-          <input id="active-namespace" required autocomplete="off" aria-label="Active namespace">
-          <button type="submit">Switch</button>
+      <div class="sidebar-scroll">
+        <button class="new-session-button" id="new-session" type="button">
+          <span aria-hidden="true">＋</span> New session
+        </button>
+        <form class="namespace-form" id="namespace-form">
+          <label for="active-namespace">Namespace</label>
+          <div>
+            <input id="active-namespace" required autocomplete="off" aria-label="Active namespace">
+            <button type="submit">Switch</button>
+          </div>
+        </form>
+        <nav class="console-nav" aria-label="Console">
+          <button id="console-overview" type="button" aria-current="page"><span aria-hidden="true">⌂</span> Overview</button>
+          <button id="console-sessions" type="button"><span aria-hidden="true">◌</span> Sessions</button>
+          <button id="console-resources" type="button"><span aria-hidden="true">◇</span> Resources</button>
+        </nav>
+        <div class="session-sidebar" id="session-sidebar" hidden>
+          <div class="session-sidebar-header">
+            <div class="sidebar-label">Conversations</div>
+          </div>
+          <div class="session-list" id="session-list" aria-live="polite"></div>
         </div>
-      </form>
-      <nav class="console-nav" aria-label="Console">
-        <button id="console-overview" type="button" aria-current="page"><span aria-hidden="true">⌂</span> Overview</button>
-        <button id="console-sessions" type="button"><span aria-hidden="true">◌</span> Sessions</button>
-        <button id="console-resources" type="button"><span aria-hidden="true">◇</span> Resources</button>
-      </nav>
-      <div class="session-sidebar" id="session-sidebar" hidden>
-        <div class="session-sidebar-header">
-          <div class="sidebar-label">Conversations</div>
-        </div>
-        <div class="session-list" id="session-list" aria-live="polite"></div>
       </div>
       <div class="sidebar-footer">
         <button class="quiet-button" id="refresh-console">Refresh</button>

--- a/internal/consoleserver/web/styles.css
+++ b/internal/consoleserver/web/styles.css
@@ -38,7 +38,8 @@ button { color: inherit; }
 .brand-mark { width: 30px; height: 30px; display: grid; place-items: center; border-radius: 50%; background: var(--accent); color: #fff; font: 700 13px/1 ui-monospace, SFMono-Regular, Menlo, monospace; }
 .brand { font-size: 15px; font-weight: 650; letter-spacing: -.01em; }
 .brand-subtitle { margin-top: 1px; color: var(--muted); font-size: 11px; }
-.new-session-button { min-height: 40px; display: flex; align-items: center; justify-content: flex-start; gap: 9px; margin: 0; padding: 9px 10px; border: 0; border-radius: 9px; background: transparent; font-size: 13px; font-weight: 500; cursor: pointer; transition: background .15s; }
+.sidebar-scroll { flex: 1; min-height: 0; overflow-y: auto; scrollbar-width: thin; }
+.new-session-button { width: 100%; min-height: 40px; display: flex; align-items: center; justify-content: flex-start; gap: 9px; margin: 0; padding: 9px 10px; border: 0; border-radius: 9px; background: transparent; font-size: 13px; font-weight: 500; cursor: pointer; transition: background .15s; }
 .new-session-button:hover { background: var(--line-soft); }
 .new-session-button span { width: 20px; font-size: 18px; text-align: center; }
 .namespace-form { margin: 8px 0; padding: 0 3px; }
@@ -52,11 +53,8 @@ button { color: inherit; }
 .console-nav button:hover { background: var(--line-soft); }
 .console-nav button[aria-current="page"] { background: var(--line-soft); font-weight: 600; }
 .console-nav button span { display: grid; place-items: center; color: var(--ink); font-size: 17px; }
-.session-sidebar { flex: 1; min-height: 0; display: flex; flex-direction: column; }
-.session-sidebar[hidden] { display: none; }
 .session-sidebar-header { min-height: 42px; display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 2px 2px 4px 10px; }
 .sidebar-label { color: var(--muted); font-size: 12px; font-weight: 600; }
-.session-list { flex: 1; min-height: 0; overflow-y: auto; scrollbar-width: thin; }
 .session-section-group { position: relative; border-radius: 11px; transition: background .15s, outline-color .15s; }
 .session-section-group + .session-section-group { margin-top: 10px; }
 .session-section-heading { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin: 0; padding: 6px 9px 4px; color: var(--faint); font-size: 11px; font-weight: 600; }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Moves New session, the namespace switcher, console navigation, and the conversation list into one scrollable sidebar region. The Kelos brand and Refresh/Sign out footer remain fixed, allowing long Session lists to use the space currently reserved by the controls after scrolling.

```text
Before                              After
+----------------------+            +----------------------+
| Kelos                | fixed      | Kelos                | fixed
+----------------------+            +----------------------+
| New session          | fixed      | +------------------+ |
| Namespace            | fixed      | | New session      | |
| Overview             | fixed      | | Namespace        | |
| Sessions             | fixed      | | Overview         | | scrolls
| Resources            | fixed      | | Sessions         | |
+----------------------+            | | Resources        | |
| Conversations        | scrolls    | | Conversations    | |
| ...                  |            | | ...              | |
+----------------------+            | +------------------+ |
| Refresh | Sign out   | fixed      | Refresh | Sign out   | fixed
+----------------------+            +----------------------+
```

Adds a UI structure assertion covering every control expected inside the shared scroll region.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

- `make verify` passes.
- The `internal/consoleserver` unit tests pass as part of `make test`.
- The full `make test` run has two unrelated failures in `internal/controller` because the local Codex environment injects `config.toml` content and does not provide the test skill reference at the expected temporary path.

#### Does this PR introduce a user-facing change?

```release-note
Console sidebar controls now scroll with the Session list, leaving more space for conversations while keeping the brand and footer fixed.
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the console sidebar controls scroll with the Session list so they no longer reserve fixed space. Previously these controls were fixed above the list; now they scroll together, while the brand/header and footer remain fixed. Scrolling the sidebar now dismisses the session actions menu.

- HTML: Groups New session, namespace switcher, console navigation, and the conversation list inside a .sidebar-scroll container placed before .sidebar-footer.
- CSS: Adds .sidebar-scroll { flex: 1; min-height: 0; overflow-y: auto; scrollbar-width: thin }, sets .new-session-button to width: 100%, and removes the separate scroller from .session-list (and related .session-sidebar flex rules).
- JS/TS: Selects sidebarScroll and moves the scroll listener from elements.list to elements.sidebarScroll to close the session actions menu on scroll.
- Tests: Extends TestSessionUIAdaptsToPhoneViewport to assert the scroll region exists with expected contents, that the .sidebar-scroll CSS rule is present, and that the updated sidebar scroll listener is wired in the compiled JS.

<sup>Written for commit a37d00bb2de194d3ba3bfe9e7d141b3c500b4c4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

