### PR TITLE
Label Task completion and duration metrics by spawner

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1430,13 +1430,15 @@ The Kelos controller and spawner pods expose Prometheus metrics on their `/metri
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
-| `kelos_task_created_total` | Counter | namespace, type | Total Tasks for which a Job was created |
-| `kelos_task_completed_total` | Counter | namespace, type, phase | Total Tasks that reached a terminal phase |
-| `kelos_task_duration_seconds` | Histogram | namespace, type, phase | Duration of Task execution from start to completion |
+| `kelos_task_created_total` | Counter | namespace, type, spawner | Total Tasks for which a Job was created |
+| `kelos_task_completed_total` | Counter | namespace, type, spawner, phase | Total Tasks that reached a terminal phase |
+| `kelos_task_duration_seconds` | Histogram | namespace, type, spawner, phase | Duration of Task execution from start to completion |
 | `kelos_task_cost_usd_total` | Counter | namespace, type, spawner, model | Cumulative cost in USD of completed Tasks |
 | `kelos_task_input_tokens_total` | Counter | namespace, type, spawner, model | Cumulative input tokens consumed by completed Tasks |
 | `kelos_task_output_tokens_total` | Counter | namespace, type, spawner, model | Cumulative output tokens consumed by completed Tasks |
 | `kelos_reconcile_errors_total` | Counter | controller | Reconciliation errors |
+
+`kelos_task_created_total` counts only Tasks that run as a Job; Tasks executed by a WorkerPool are not counted. `kelos_task_completed_total` and `kelos_task_duration_seconds` cover both. Comparing created against completed for a given `spawner` is therefore only meaningful for spawners that do not route to a WorkerPool.
 
 ### Spawner Metrics
 

--- a/internal/controller/job_builder.go
+++ b/internal/controller/job_builder.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
+	"github.com/kelos-dev/kelos/internal/taskbuilder"
 )
 
 const (
@@ -162,6 +163,14 @@ func resolveTaskType(task *kelos.Task) string {
 		return task.Spec.Worker.Type
 	}
 	return task.Spec.Type
+}
+
+// resolveTaskSpawner returns the name of the TaskSpawner that created a Task,
+// or the empty string for Tasks that were not created by a spawner. The label
+// is written by taskbuilder, so the key is sourced from there rather than
+// respelled here.
+func resolveTaskSpawner(task *kelos.Task) string {
+	return task.Labels[taskbuilder.SpawnerLabel]
 }
 
 // resolveTaskWorkspaceRef returns the effective workspace reference for a Task,
@@ -382,7 +391,7 @@ func (b *JobBuilder) buildAgentJob(task *kelos.Task, workspace *kelos.WorkspaceS
 		Value: agentType,
 	})
 
-	if spawner := task.Labels["kelos.dev/taskspawner"]; spawner != "" {
+	if spawner := resolveTaskSpawner(task); spawner != "" {
 		envVars = append(envVars, corev1.EnvVar{
 			Name:  "KELOS_TASKSPAWNER",
 			Value: spawner,

--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -3,6 +3,8 @@ package controller
 import (
 	"github.com/prometheus/client_golang/prometheus"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
 )
 
 var (
@@ -12,7 +14,7 @@ var (
 			Name: "kelos_task_created_total",
 			Help: "Total number of Tasks for which a Job was created",
 		},
-		[]string{"namespace", "type"},
+		[]string{"namespace", "type", "spawner"},
 	)
 
 	// taskCompletedTotal counts the total number of Tasks that reached a terminal phase.
@@ -21,7 +23,7 @@ var (
 			Name: "kelos_task_completed_total",
 			Help: "Total number of Tasks that reached a terminal phase",
 		},
-		[]string{"namespace", "type", "phase"},
+		[]string{"namespace", "type", "spawner", "phase"},
 	)
 
 	// taskDurationSeconds records the duration of Task execution.
@@ -31,7 +33,7 @@ var (
 			Help:    "Duration of Task execution from start to completion",
 			Buckets: []float64{30, 60, 120, 300, 600, 1200, 1800, 3600},
 		},
-		[]string{"namespace", "type", "phase"},
+		[]string{"namespace", "type", "spawner", "phase"},
 	)
 
 	// reconcileErrorsTotal counts the total number of reconciliation errors.
@@ -70,6 +72,23 @@ var (
 		[]string{"namespace", "type", "spawner", "model"},
 	)
 )
+
+// recordTaskCompleted increments taskCompletedTotal for a Task that has just
+// reached a terminal phase. Callers are responsible for the transition guard;
+// this only owns the label tuple.
+//
+// taskCompletedTotal and taskDurationSeconds use positional label values, so a
+// reordering of their label slices above would silently mislabel every series
+// if the tuple were respelled at each call site. Both are built here instead.
+func recordTaskCompleted(task *kelos.Task, phase kelos.TaskPhase) {
+	taskCompletedTotal.WithLabelValues(task.Namespace, resolveTaskType(task), resolveTaskSpawner(task), string(phase)).Inc()
+}
+
+// observeTaskDuration records the execution duration of a Task that reached the
+// given terminal phase.
+func observeTaskDuration(task *kelos.Task, phase kelos.TaskPhase, seconds float64) {
+	taskDurationSeconds.WithLabelValues(task.Namespace, resolveTaskType(task), resolveTaskSpawner(task), string(phase)).Observe(seconds)
+}
 
 func init() {
 	metrics.Registry.MustRegister(

--- a/internal/controller/metrics_test.go
+++ b/internal/controller/metrics_test.go
@@ -38,31 +38,31 @@ func TestMetricsRegistered(t *testing.T) {
 }
 
 func TestTaskCreatedTotalCounter(t *testing.T) {
-	taskCreatedTotal.WithLabelValues("default", "claude-code").Add(0)
-	before := testutil.ToFloat64(taskCreatedTotal.WithLabelValues("default", "claude-code"))
+	taskCreatedTotal.WithLabelValues("default", "claude-code", "slack-general").Add(0)
+	before := testutil.ToFloat64(taskCreatedTotal.WithLabelValues("default", "claude-code", "slack-general"))
 
-	taskCreatedTotal.WithLabelValues("default", "claude-code").Inc()
+	taskCreatedTotal.WithLabelValues("default", "claude-code", "slack-general").Inc()
 
-	after := testutil.ToFloat64(taskCreatedTotal.WithLabelValues("default", "claude-code"))
+	after := testutil.ToFloat64(taskCreatedTotal.WithLabelValues("default", "claude-code", "slack-general"))
 	if after != before+1 {
 		t.Errorf("expected taskCreatedTotal to increment by 1, got delta %f", after-before)
 	}
 }
 
 func TestTaskCompletedTotalCounter(t *testing.T) {
-	taskCompletedTotal.WithLabelValues("default", "claude-code", "Succeeded").Add(0)
-	before := testutil.ToFloat64(taskCompletedTotal.WithLabelValues("default", "claude-code", "Succeeded"))
+	taskCompletedTotal.WithLabelValues("default", "claude-code", "slack-general", "Succeeded").Add(0)
+	before := testutil.ToFloat64(taskCompletedTotal.WithLabelValues("default", "claude-code", "slack-general", "Succeeded"))
 
-	taskCompletedTotal.WithLabelValues("default", "claude-code", "Succeeded").Inc()
+	taskCompletedTotal.WithLabelValues("default", "claude-code", "slack-general", "Succeeded").Inc()
 
-	after := testutil.ToFloat64(taskCompletedTotal.WithLabelValues("default", "claude-code", "Succeeded"))
+	after := testutil.ToFloat64(taskCompletedTotal.WithLabelValues("default", "claude-code", "slack-general", "Succeeded"))
 	if after != before+1 {
 		t.Errorf("expected taskCompletedTotal to increment by 1, got delta %f", after-before)
 	}
 }
 
 func TestTaskDurationSecondsHistogram(t *testing.T) {
-	taskDurationSeconds.WithLabelValues("test-ns", "claude-code", "Succeeded").Observe(120.5)
+	taskDurationSeconds.WithLabelValues("test-ns", "claude-code", "slack-general", "Succeeded").Observe(120.5)
 
 	// Verify the histogram was observed by checking the underlying collector
 	count := testutil.CollectAndCount(taskDurationSeconds)

--- a/internal/controller/task_controller.go
+++ b/internal/controller/task_controller.go
@@ -454,7 +454,7 @@ func (r *TaskReconciler) createJob(ctx context.Context, task *kelos.Task) (ctrl.
 
 	logger.Info("created Job", "job", job.Name)
 	r.recordEvent(task, corev1.EventTypeNormal, "TaskCreated", "Created Job %s for task", job.Name)
-	taskCreatedTotal.WithLabelValues(task.Namespace, resolveTaskType(task)).Inc()
+	taskCreatedTotal.WithLabelValues(task.Namespace, resolveTaskType(task), resolveTaskSpawner(task)).Inc()
 
 	// Update status
 	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
@@ -881,7 +881,7 @@ func (r *TaskReconciler) updateStatus(ctx context.Context, task *kelos.Task, job
 			newMessage = "Task completed successfully"
 			setCompletionTime = true
 			r.recordEvent(task, corev1.EventTypeNormal, "TaskSucceeded", "Task completed successfully")
-			taskCompletedTotal.WithLabelValues(task.Namespace, resolveTaskType(task), string(kelos.TaskPhaseSucceeded)).Inc()
+			recordTaskCompleted(task, kelos.TaskPhaseSucceeded)
 		}
 	} else if isJobFailed(job) {
 		if task.Status.Phase != kelos.TaskPhaseFailed {
@@ -889,7 +889,7 @@ func (r *TaskReconciler) updateStatus(ctx context.Context, task *kelos.Task, job
 			newMessage = "Task failed"
 			setCompletionTime = true
 			r.recordEvent(task, corev1.EventTypeWarning, "TaskFailed", "Task failed")
-			taskCompletedTotal.WithLabelValues(task.Namespace, resolveTaskType(task), string(kelos.TaskPhaseFailed)).Inc()
+			recordTaskCompleted(task, kelos.TaskPhaseFailed)
 		}
 	}
 
@@ -971,7 +971,7 @@ func (r *TaskReconciler) updateStatus(ctx context.Context, task *kelos.Task, job
 	// Record task duration when completion time is set and we have a start time
 	if setCompletionTime && task.Status.StartTime != nil {
 		duration := task.Status.CompletionTime.Time.Sub(task.Status.StartTime.Time).Seconds()
-		taskDurationSeconds.WithLabelValues(task.Namespace, resolveTaskType(task), string(newPhase)).Observe(duration)
+		observeTaskDuration(task, newPhase, duration)
 	}
 
 	// Record cost and token metrics when results are available
@@ -1142,7 +1142,7 @@ func (r *TaskReconciler) checkDependencies(ctx context.Context, task *kelos.Task
 				logger.Error(updateErr, "Unable to update Task status")
 			}
 			r.recordEvent(task, corev1.EventTypeWarning, "DependencyFailed", "Dependency %q failed", depName)
-			taskCompletedTotal.WithLabelValues(task.Namespace, resolveTaskType(task), string(kelos.TaskPhaseFailed)).Inc()
+			recordTaskCompleted(task, kelos.TaskPhaseFailed)
 			return false, ctrl.Result{}, nil
 		}
 
@@ -1293,9 +1293,8 @@ func (r *TaskReconciler) resolvePromptTemplate(ctx context.Context, task *kelos.
 // RecordCostTokenMetrics emits Prometheus counters for cost and token usage
 // extracted from Task results.
 func RecordCostTokenMetrics(task *kelos.Task, results map[string]string) {
-	spawner := task.Labels["kelos.dev/taskspawner"]
 	model := resolveTaskModel(task)
-	labels := []string{task.Namespace, resolveTaskType(task), spawner, model}
+	labels := []string{task.Namespace, resolveTaskType(task), resolveTaskSpawner(task), model}
 
 	if costStr, ok := results["cost-usd"]; ok {
 		if cost, err := strconv.ParseFloat(costStr, 64); err == nil && cost > 0 {

--- a/internal/controller/workerpool_controller.go
+++ b/internal/controller/workerpool_controller.go
@@ -1295,10 +1295,23 @@ func (r *WorkerPoolReconciler) monitorTaskCompletion(ctx context.Context, task *
 
 func (r *WorkerPoolReconciler) completeTask(ctx context.Context, task *kelos.Task, phase kelos.TaskPhase, message string) error {
 	outputs, results := r.readPodOutputs(ctx, task.Namespace, task.Status.PodName, task.Name)
+	// completeTask can run for a Task that is already terminal: the phase switch
+	// in Reconcile routes on a possibly-stale cached copy, while the Get below
+	// refreshes from the API server. Capture the phase actually found there so
+	// completion metrics are only emitted on the transition into a terminal
+	// phase. Assigning inside the retry closure keeps the value consistent with
+	// the attempt that persisted the update.
+	//
+	// This guards on any terminal phase, deliberately broader than the
+	// TaskReconciler's per-phase guards: a Succeeded -> Failed correction records
+	// nothing here, keeping one completion count per Task rather than inflating
+	// the totals a success rate is computed from.
+	var alreadyTerminal bool
 	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		if err := r.Get(ctx, client.ObjectKeyFromObject(task), task); err != nil {
 			return err
 		}
+		alreadyTerminal = isTerminalTaskPhase(task.Status.Phase)
 		task.Status.Phase = phase
 		task.Status.Message = message
 		now := metav1.Now()
@@ -1313,6 +1326,13 @@ func (r *WorkerPoolReconciler) completeTask(ctx context.Context, task *kelos.Tas
 		return r.Status().Update(ctx, task)
 	}); err != nil {
 		return err
+	}
+
+	if !alreadyTerminal {
+		recordTaskCompleted(task, phase)
+		if task.Status.StartTime != nil {
+			observeTaskDuration(task, phase, task.Status.CompletionTime.Time.Sub(task.Status.StartTime.Time).Seconds())
+		}
 	}
 
 	if results != nil {

--- a/internal/controller/workerpool_controller_test.go
+++ b/internal/controller/workerpool_controller_test.go
@@ -14,6 +14,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
@@ -33,6 +36,7 @@ import (
 
 	kelos "github.com/kelos-dev/kelos/api/v1alpha2"
 	"github.com/kelos-dev/kelos/internal/githubapp"
+	"github.com/kelos-dev/kelos/internal/taskbuilder"
 )
 
 func newWorkerPoolTestScheme() *runtime.Scheme {
@@ -667,6 +671,117 @@ func TestWorkerPoolReconciler_TaskCompletionFailed(t *testing.T) {
 	assert.Equal(t, kelos.TaskPhaseFailed, updatedTask.Status.Phase)
 	assert.Equal(t, "OOM killed", updatedTask.Status.Message)
 	assert.NotNil(t, updatedTask.Status.CompletionTime)
+}
+
+// durationSampleCount returns the number of observations recorded by
+// taskDurationSeconds for the given label values.
+func durationSampleCount(t *testing.T, labels ...string) uint64 {
+	t.Helper()
+	observer, err := taskDurationSeconds.GetMetricWithLabelValues(labels...)
+	require.NoError(t, err)
+	var pb dto.Metric
+	require.NoError(t, observer.(prometheus.Metric).Write(&pb))
+	return pb.GetHistogram().GetSampleCount()
+}
+
+// TestWorkerPoolReconciler_CompleteTaskRecordsCompletionMetrics covers the
+// WorkerPool completion path, which previously set the terminal phase without
+// ever incrementing taskCompletedTotal or observing taskDurationSeconds, so
+// every Task served by a WorkerPool was absent from both metrics.
+func TestWorkerPoolReconciler_CompleteTaskRecordsCompletionMetrics(t *testing.T) {
+	scheme := newWorkerPoolTestScheme()
+
+	startTime := metav1.NewTime(time.Now().Add(-90 * time.Second))
+	task := &kelos.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-task",
+			Namespace: "default",
+			Labels:    map[string]string{taskbuilder.SpawnerLabel: "wp-spawner"},
+		},
+		Spec: kelos.TaskSpec{
+			Type:   AgentTypeClaudeCode,
+			Prompt: "Do something",
+			WorkerPoolRef: &kelos.WorkerPoolReference{
+				Name: "my-pool",
+			},
+		},
+		Status: kelos.TaskStatus{
+			Phase:     kelos.TaskPhaseRunning,
+			PodName:   "wp-my-pool-0",
+			StartTime: &startTime,
+		},
+	}
+
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&kelos.Task{}).
+		WithObjects(task).
+		Build()
+
+	r := newWorkerPoolReconciler(cl, scheme)
+
+	labels := []string{"default", AgentTypeClaudeCode, "wp-spawner", string(kelos.TaskPhaseSucceeded)}
+	completedBefore := testutil.ToFloat64(taskCompletedTotal.WithLabelValues(labels...))
+	durationBefore := durationSampleCount(t, labels...)
+
+	require.NoError(t, r.completeTask(context.Background(), task, kelos.TaskPhaseSucceeded, ""))
+
+	assert.Equal(t, completedBefore+1, testutil.ToFloat64(taskCompletedTotal.WithLabelValues(labels...)),
+		"expected taskCompletedTotal to increment once on the transition to a terminal phase")
+	assert.Equal(t, durationBefore+1, durationSampleCount(t, labels...),
+		"expected taskDurationSeconds to record one observation")
+
+	// completeTask is reachable again on a re-reconcile of an already-terminal
+	// Task; it must not double-count.
+	require.NoError(t, r.completeTask(context.Background(), task, kelos.TaskPhaseSucceeded, ""))
+
+	assert.Equal(t, completedBefore+1, testutil.ToFloat64(taskCompletedTotal.WithLabelValues(labels...)),
+		"expected no further taskCompletedTotal increment for an already-terminal Task")
+	assert.Equal(t, durationBefore+1, durationSampleCount(t, labels...),
+		"expected no further taskDurationSeconds observation for an already-terminal Task")
+}
+
+// TestWorkerPoolReconciler_CompleteTaskSkipsDurationWithoutStartTime ensures a
+// Task that never recorded a start time still counts as completed.
+func TestWorkerPoolReconciler_CompleteTaskSkipsDurationWithoutStartTime(t *testing.T) {
+	scheme := newWorkerPoolTestScheme()
+
+	task := &kelos.Task{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "no-start-task",
+			Namespace: "default",
+			Labels:    map[string]string{taskbuilder.SpawnerLabel: "no-start-spawner"},
+		},
+		Spec: kelos.TaskSpec{
+			Type:   AgentTypeClaudeCode,
+			Prompt: "Do something",
+			WorkerPoolRef: &kelos.WorkerPoolReference{
+				Name: "my-pool",
+			},
+		},
+		Status: kelos.TaskStatus{
+			Phase:   kelos.TaskPhasePending,
+			PodName: "wp-my-pool-0",
+		},
+	}
+
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&kelos.Task{}).
+		WithObjects(task).
+		Build()
+
+	r := newWorkerPoolReconciler(cl, scheme)
+
+	labels := []string{"default", AgentTypeClaudeCode, "no-start-spawner", string(kelos.TaskPhaseFailed)}
+	completedBefore := testutil.ToFloat64(taskCompletedTotal.WithLabelValues(labels...))
+	durationBefore := durationSampleCount(t, labels...)
+
+	require.NoError(t, r.completeTask(context.Background(), task, kelos.TaskPhaseFailed, "Worker pod was deleted"))
+
+	assert.Equal(t, completedBefore+1, testutil.ToFloat64(taskCompletedTotal.WithLabelValues(labels...)))
+	assert.Equal(t, durationBefore, durationSampleCount(t, labels...),
+		"expected no duration observation when StartTime is nil")
 }
 
 func TestRequestWorkerPodTaskCancellationMarksAssignedTask(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

`kelos_task_cost_usd_total`, `kelos_task_input_tokens_total` and `kelos_task_output_tokens_total` already carry a `spawner` label, so spend can be attributed per TaskSpawner. `kelos_task_created_total`, `kelos_task_completed_total` and `kelos_task_duration_seconds` do not, so there is no way to compute a per-spawner success rate or latency from metrics at all. This PR adds `spawner` to those three, making queries like the following meaningful:

```
sum(rate(kelos_task_completed_total{spawner="my-spawner"}[1w])) by (phase)
```

`spawner` is placed directly after `type`, the same position the cost metrics use, so all six task metrics read consistently and the three task counters stay mutually joinable — a created-vs-completed reconciliation per spawner is how you spot Tasks that never reach a terminal phase.

The label is derived through a new `resolveTaskSpawner` helper next to `resolveTaskType` in `job_builder.go`, which reads the existing exported `taskbuilder.SpawnerLabel` constant rather than respelling the key. `RecordCostTokenMetrics` now uses the helper too, so there is exactly one definition of which spawner owns a Task instead of a bare `kelos.dev/taskspawner` string literal in the metrics path. The remaining literal in `job_builder.go`, which injects `KELOS_TASKSPAWNER` into the agent pod, goes through the same helper.

`taskCompletedTotal` and `taskDurationSeconds` take positional label values, so a future reordering of their label slices would silently mislabel every series if the tuple were respelled at each of the four call sites. The tuples are therefore built in `recordTaskCompleted` and `observeTaskDuration` next to the metric definitions in `metrics.go`. These deliberately stay two separate helpers rather than one combined `recordTaskCompletionMetrics`: in `TaskReconciler.updateStatus` the counter increment happens during phase determination (before the status update) while the duration observation happens after it, so a combined helper would require moving the increment across the status update — a control-flow change to the reconciler that is out of scope here. Each call site keeps its original position.

While tracing the metric paths, a second and larger gap turned up, fixed here in the same change: `WorkerPoolReconciler.completeTask` sets the terminal phase, sets the completion time and records cost/token metrics, but never increments `kelos_task_completed_total` and never observes `kelos_task_duration_seconds`. Every Task served by a WorkerPool was therefore entirely absent from both metrics. `completeTask` now records both. Adding the `spawner` label without fixing this would have produced per-spawner dashboards that silently omit all WorkerPool-backed Tasks.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

**`created_total` is not comparable to `completed_total` for WorkerPool Tasks.** `kelos_task_created_total` fires only in `TaskReconciler.createJob`, so WorkerPool-backed Tasks — which now do increment `kelos_task_completed_total` thanks to the fix above — are still absent from it. A created-vs-completed reconciliation will therefore show completed > created for any spawner routing to a WorkerPool. `docs/reference.md` now states this under the metrics table. Making `created_total` cover WorkerPool Tasks would change what the metric means (there is no Job to create), so it is left for a separate change.

**Known pre-existing issue, deliberately not fixed here.** `RecordCostTokenMetrics` in `completeTask` is unguarded, so a second completion of an already-terminal Task whose pod logs are still readable re-adds cost and tokens. The `alreadyTerminal` flag added here would suppress it, but the fix is not quite that simple: unlike the Job path — which bounds re-recording via `retryOutputs`, gated on `len(Status.Results) == 0` — the WorkerPool path has no late-outputs retry, so a plain `!alreadyTerminal` guard would also skip cost recording in the case where the second pass is the first one to capture results at all, leaving `Status.Usage` populated but the cost counters not. Since this touches budget accounting rather than the labels this PR is about, it is left for a follow-up with its own test.

**Cardinality is bounded.** `spawner` is the name of a TaskSpawner in the cluster, so the added dimension is the number of spawners — on the order of tens — times the existing worker types and phases. No cardinality mitigation is needed.

**Series identity changes.** Adding a label changes the series identity of the three metrics, so any existing recording rule, alert or dashboard selecting on them would need updating. No compatibility shim or duplicate unlabelled metric is included here deliberately, on the assumption these metrics have no rule/dashboard consumers in tree; please flag if that assumption is wrong for your deployments.

**Empty spawner is intentional.** Tasks created manually or through the API carry no `kelos.dev/taskspawner` label and report `spawner=""`. This matches exactly what the cost and token metrics already do; substituting `"none"` or `"unknown"` would make the two metric families disagree for the same Task.

**Double-counting in the WorkerPool path.** The `TaskReconciler` paths guard their increments with `if task.Status.Phase != <terminal>`, so `completeTask` needs an equivalent. It captures `isTerminalTaskPhase(task.Status.Phase)` inside the `RetryOnConflict` closure, immediately after the `Get` and before the phase is overwritten, and only records when the Task was not already terminal. Assigning inside the closure rather than before it keeps the value consistent with the attempt that actually persisted the status update. The duration observation is additionally skipped when `Status.StartTime` is nil, matching the `TaskReconciler` behaviour.

Note on reachability: the phase switch in `Reconcile` routes `Succeeded`/`Failed` away from `monitorTaskCompletion`, so the guard is not load-bearing in the common flow. It matters because that switch reads a possibly-stale cached Task while `completeTask` re-`Get`s from the API server, so a terminal Task can still reach it.

The guard uses `isTerminalTaskPhase`, which is intentionally broader than the `TaskReconciler`'s per-phase checks: a `Succeeded` -> `Failed` correction records nothing here, whereas the Job path would count a second completion for the same Task. Keeping one completion count per Task avoids inflating the denominator of a success-rate query, which is the point of the PR; the code comment records this as a decision.

**Tests.** `TestWorkerPoolReconciler_CompleteTaskRecordsCompletionMetrics` asserts the counter increments exactly once and the histogram records exactly one observation for a Task completed via `completeTask`, and that neither moves on a second call for an already-terminal Task. Both halves were checked to fail without the corresponding production change: removing the metric block fails the first assertions, and replacing the `!alreadyTerminal` guard with an unconditional increment fails the second. A second test covers a Task with no `StartTime`, which must still count as completed but record no duration. The existing `metrics_test.go` label arities were updated with a real spawner value rather than `""`, so an arity regression fails loudly.

`make update` regenerated nothing. `make verify`, `make test` and `make test-integration` all pass locally.

#### Does this PR introduce a user-facing change?

```release-note
The `kelos_task_created_total`, `kelos_task_completed_total` and `kelos_task_duration_seconds` metrics now carry a `spawner` label identifying the TaskSpawner that created the Task, matching the existing cost and token metrics, so per-spawner success rate and latency can be queried. Tasks not created by a spawner report an empty `spawner` value. Note that adding this label changes the series identity of these three metrics, so any queries, dashboards or alerting rules selecting on them may need updating. Additionally, Tasks completed by a WorkerPool are now counted in `kelos_task_completed_total` and `kelos_task_duration_seconds`; previously they were omitted from both entirely.
```
