### PR TITLE
Replace degenerate agent output with a notice in Slack

### DIFF
--- a/internal/reporting/slack.go
+++ b/internal/reporting/slack.go
@@ -117,6 +117,16 @@ func FormatProgressMessage(text, taskName string) SlackMessage {
 	}
 }
 
+// degenerateNoticeText returns the notice shown in place of an agent response
+// that capture flagged as degenerate. The raw response is still preserved in
+// the Task's results; only the Slack rendering is substituted.
+func degenerateNoticeText(phase string) string {
+	if phase == "failed" {
+		return ":warning: The model returned an unusable reply. This ran twice and produced unusable output both times, so there is no answer to show."
+	}
+	return ":warning: The model returned an unusable reply, so there is no answer to show."
+}
+
 // FormatSlackTransitionMessage returns one or more rich Slack messages for a
 // task phase transition. When the agent response is short enough to fit in a
 // single message (≤ SlackBlockLimit blocks), a single SlackMessage is returned.
@@ -133,9 +143,15 @@ func FormatSlackTransitionMessage(phase, taskName, message string, results map[s
 		))
 	}
 
-	// Build the response blocks from the agent output.
+	// Build the response blocks from the agent output. When capture flagged
+	// the output as degenerate, the agent's final message is unusable, so a
+	// short notice is rendered in its place rather than the fragments.
 	resp := results["response"]
 	decoded := decodeResponse(resp)
+	if results["degenerate"] == "true" {
+		decoded = degenerateNoticeText(phase)
+		resp = decoded
+	}
 	var responseBlocks []slack.Block
 	if resp != "" {
 		responseBlocks = responseToBlocks(decoded)

--- a/internal/reporting/slack_test.go
+++ b/internal/reporting/slack_test.go
@@ -636,3 +636,170 @@ func assertContextContains(t *testing.T, block slack.Block, substr string) {
 	}
 	t.Errorf("context block does not contain %q", substr)
 }
+
+// garbledResponse is the real degenerate output posted to a customer thread on
+// 2026-08-21: fragments of HTML with no answer in them.
+const garbledResponse = "`stale=False</li>\n</ul>\n</section\n</section>"
+
+const (
+	degenerateNotice       = ":warning: The model returned an unusable reply, so there is no answer to show."
+	degenerateNoticeFailed = ":warning: The model returned an unusable reply. This ran twice and produced unusable output both times, so there is no answer to show."
+)
+
+// allBlockText concatenates the text of every section and context block so a
+// test can assert that a fragment appears nowhere in the rendered message.
+func allBlockText(blocks []slack.Block) string {
+	var sb strings.Builder
+	for _, b := range blocks {
+		switch block := b.(type) {
+		case *slack.SectionBlock:
+			if block.Text != nil {
+				sb.WriteString(block.Text.Text)
+				sb.WriteString("\n")
+			}
+			for _, f := range block.Fields {
+				sb.WriteString(f.Text)
+				sb.WriteString("\n")
+			}
+		case *slack.HeaderBlock:
+			if block.Text != nil {
+				sb.WriteString(block.Text.Text)
+				sb.WriteString("\n")
+			}
+		case *slack.ContextBlock:
+			for _, elem := range block.ContextElements.Elements {
+				if txt, ok := elem.(*slack.TextBlockObject); ok {
+					sb.WriteString(txt.Text)
+					sb.WriteString("\n")
+				}
+			}
+		}
+	}
+	return sb.String()
+}
+
+// assertNoFragments fails if any part of the garbled response leaked into the
+// rendered blocks or the fallback text.
+func assertNoFragments(t *testing.T, msg SlackMessage) {
+	t.Helper()
+	rendered := allBlockText(msg.Blocks)
+	for _, fragment := range []string{"stale=False", "</ul>", "</section"} {
+		if strings.Contains(rendered, fragment) {
+			t.Errorf("blocks contain garbled fragment %q:\n%s", fragment, rendered)
+		}
+		if strings.Contains(msg.Text, fragment) {
+			t.Errorf("fallback text contains garbled fragment %q: %q", fragment, msg.Text)
+		}
+	}
+}
+
+func TestFormatSlackTransitionMessage_Degenerate(t *testing.T) {
+	t.Run("succeeded substitutes notice for fragments", func(t *testing.T) {
+		results := map[string]string{
+			"response":   b64(garbledResponse),
+			"degenerate": "true",
+		}
+		msgs := FormatSlackTransitionMessage("succeeded", "spawner-1234567890.123456", "", results)
+		if len(msgs) != 1 {
+			t.Fatalf("message count = %d, want 1", len(msgs))
+		}
+		got := msgs[0]
+		if got.Text != degenerateNotice+" (Task: spawner-1234567890.123456)" {
+			t.Errorf("fallback text = %q", got.Text)
+		}
+		assertBlockCount(t, got.Blocks, 2) // notice + context
+		assertSectionText(t, got.Blocks[0], degenerateNotice)
+		assertContextContains(t, got.Blocks[1], "Task: `spawner-1234567890.123456`")
+		assertNoFragments(t, got)
+	})
+
+	t.Run("succeeded keeps the PR link", func(t *testing.T) {
+		results := map[string]string{
+			"response":   b64(garbledResponse),
+			"degenerate": "true",
+			"pr":         "https://github.com/org/repo/pull/42",
+		}
+		got := firstMsg(t, FormatSlackTransitionMessage("succeeded", "spawner-1234567890.123456", "", results))
+		want := degenerateNotice + "\nPR: https://github.com/org/repo/pull/42 (Task: spawner-1234567890.123456)"
+		if got.Text != want {
+			t.Errorf("fallback text = %q, want %q", got.Text, want)
+		}
+		assertBlockCount(t, got.Blocks, 3) // notice + PR + context
+		assertSectionText(t, got.Blocks[0], degenerateNotice)
+		assertSectionText(t, got.Blocks[1], ":link: *Pull Request:* <https://github.com/org/repo/pull/42>")
+		assertNoFragments(t, got)
+	})
+
+	t.Run("failed keeps the error line", func(t *testing.T) {
+		results := map[string]string{
+			"response":   b64(garbledResponse),
+			"degenerate": "true",
+		}
+		got := firstMsg(t, FormatSlackTransitionMessage("failed", "spawner-1234567890.123456", "degenerate_output=turns=41,chars=58", results))
+		want := degenerateNoticeFailed + "\nError: degenerate_output=turns=41,chars=58 (Task: spawner-1234567890.123456)"
+		if got.Text != want {
+			t.Errorf("fallback text = %q, want %q", got.Text, want)
+		}
+		assertBlockCount(t, got.Blocks, 4) // header + notice + error + context
+		assertSectionText(t, got.Blocks[0], ":x: *Something went wrong*")
+		assertSectionText(t, got.Blocks[1], degenerateNoticeFailed)
+		assertSectionText(t, got.Blocks[2], ":warning: *Error:* degenerate_output=turns=41,chars=58")
+		assertNoFragments(t, got)
+	})
+
+	t.Run("no response still renders the notice", func(t *testing.T) {
+		results := map[string]string{"degenerate": "true"}
+		got := firstMsg(t, FormatSlackTransitionMessage("failed", "spawner-1234567890.123456", "", results))
+		if got.Text != degenerateNoticeFailed+" (Task: spawner-1234567890.123456)" {
+			t.Errorf("fallback text = %q", got.Text)
+		}
+		assertBlockCount(t, got.Blocks, 3) // header + notice + context
+		assertSectionText(t, got.Blocks[1], degenerateNoticeFailed)
+	})
+
+	t.Run("long degenerate output stays a single message", func(t *testing.T) {
+		var sb strings.Builder
+		for i := 0; i < 60; i++ {
+			if i > 0 {
+				sb.WriteString("\n\n")
+			}
+			sb.WriteString("### Header\n" + garbledResponse)
+		}
+		results := map[string]string{
+			"response":   b64(sb.String()),
+			"degenerate": "true",
+		}
+		msgs := FormatSlackTransitionMessage("succeeded", "spawner-1234567890.123456", "", results)
+		if len(msgs) != 1 {
+			t.Fatalf("message count = %d, want 1 (split path must not be entered)", len(msgs))
+		}
+		assertBlockCount(t, msgs[0].Blocks, 2) // notice + context
+		if len(msgs[0].Blocks) > SlackBlockLimit {
+			t.Errorf("block count = %d, must be <= %d", len(msgs[0].Blocks), SlackBlockLimit)
+		}
+		assertNoFragments(t, msgs[0])
+	})
+
+	t.Run("marker unset leaves the response untouched", func(t *testing.T) {
+		results := map[string]string{"response": b64("I need your GitHub username to proceed.")}
+		got := firstMsg(t, FormatSlackTransitionMessage("succeeded", "spawner-1234567890.123456", "", results))
+		if got.Text != "I need your GitHub username to proceed. (Task: spawner-1234567890.123456)" {
+			t.Errorf("fallback text = %q", got.Text)
+		}
+		assertBlockCount(t, got.Blocks, 2) // response + context
+		assertSectionText(t, got.Blocks[0], "I need your GitHub username to proceed.")
+	})
+
+	t.Run("marker set to a non-true value leaves the response untouched", func(t *testing.T) {
+		results := map[string]string{
+			"response":   b64("I need your GitHub username to proceed."),
+			"degenerate": "false",
+		}
+		got := firstMsg(t, FormatSlackTransitionMessage("succeeded", "spawner-1234567890.123456", "", results))
+		if got.Text != "I need your GitHub username to proceed. (Task: spawner-1234567890.123456)" {
+			t.Errorf("fallback text = %q", got.Text)
+		}
+		assertBlockCount(t, got.Blocks, 2) // response + context
+		assertSectionText(t, got.Blocks[0], "I need your GitHub username to proceed.")
+	})
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When an agent's final message is unusable, Kelos currently pastes it into the
Slack thread verbatim. On 2026-08-21 that put this into a live customer-issue
thread:

```
`stale=False</li>
</ul>
</section
</section>
```

`FormatSlackTransitionMessage` now reads the `degenerate` marker that
`kelos-capture` sets in the Task's results and renders a short notice in place
of the response:

> :warning: The model returned an unusable reply. This ran twice and produced
> unusable output both times, so there is no answer to show.

The notice is phase-aware — the `failed` phase says the run was attempted twice
(`backoffLimit` is 1, so a Failed Task has exhausted both attempts); other
phases get the shorter form without the count claim.

Everything else in the message is left alone: the PR link block still renders
(the agent may well have opened a real PR before its final message degenerated,
and that link is the most useful thing in the reply), the task-name context
block still renders, and the `:warning: *Error:*` line still renders on the
`failed` phase.

The substitution happens on the decoded response *before* both `responseToBlocks`
and `buildFallbackText` run, so the fragments stay out of the message `Text` too
— otherwise they would still ship in notifications and accessibility surfaces
even with the blocks replaced.

The raw `response` key is left untouched in `task.Status.Results`. It is the
only evidence available for calibrating the detection thresholds, and nothing
here clears it.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

**Depends on `fix/detect-degenerate-claude-output`**, which introduces the
`degenerate` result key. Until that lands this branch is inert: with the marker
unset, every existing code path is unchanged. Two of the new tests assert
exactly that (marker absent, and marker present but not `"true"`).

Deliberately narrow:

- **Slack only.** `TaskReporter` (GitHub comments and check runs) is a different
  surface with different readers and is untouched.
- **The progress path is untouched.** `FormatProgressMessage` renders in-flight
  snapshots from pod logs, not the final result, and has no results map.
- **No change to the retry count.** `backoffLimit` stays at 1.
- **The heuristic is not re-derived here.** This layer is a marker lookup. The
  `reporting` package does not have `num_turns` anyway, and a second copy of the
  predicate would drift from the first.

New tests in `internal/reporting/slack_test.go` use the real 2026-08-21 garbled
output as the fixture and assert the fragments appear in neither the rendered
blocks nor the fallback text: substitution on `succeeded`, PR link survival,
notice plus error line together on `failed`, a degenerate attempt that produced
no response at all, a long garbled response staying a single message (the
multi-message split path is not entered and the block count stays far under
`SlackBlockLimit`), and the two no-op cases above.

`make test` and `make verify` both pass.

#### Does this PR introduce a user-facing change?

```release-note
Slack replies for tasks whose agent returned unusable output now show a short notice instead of the garbled text. The pull request link, task name, and error details are still shown.
```
