### PR TITLE
Configure dev webhook gateway as NodePort

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -207,6 +207,8 @@ jobs:
           webhookServer:
             gatewayServer:
               enabled: true
+              service:
+                type: NodePort
             resources:
               requests:
                 cpu: 100m


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Configures the dev webhook gateway server Service as NodePort so the dev cluster can expose the gateway server through its existing external routing setup. Kubernetes allocates the node port dynamically.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Follow-up to #1238, which merged before this dev deployment override was added. The existing source-specific GitHub webhook Deployment and Service are not rendered by the current install configuration and are not pruned automatically.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```