### PR TITLE
Fail Claude Code runs that end with a degenerate final message

### DIFF
--- a/docs/agent-image-interface.md
+++ b/docs/agent-image-interface.md
@@ -266,6 +266,13 @@ entrypoint preserves Claude Code's own non-zero exit code when present;
 otherwise, it propagates the capture failure so the Task is not reported as
 successful.
 
+A run that terminates cleanly but returns a final message too short to be an
+answer after many turns is also treated as a failure, since Claude Code reports
+such a run as a success. `kelos-capture` emits `degenerate: true` alongside the
+usual outputs in that case and returns non-zero, so the Job's retry reruns the
+agent. The `response` output is still captured on the failing attempt, so the
+agent's final message is recorded in the Task's results either way.
+
 Also use `set -uo pipefail` (without `-e`) so the capture step runs even if
 the agent exits non-zero.
 

--- a/internal/capture/capture.go
+++ b/internal/capture/capture.go
@@ -20,7 +20,8 @@ const (
 
 // Run streams the agent's JSON output from stdin to stdout, accumulating
 // per-agent token usage in memory, then emits deterministic outputs
-// (branch, commit, PRs, token usage) between markers on stdout. It is
+// (branch, commit, PRs, token usage, and a degenerate marker when Claude
+// Code returned an unusable final message) between markers on stdout. It is
 // intended to be the right-hand side of a pipe from the agent process so
 // that no on-disk copy of the stream is required. It returns non-zero when
 // the stream cannot be processed or Claude Code reports an incomplete result.
@@ -95,7 +96,7 @@ func captureOutputs(r runner, usage map[string]string) []string {
 		}
 	}
 
-	for _, key := range []string{"cost-usd", "input-tokens", "output-tokens", "response"} {
+	for _, key := range []string{"cost-usd", "input-tokens", "output-tokens", "response", "degenerate"} {
 		if v, ok := usage[key]; ok {
 			outputs = append(outputs, key+": "+v)
 		}

--- a/internal/capture/capture_test.go
+++ b/internal/capture/capture_test.go
@@ -285,18 +285,36 @@ func TestRunClaudeCodeResultStatus(t *testing.T) {
 		input      string
 		wantCode   int
 		wantStderr string
+		// wantOutputs are additional captured output lines the marker
+		// block must contain.
+		wantOutputs []string
+		// unwantOutputs are captured output keys the marker block must
+		// not contain.
+		unwantOutputs []string
 	}{
 		{
-			name:       "completed result",
-			input:      `{"type":"result","subtype":"success","is_error":false,"stop_reason":"end_turn","terminal_reason":"completed","total_cost_usd":0.01}` + "\n",
-			wantCode:   0,
-			wantStderr: "",
+			name:          "completed result",
+			input:         `{"type":"result","subtype":"success","is_error":false,"stop_reason":"end_turn","terminal_reason":"completed","total_cost_usd":0.01}` + "\n",
+			wantCode:      0,
+			wantStderr:    "",
+			unwantOutputs: []string{"degenerate: "},
 		},
 		{
-			name:       "incomplete result",
-			input:      `{"type":"result","subtype":"success","is_error":false,"stop_reason":"tool_use","result":"Starting the next tool","total_cost_usd":0.01}` + "\n",
-			wantCode:   1,
-			wantStderr: "kelos-capture: Claude Code run incomplete (stop_reason=tool_use)\n",
+			name:          "incomplete result",
+			input:         `{"type":"result","subtype":"success","is_error":false,"stop_reason":"tool_use","result":"Starting the next tool","total_cost_usd":0.01}` + "\n",
+			wantCode:      1,
+			wantStderr:    "kelos-capture: Claude Code run incomplete (stop_reason=tool_use)\n",
+			unwantOutputs: []string{"degenerate: "},
+		},
+		{
+			// The degenerate marker and the response are both emitted
+			// on the failing attempt so downstream consumers can tell
+			// this failure apart from any other.
+			name:        "degenerate result",
+			input:       `{"type":"result","subtype":"success","is_error":false,"stop_reason":"end_turn","terminal_reason":"completed","num_turns":41,"result":"` + garbledResultJSON + `","total_cost_usd":0.01}` + "\n",
+			wantCode:    1,
+			wantStderr:  "kelos-capture: Claude Code returned a degenerate final message (degenerate_output=turns=41,chars=44)\n",
+			wantOutputs: []string{"degenerate: true\n", "response: "},
 		},
 	}
 
@@ -321,6 +339,16 @@ func TestRunClaudeCodeResultStatus(t *testing.T) {
 				!strings.Contains(stdout.String(), "cost-usd: 0.01\n") ||
 				!strings.Contains(stdout.String(), markerEnd+"\n") {
 				t.Fatalf("stdout is missing captured outputs: %q", stdout.String())
+			}
+			for _, want := range tt.wantOutputs {
+				if !strings.Contains(stdout.String(), want) {
+					t.Fatalf("stdout is missing %q: %q", want, stdout.String())
+				}
+			}
+			for _, unwant := range tt.unwantOutputs {
+				if strings.Contains(stdout.String(), unwant) {
+					t.Fatalf("stdout unexpectedly contains %q: %q", unwant, stdout.String())
+				}
 			}
 		})
 	}

--- a/internal/capture/usage.go
+++ b/internal/capture/usage.go
@@ -45,7 +45,8 @@ func newUsageAccumulator(agentType string) usageAccumulator {
 // `tee` produced previously), and returns the parsed token usage for the
 // given agent type. Returns nil usage for empty/unknown agent types or
 // when no usage data is present. For Claude Code, an incomplete final result
-// returns the parsed usage together with a non-nil error.
+// returns the parsed usage together with a non-nil error; a degenerate final
+// result additionally sets the "degenerate" key in the returned usage.
 //
 // Bytes from r are forwarded to w exactly as read, in order — there is no
 // scanner buffer between us and r, so an arbitrarily long line is still
@@ -100,7 +101,21 @@ func StreamUsage(agentType string, r io.Reader, w io.Writer) (usage map[string]s
 		lastResultAccumulator, ok := acc.(*lastResultAccumulator)
 		if ok && lastResultAccumulator.last != nil {
 			completion := extractClaudeCodeCompletion(lastResultAccumulator.last)
-			if completion.Status() != claudecode.ResultCompleted {
+			status := completion.Status()
+			// Marked only when degeneracy is what makes the run
+			// incomplete. An explicit error result is a different
+			// failure even when its short message trips the same
+			// length floor, and mislabelling it would hide the real
+			// reason from downstream consumers. Recorded even though
+			// the run fails, so those consumers can tell a degenerate
+			// result apart from any other failure.
+			if status == claudecode.ResultIncomplete && completion.IsDegenerateOutput() {
+				if usage == nil {
+					usage = make(map[string]string)
+				}
+				usage["degenerate"] = "true"
+			}
+			if status != claudecode.ResultCompleted {
 				return usage, errors.New(completion.FailureMessage())
 			}
 		}
@@ -220,11 +235,14 @@ func extractClaudeCodeCompletion(m map[string]any) claudecode.Result {
 	isError, _ := m["is_error"].(bool)
 	stopReason, _ := m["stop_reason"].(string)
 	terminalReason, _ := m["terminal_reason"].(string)
+	text, _ := m["result"].(string)
 	return claudecode.Result{
 		Subtype:        subtype,
 		IsError:        isError,
 		StopReason:     stopReason,
 		TerminalReason: terminalReason,
+		Text:           text,
+		NumTurns:       int(toInt64(m["num_turns"])),
 	}
 }
 

--- a/internal/capture/usage_test.go
+++ b/internal/capture/usage_test.go
@@ -2,6 +2,7 @@ package capture
 
 import (
 	"bytes"
+	"encoding/base64"
 	"errors"
 	"strings"
 	"testing"
@@ -183,6 +184,30 @@ func TestStreamUsage(t *testing.T) {
 			},
 		},
 		{
+			name:      "claude-code brief answer after few turns is not degenerate",
+			agentType: "claude-code",
+			content: `{"type":"result","subtype":"success","is_error":false,"num_turns":2,"total_cost_usd":0.01,"result":"Fixed in v0.472.","usage":{"input_tokens":100,"output_tokens":20}}
+`,
+			want: map[string]string{
+				"cost-usd":      "0.01",
+				"input-tokens":  "100",
+				"output-tokens": "20",
+				"response":      "Rml4ZWQgaW4gdjAuNDcyLg==", // base64("Fixed in v0.472.")
+			},
+		},
+		{
+			name:      "claude-code long answer after many turns is not degenerate",
+			agentType: "claude-code",
+			content: `{"type":"result","subtype":"success","is_error":false,"num_turns":41,"total_cost_usd":0.5,"result":"` + strings.Repeat("a", 400) + `","usage":{"input_tokens":100,"output_tokens":20}}
+`,
+			want: map[string]string{
+				"cost-usd":      "0.5",
+				"input-tokens":  "100",
+				"output-tokens": "20",
+				"response":      base64.StdEncoding.EncodeToString([]byte(strings.Repeat("a", 400))),
+			},
+		},
+		{
 			name:      "claude-code no result lines returns nil",
 			agentType: "claude-code",
 			content:   `{"type":"assistant","message":"done"}` + "\n",
@@ -216,6 +241,70 @@ func TestStreamUsageRejectsIncompleteClaudeCodeResult(t *testing.T) {
 	}
 	if out.String() != in {
 		t.Fatalf("forwarded output = %q, want %q", out.String(), in)
+	}
+}
+
+// garbledResultJSON is the JSON-escaped form of the final message from a real
+// degenerate run: markup fragments emitted in place of an answer.
+const garbledResultJSON = "`stale=False</li>\\n</ul>\\n</section\\n</section>"
+
+// TestStreamUsageFlagsDegenerateClaudeCodeResult covers the incident case: a
+// run that did substantial work, terminated cleanly, and returned fragments.
+// It must fail (so the Job's backoffLimit reruns it) while still recording the
+// response and a "degenerate" marker for downstream consumers.
+func TestStreamUsageFlagsDegenerateClaudeCodeResult(t *testing.T) {
+	in := `{"type":"result","subtype":"success","is_error":false,"stop_reason":"end_turn","terminal_reason":"completed","num_turns":41,"total_cost_usd":0.42,"result":"` + garbledResultJSON + `","usage":{"input_tokens":150000,"output_tokens":4821}}` + "\n"
+	var out bytes.Buffer
+	usage, err := StreamUsage("claude-code", strings.NewReader(in), &out)
+	want := "Claude Code returned a degenerate final message (degenerate_output=turns=41,chars=44)"
+	if err == nil || err.Error() != want {
+		t.Fatalf("StreamUsage() error = %v, want %q", err, want)
+	}
+	if usage["degenerate"] != "true" {
+		t.Fatalf("degenerate = %q, want %q", usage["degenerate"], "true")
+	}
+	// The response is still recorded so the failed path can show the user
+	// whatever the agent produced.
+	if usage["response"] == "" {
+		t.Fatal("response is empty, want the agent output recorded")
+	}
+	if usage["cost-usd"] != "0.42" {
+		t.Fatalf("cost-usd = %q, want %q", usage["cost-usd"], "0.42")
+	}
+	if out.String() != in {
+		t.Fatalf("forwarded output = %q, want %q", out.String(), in)
+	}
+}
+
+// TestStreamUsageIgnoresMissingNumTurns pins backward compatibility with
+// Claude Code versions that omit num_turns: a short final message must not be
+// classified degenerate when the turn count is unknown.
+func TestStreamUsageIgnoresMissingNumTurns(t *testing.T) {
+	in := `{"type":"result","subtype":"success","is_error":false,"stop_reason":"end_turn","terminal_reason":"completed","total_cost_usd":0.42,"result":"` + garbledResultJSON + `"}` + "\n"
+	var out bytes.Buffer
+	usage, err := StreamUsage("claude-code", strings.NewReader(in), &out)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := usage["degenerate"]; ok {
+		t.Fatal("degenerate key set without num_turns")
+	}
+}
+
+// TestStreamUsageOmitsDegenerateOnErrorResult pins that the marker tracks the
+// degenerate classification rather than the length floor alone. An explicit
+// error result is a different failure, so labelling it degenerate would hide
+// the real reason from downstream consumers.
+func TestStreamUsageOmitsDegenerateOnErrorResult(t *testing.T) {
+	in := `{"type":"result","subtype":"error_max_turns","is_error":true,"num_turns":41,"total_cost_usd":0.42,"result":"Reached max turns"}` + "\n"
+	var out bytes.Buffer
+	usage, err := StreamUsage("claude-code", strings.NewReader(in), &out)
+	want := "Claude Code returned an unsuccessful result (subtype=error_max_turns, is_error=true)"
+	if err == nil || err.Error() != want {
+		t.Fatalf("StreamUsage() error = %v, want %q", err, want)
+	}
+	if _, ok := usage["degenerate"]; ok {
+		t.Fatalf("degenerate key set on an error result: %v", usage)
 	}
 }
 

--- a/internal/claudecode/result.go
+++ b/internal/claudecode/result.go
@@ -3,6 +3,18 @@ package claudecode
 import (
 	"fmt"
 	"strings"
+	"unicode/utf8"
+)
+
+// Degenerate-output thresholds. A run that took many turns but ended with a
+// tiny final message is treated as degenerate: the agent did substantial work
+// and then emitted fragments instead of an answer. The floors are deliberately
+// conservative — a false positive costs at most one retry (invisible to the
+// user) and never loses the response text, since the failed path still reports
+// it.
+const (
+	degenerateTurnFloor = 10
+	degenerateCharFloor = 200
 )
 
 // Result describes the fields Claude Code uses to report how an agent loop
@@ -12,6 +24,11 @@ type Result struct {
 	IsError        bool
 	StopReason     string
 	TerminalReason string
+	// Text is the result line's "result" field: the agent's final message.
+	Text string
+	// NumTurns is the result line's "num_turns" field. Older Claude Code
+	// versions omit it, in which case it is zero.
+	NumTurns int
 }
 
 // ResultStatus describes whether a Claude Code result represents normal
@@ -37,7 +54,28 @@ func (r Result) Status() ResultStatus {
 	if r.StopReason != "" && r.StopReason != "end_turn" {
 		return ResultIncomplete
 	}
+	if r.IsDegenerateOutput() {
+		return ResultIncomplete
+	}
 	return ResultCompleted
+}
+
+// IsDegenerateOutput reports whether the run did substantial work but ended
+// with a final message too short to be a real answer. Claude Code reports such
+// a run as a clean success, so content length is the only signal.
+//
+// The check measures the character length of the final message rather than
+// usage.output_tokens, which is cumulative over the session and so stays large
+// even when the final message is junk.
+func (r Result) IsDegenerateOutput() bool {
+	return r.NumTurns >= degenerateTurnFloor && r.textLen() < degenerateCharFloor
+}
+
+// textLen returns the number of characters in the trimmed final message.
+// Runes rather than bytes, so the floor means the same thing for a non-ASCII
+// answer as it does for an ASCII one.
+func (r Result) textLen() int {
+	return utf8.RuneCountInString(strings.TrimSpace(r.Text))
 }
 
 // Details returns the result fields that explain a non-completed status.
@@ -58,6 +96,9 @@ func (r Result) Details() string {
 	if r.StopReason != "" && r.StopReason != "end_turn" {
 		details = append(details, "stop_reason="+r.StopReason)
 	}
+	if r.IsDegenerateOutput() {
+		details = append(details, fmt.Sprintf("degenerate_output=turns=%d,chars=%d", r.NumTurns, r.textLen()))
+	}
 	return strings.Join(details, ", ")
 }
 
@@ -70,6 +111,9 @@ func (r Result) FailureMessage() string {
 		}
 		return "Claude Code returned an unsuccessful result"
 	case ResultIncomplete:
+		if r.IsDegenerateOutput() {
+			return fmt.Sprintf("Claude Code returned a degenerate final message (%s)", r.Details())
+		}
 		return fmt.Sprintf("Claude Code run incomplete (%s)", r.Details())
 	default:
 		return ""

--- a/internal/claudecode/result_test.go
+++ b/internal/claudecode/result_test.go
@@ -1,6 +1,13 @@
 package claudecode
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
+
+// garbledText is the final message from a real degenerate run: the agent did
+// substantial work and then emitted markup fragments instead of an answer.
+const garbledText = "`stale=False</li>\n</ul>\n</section\n</section>"
 
 func TestResultStatus(t *testing.T) {
 	tests := []struct {
@@ -43,6 +50,73 @@ func TestResultStatus(t *testing.T) {
 			wantStatus:  ResultError,
 			wantDetails: "subtype=error_max_turns, is_error=true",
 		},
+		{
+			name:        "degenerate output after many turns",
+			result:      Result{Subtype: "success", StopReason: "end_turn", TerminalReason: "completed", Text: garbledText, NumTurns: 41},
+			wantStatus:  ResultIncomplete,
+			wantDetails: "degenerate_output=turns=41,chars=44",
+		},
+		{
+			name:        "degenerate output at the turn floor",
+			result:      Result{Subtype: "success", StopReason: "end_turn", TerminalReason: "completed", Text: "</section>", NumTurns: degenerateTurnFloor},
+			wantStatus:  ResultIncomplete,
+			wantDetails: "degenerate_output=turns=10,chars=10",
+		},
+		{
+			name:        "whitespace-only final message after many turns",
+			result:      Result{Subtype: "success", StopReason: "end_turn", TerminalReason: "completed", Text: "   \n  ", NumTurns: 41},
+			wantStatus:  ResultIncomplete,
+			wantDetails: "degenerate_output=turns=41,chars=0",
+		},
+		{
+			name:       "brief answer after a couple of turns",
+			result:     Result{Subtype: "success", StopReason: "end_turn", TerminalReason: "completed", Text: "Fixed in v0.472.", NumTurns: 2},
+			wantStatus: ResultCompleted,
+		},
+		{
+			name:       "long answer after many turns",
+			result:     Result{Subtype: "success", StopReason: "end_turn", TerminalReason: "completed", Text: strings.Repeat("a", 800), NumTurns: 41},
+			wantStatus: ResultCompleted,
+		},
+		{
+			name:       "short answer just above the char floor after many turns",
+			result:     Result{Subtype: "success", StopReason: "end_turn", TerminalReason: "completed", Text: strings.Repeat("a", degenerateCharFloor), NumTurns: 41},
+			wantStatus: ResultCompleted,
+		},
+		{
+			name:       "num_turns absent on older claude code",
+			result:     Result{Subtype: "success", StopReason: "end_turn", TerminalReason: "completed", Text: garbledText},
+			wantStatus: ResultCompleted,
+		},
+		{
+			// The floor counts characters, not bytes: a multi-byte
+			// answer of the same visible length is treated the same
+			// as an ASCII one.
+			name:        "short multi-byte final message after many turns",
+			result:      Result{Subtype: "success", StopReason: "end_turn", TerminalReason: "completed", Text: strings.Repeat("\u6f22", 80), NumTurns: 41},
+			wantStatus:  ResultIncomplete,
+			wantDetails: "degenerate_output=turns=41,chars=80",
+		},
+		{
+			name:       "long multi-byte answer after many turns",
+			result:     Result{Subtype: "success", StopReason: "end_turn", TerminalReason: "completed", Text: strings.Repeat("\u6f22", degenerateCharFloor), NumTurns: 41},
+			wantStatus: ResultCompleted,
+		},
+		{
+			// An explicit error is a different failure, so the
+			// degenerate token must not appear in its details even
+			// though the short message trips the length floor.
+			name:        "error result with a short message after many turns",
+			result:      Result{Subtype: "error_max_turns", IsError: true, Text: "Reached max turns", NumTurns: 41},
+			wantStatus:  ResultError,
+			wantDetails: "subtype=error_max_turns, is_error=true",
+		},
+		{
+			name:        "degenerate output alongside an explicit stop reason",
+			result:      Result{Subtype: "success", StopReason: "max_tokens", Text: garbledText, NumTurns: 41},
+			wantStatus:  ResultIncomplete,
+			wantDetails: "stop_reason=max_tokens, degenerate_output=turns=41,chars=44",
+		},
 	}
 
 	for _, tt := range tests {
@@ -60,5 +134,18 @@ func TestResultStatus(t *testing.T) {
 				t.Fatal("FailureMessage() is empty for non-completed result")
 			}
 		})
+	}
+}
+
+// TestDegenerateFailureMessage pins the operator-facing diagnostic, which is
+// what reaches Slack when both attempts of a Task are classified degenerate.
+func TestDegenerateFailureMessage(t *testing.T) {
+	r := Result{Subtype: "success", StopReason: "end_turn", TerminalReason: "completed", Text: garbledText, NumTurns: 41}
+	want := "Claude Code returned a degenerate final message (degenerate_output=turns=41,chars=44)"
+	if got := r.FailureMessage(); got != want {
+		t.Fatalf("FailureMessage() = %q, want %q", got, want)
+	}
+	if !r.IsDegenerateOutput() {
+		t.Fatal("IsDegenerateOutput() = false, want true")
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Claude Code can finish a run cleanly — `subtype: success`, `is_error: false`,
`stop_reason: end_turn`, `terminal_reason: completed` — after doing substantial
real work, and still emit markup fragments instead of an answer as its final
message. A Slack-facing agent did exactly this in production, ending a
41-turn run with:

```
`stale=False</li>
</ul>
</section
</section>
```

The completion gate in `kelos-capture` only inspects the termination fields, so
this passes, the Task is recorded as Succeeded, and the fragments are reported
verbatim.

This adds a content predicate. A result is classified `ResultIncomplete` when
all of the following hold:

1. it would otherwise be `ResultCompleted` (an already-failing run is not
   second-guessed),
2. `num_turns >= 10` — the agent did substantial work, and
3. the trimmed final message is under 200 characters.

`ResultIncomplete` is reused rather than adding a new status, because it already
makes `kelos-capture` exit non-zero. The Job's existing unconditional
`backoffLimit: 1` turns that into a rerun, and `isJobFailed` waits for the
`JobFailed` condition rather than `job.Status.Failed > 0`, so the Task stays
`Running` across the retry. No new retry machinery is needed.

`kelos-capture` also emits a `degenerate: true` output key on the failing
attempt (`run()` emits the marker block even when the exit code is 1), so
downstream consumers can distinguish this failure from any other without
duplicating the heuristic.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

**The predicate measures characters, not tokens.** `usage.output_tokens` on the
result line appears to be cumulative over the session, not per-final-turn, so a
run with 40 tool calls carries a large `output_tokens` even when the final
message is junk — a token-based floor would silently never fire. `result` is
unambiguously the final message, so measuring its length sidesteps the question.
Length is counted in runes, not bytes, so the floor means the same thing for a
non-ASCII answer as for an ASCII one.

**The `degenerate` marker is gated on the classification, not the length
floor.** `IsDegenerateOutput()` is independent of `Status()`, so an explicit
error result (`subtype: error_max_turns`) whose short error text trips the same
floor would otherwise be labelled degenerate. That is a different failure, and
mislabelling it would hide the real reason from downstream consumers, so the
marker is only set when the result is `ResultIncomplete` *and* degenerate.

**This is not provider-side truncation.** FireRouter was probed directly against
`deepseek-v4-flash-0731`: `max_tokens: 8` returns `stop_reason: max_tokens` and
`max_tokens: 512` returns `end_turn`. `stop_reason` is forwarded faithfully, so
the existing `max_tokens` guard already catches genuine truncation. The garbled
run came back as a real clean `end_turn`; content is the only remaining signal.

**A false positive is cheap.** If only the first attempt is misjudged, it costs
one retry and is invisible to the user — the Task stays `Running` and Slack
shows only the progress message. If both attempts are misjudged, the Task goes
`Failed` and Slack posts the error header with `results["response"]` still
attached, so the user still gets their answer. A false positive never loses an
answer, which is the argument for erring toward detection.

**The thresholds (10 turns, 200 chars) are deliberately conservative and not
yet calibrated.** There is no metric for final-message length today; the
distribution has to come from `task.Status.Results["response"]` on completed
Tasks. `kelos_task_output_tokens_total` is labeled by spawner as of `c2faf5f1`,
so the token distribution per spawner is already queryable, but per the note
above tokens are the wrong measure here. Intent is to ship conservative and
tighten once the distribution is known.

Backward compatibility: older Claude Code versions that omit `num_turns` leave
it at zero, so the predicate never fires for them — matching how `Status()`
already tolerates empty reason fields. There is an explicit test for this.

Tests cover the real garbled sample after a high turn count, a legitimate brief
answer after two turns (`"Fixed in v0.472."` — the case the predicate must not
break, since the general spawner answers casually all the time), a long
coherent answer after many turns, the `charFloor` and `turnFloor` boundaries,
the missing-`num_turns` case, and that `degenerate: true` reaches the captured
outputs on a failing attempt.

`make test` and `make verify` pass.

#### Does this PR introduce a user-facing change?

```release-note
Claude Code runs that terminate cleanly but return a final message too short to be an answer after many turns are now treated as failures rather than successes, so the Task's existing retry reruns the agent instead of reporting garbled output. `kelos-capture` emits a `degenerate: true` result key on such an attempt.
```
