### PR TITLE
Keep the current request visible in console

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -337,7 +337,10 @@ to expand retained results that exceed five lines.
 Selecting a Session in the web chat opens a bounded page at the latest retained
 message. Use **Load earlier messages** to prepend the previous page without
 moving away from the current scroll position. Reconnecting preserves an
-intentional upward scroll position and the loaded conversation view.
+intentional upward scroll position and the loaded conversation view. When the
+request for the visible response has scrolled out of view, a compact **Current
+request** link follows it while browsing history and scrolls back to the full
+request when clicked. The link stays hidden while viewing file changes.
 
 The Session sidebar shows compact relative activity times, and the selected
 Session header shows whether it is active now, when it was last active, or when

--- a/internal/consoleserver/frontend/app.ts
+++ b/internal/consoleserver/frontend/app.ts
@@ -384,6 +384,9 @@ const elements = requireElements({
   sectionChoiceCustom: document.querySelector('#session-section-choice-custom'),
   saveSectionButton: document.querySelector('#save-session-section'),
   cancelSectionButton: document.querySelector('#cancel-session-section'),
+  currentRequest: document.querySelector('#current-request'),
+  currentRequestButton: document.querySelector('#current-request-button'),
+  currentRequestText: document.querySelector('#current-request-text'),
   messages: document.querySelector('#messages'),
   changes: document.querySelector('#changes-view'),
   changesList: document.querySelector('#changes-list'),
@@ -597,6 +600,7 @@ function setConsoleView(view: string) {
     else button.removeAttribute('aria-current');
   }
   if (state.consoleView === 'sessions' && !state.selected && state.sessions.length) selectSession(state.sessions[0]);
+  if (state.consoleView === 'sessions') updateCurrentRequest();
   setSidebarOpen(false);
 }
 
@@ -1240,6 +1244,7 @@ function activateSessionView(view: SessionView) {
   refreshSessionProgress();
   renderRuntimeStatus();
   renderHistoryControl();
+  updateCurrentRequest();
 }
 
 function cachedSessionView(session: SessionSummary) {
@@ -1290,6 +1295,7 @@ function resetCurrentSessionView() {
   elements.messages.replaceChildren();
   elements.pending.replaceChildren();
   elements.pending.hidden = true;
+  hideCurrentRequest();
   renderFileChanges();
   if (view) {
     view.historyLoaded = false;
@@ -3689,6 +3695,7 @@ function replayOlderHistoryPage(events) {
   messages.style.scrollBehavior = 'auto';
   messages.scrollTop = Math.max(0, previousTop + (Number(messages.scrollHeight) || 0) - previousHeight);
   messages.style.scrollBehavior = scrollBehavior;
+  updateCurrentRequest();
   refreshSessionProgress();
   updateComposerAction();
 }
@@ -3721,6 +3728,7 @@ function finishHistoryReplay(historyState) {
   renderHistoryControl();
   if (pinToBottom) scheduleBottomAnchor();
   state.pinHistoryToBottom = false;
+  updateCurrentRequest();
 }
 
 function handleEvent(event) {
@@ -3860,10 +3868,66 @@ function renderUser(event) {
   renderAcceptedUser(event);
 }
 
+let currentRequestRow: HTMLElement | null = null;
+let currentRequestUpdateFrame: number | null = null;
+
+function hideCurrentRequest() {
+  if (!currentRequestRow && elements.currentRequest.hidden) return;
+  currentRequestRow = null;
+  elements.currentRequest.hidden = true;
+}
+
+function updateCurrentRequest() {
+  if (elements.sessionsView.hidden) return;
+  if (elements.messages.hidden) {
+    hideCurrentRequest();
+    return;
+  }
+
+  const viewportTop = elements.messages.getBoundingClientRect().top;
+  let request: HTMLElement | null = null;
+  for (const row of elements.messages.querySelectorAll<HTMLElement>('.event-row.user')) {
+    const bounds = row.getBoundingClientRect();
+    if (bounds.top > viewportTop) break;
+    if (bounds.bottom > viewportTop) {
+      request = null;
+      break;
+    }
+    request = row;
+  }
+
+  const text = request?.dataset.requestText || '';
+  if (!request || !text) {
+    hideCurrentRequest();
+    return;
+  }
+  if (currentRequestRow === request && !elements.currentRequest.hidden && elements.currentRequestText.textContent === text) return;
+  currentRequestRow = request;
+  elements.currentRequestText.textContent = text;
+  elements.currentRequestButton.title = text;
+  elements.currentRequest.hidden = false;
+}
+
+function scheduleCurrentRequestUpdate() {
+  if (currentRequestUpdateFrame !== null) return;
+  currentRequestUpdateFrame = window.requestAnimationFrame(() => {
+    currentRequestUpdateFrame = null;
+    updateCurrentRequest();
+  });
+}
+
+function jumpToCurrentRequest() {
+  const request = currentRequestRow;
+  if (!request) return;
+  hideCurrentRequest();
+  request.scrollIntoView({behavior: 'smooth', block: 'start'});
+}
+
 function renderAcceptedUser(event) {
   ensureConversation();
   const row = document.createElement('div');
   row.className = 'event-row user';
+  row.dataset.requestText = event.text || (event.attachments || []).map(attachment => attachment.name).join(', ');
   const message = document.createElement('div');
   message.className = 'user-message';
   const bubble = document.createElement('div');
@@ -4518,6 +4582,8 @@ function setActiveView(view) {
   elements.changesTab.setAttribute('aria-selected', String(changesActive));
   elements.conversationTab.tabIndex = changesActive ? -1 : 0;
   elements.changesTab.tabIndex = changesActive ? 0 : -1;
+  if (changesActive) hideCurrentRequest();
+  else updateCurrentRequest();
 }
 
 function handleViewTabKeydown(event) {
@@ -5167,6 +5233,8 @@ elements.sessionActionsMenu.addEventListener('focusout', handleSessionActionsFoc
 elements.conversationTab.addEventListener('click', () => setActiveView('conversation'));
 elements.changesTab.addEventListener('click', () => setActiveView('changes'));
 elements.viewTabs.addEventListener('keydown', handleViewTabKeydown);
+elements.currentRequestButton.addEventListener('click', jumpToCurrentRequest);
+elements.messages.addEventListener('scroll', scheduleCurrentRequestUpdate);
 
 function interruptActiveTurn() {
   if (!state.socket || state.socket.readyState !== WebSocket.OPEN || !state.activeTurn || state.interrupting) return;
@@ -5214,7 +5282,10 @@ document.querySelectorAll('.open-sidebar-button').forEach(button => {
 elements.closeSidebar.addEventListener('click', () => setSidebarOpen(false));
 elements.sidebarScrim.addEventListener('click', () => setSidebarOpen(false));
 elements.sidebarScroll.addEventListener('scroll', () => closeSessionActionsMenu());
-window.addEventListener('resize', () => closeSessionActionsMenu());
+window.addEventListener('resize', () => {
+  closeSessionActionsMenu();
+  scheduleCurrentRequestUpdate();
+});
 document.addEventListener('pointerdown', event => {
   if (elements.sessionActionsMenu.hidden) return;
   const target = event.target as Node | null;

--- a/internal/consoleserver/testdata/console_resources_test.js
+++ b/internal/consoleserver/testdata/console_resources_test.js
@@ -18,6 +18,28 @@ vm.runInThisContext(applicationSlice('const allResourceKind', 'async function lo
 vm.runInThisContext(applicationSlice('async function refreshConsole', 'async function openResourceDetail'), {filename: 'app.js'});
 vm.runInThisContext(applicationSlice('function setResourceDetailView', 'function sessionKey'), {filename: 'app.js'});
 
+function testReturningToSessionsRefreshesCurrentRequest() {
+  let updates = 0;
+  const navigationButton = () => ({setAttribute() {}, removeAttribute() {}});
+  global.state = {consoleView: 'overview', selected: {}, sessions: []};
+  global.elements = {
+    overviewView: {hidden: false},
+    sessionsView: {hidden: true},
+    resourcesView: {hidden: true},
+    sessionSidebar: {hidden: true},
+    overviewButton: navigationButton(),
+    sessionsButton: navigationButton(),
+    resourcesButton: navigationButton(),
+  };
+  global.updateCurrentRequest = () => { updates++; };
+  global.setSidebarOpen = () => {};
+
+  setConsoleView('sessions');
+
+  assert.equal(elements.sessionsView.hidden, false);
+  assert.equal(updates, 1);
+}
+
 function testResourceInventorySupportsAllTypesAndSearch() {
   const collections = [
     {resource: 'tasks', kind: 'Task', label: 'Tasks', items: [
@@ -211,6 +233,7 @@ function testResourceDetailTabsSupportKeyboardNavigation() {
   assert.equal(prevented, true);
 }
 
+testReturningToSessionsRefreshesCurrentRequest();
 testResourceInventorySupportsAllTypesAndSearch();
 testResourceRelationshipHelpersResolveExistingAndMissingResources();
 testResourceViewTabsSupportKeyboardNavigation();

--- a/internal/consoleserver/testdata/session_history_test.js
+++ b/internal/consoleserver/testdata/session_history_test.js
@@ -16,6 +16,8 @@ class TestNode {
     this.listeners = new Map();
     this.style = {};
     this.scrollTop = 0;
+    this.bounds = {top: 0, bottom: 0};
+    this.scrollIntoViewOptions = null;
     this.classList = {
       add: (...names) => names.forEach((name) => this.classes.add(name)),
       remove: (...names) => names.forEach((name) => this.classes.delete(name)),
@@ -96,9 +98,10 @@ class TestNode {
   querySelectorAll(selector) {
     const matches = [];
     for (const child of this.children) {
+      const selectorClasses = selector.startsWith('.') ? selector.slice(1).split('.') : [];
       const classMatch = selector === '.file-change[open]'
         ? child.classes.has('file-change') && child.open
-        : selector.startsWith('.') && child.classes.has(selector.slice(1));
+        : selectorClasses.length > 0 && selectorClasses.every(name => child.classes.has(name));
       if (classMatch || child.tag === selector) matches.push(child);
       matches.push(...child.querySelectorAll(selector));
     }
@@ -111,6 +114,14 @@ class TestNode {
 
   addEventListener(name, listener) {
     this.listeners.set(name, listener);
+  }
+
+  getBoundingClientRect() {
+    return this.bounds;
+  }
+
+  scrollIntoView(options) {
+    this.scrollIntoViewOptions = options;
   }
 
   set textContent(value) {
@@ -141,6 +152,7 @@ let bottomAnchors;
 let interruptRequests;
 let socketConnections;
 let progressTimers;
+let animationFrames;
 let toasts;
 let closeSocketRequests;
 
@@ -148,6 +160,10 @@ global.window = {
   clearInterval: (timer) => progressTimers.delete(timer),
   confirm: () => true,
   matchMedia: () => ({matches: false}),
+  requestAnimationFrame: (callback) => {
+    animationFrames.push(callback);
+    return animationFrames.length;
+  },
   setInterval: (callback) => {
     const timer = progressTimers.size + 1;
     progressTimers.set(timer, callback);
@@ -163,6 +179,10 @@ function resetHarness() {
     changesList: new TestNode('div'),
     changesCount: new TestNode('span'),
     changesSummary: new TestNode('span'),
+    currentRequest: new TestNode('div'),
+    currentRequestButton: new TestNode('button'),
+    currentRequestText: new TestNode('span'),
+    sessionsView: new TestNode('main'),
     composerHint: new TestNode('span'),
     input: new TestNode('textarea'),
     attachFiles: new TestNode('button'),
@@ -185,6 +205,7 @@ function resetHarness() {
     connection: new TestNode('div'),
     welcome: null,
   };
+  elements.currentRequest.hidden = true;
   elements.connection.append(new TestNode('span'), new TestNode('span'));
   global.state = {
     sessions: [],
@@ -230,6 +251,7 @@ function resetHarness() {
   socketConnections = 0;
   closeSocketRequests = 0;
   progressTimers = new Map();
+  animationFrames = [];
   toasts = [];
 }
 
@@ -917,6 +939,61 @@ function testUserAttachmentRendering() {
   assert.match(link.textContent, /screen\.png/);
 }
 
+function testCurrentRequestTracksScrolledTurn() {
+  resetHarness();
+  elements.messages.bounds = {top: 100, bottom: 600};
+  renderAcceptedUser({type: 'user.message', text: 'Review the controller changes'});
+  renderAcceptedUser({type: 'user.message', text: 'Then run the focused tests'});
+  const requests = elements.messages.querySelectorAll('.event-row.user');
+  requests[0].bounds = {top: 20, bottom: 80};
+  requests[1].bounds = {top: 300, bottom: 340};
+
+  updateCurrentRequest();
+
+  assert.equal(elements.currentRequest.hidden, false);
+  assert.equal(elements.currentRequestText.textContent, 'Review the controller changes');
+  assert.equal(elements.currentRequestButton.title, 'Review the controller changes');
+  jumpToCurrentRequest();
+  assert.deepEqual(requests[0].scrollIntoViewOptions, {behavior: 'smooth', block: 'start'});
+  assert.equal(elements.currentRequest.hidden, true);
+  updateCurrentRequest();
+
+  elements.sessionsView.hidden = true;
+  requests[0].bounds = {top: 0, bottom: 0};
+  requests[1].bounds = {top: 0, bottom: 0};
+  updateCurrentRequest();
+  assert.equal(elements.currentRequest.hidden, false);
+  assert.equal(elements.currentRequestText.textContent, 'Review the controller changes');
+
+  elements.sessionsView.hidden = false;
+  requests[1].bounds = {top: 40, bottom: 90};
+  updateCurrentRequest();
+  assert.equal(elements.currentRequestText.textContent, 'Then run the focused tests');
+
+  requests[1].bounds = {top: 100, bottom: 140};
+  updateCurrentRequest();
+  assert.equal(elements.currentRequest.hidden, true);
+}
+
+function testCurrentRequestScrollUpdatesAreThrottled() {
+  resetHarness();
+  elements.messages.bounds = {top: 100, bottom: 600};
+  renderAcceptedUser({type: 'user.message', text: 'Inspect the long response'});
+  elements.messages.querySelectorAll('.event-row.user')[0].bounds = {top: 20, bottom: 80};
+
+  scheduleCurrentRequestUpdate();
+  scheduleCurrentRequestUpdate();
+
+  assert.equal(animationFrames.length, 1);
+  animationFrames.shift()();
+  assert.equal(elements.currentRequest.hidden, false);
+  assert.equal(elements.currentRequestText.textContent, 'Inspect the long response');
+
+  scheduleCurrentRequestUpdate();
+  assert.equal(animationFrames.length, 1);
+  animationFrames.shift()();
+}
+
 function testPendingMessageEditing() {
   resetHarness();
   const sent = [];
@@ -999,6 +1076,8 @@ testGoalRendering();
 testToolOutputRenderingNormalizesCarriageReturns();
 testHistoryToolCompletionRendersOutputWithoutStart();
 testUserAttachmentRendering();
+testCurrentRequestTracksScrolledTurn();
+testCurrentRequestScrollUpdatesAreThrottled();
 testPendingMessageEditing();
 testPendingMessageRemoval();
 testPendingMessageSurvivesCompletedHistoryReplay();

--- a/internal/consoleserver/web/app.js
+++ b/internal/consoleserver/web/app.js
@@ -76,6 +76,9 @@
         sectionChoiceCustom: document.querySelector('#session-section-choice-custom'),
         saveSectionButton: document.querySelector('#save-session-section'),
         cancelSectionButton: document.querySelector('#cancel-session-section'),
+        currentRequest: document.querySelector('#current-request'),
+        currentRequestButton: document.querySelector('#current-request-button'),
+        currentRequestText: document.querySelector('#current-request-text'),
         messages: document.querySelector('#messages'),
         changes: document.querySelector('#changes-view'),
         changesList: document.querySelector('#changes-list'),
@@ -286,6 +289,8 @@
         }
         if (state.consoleView === 'sessions' && !state.selected && state.sessions.length)
             selectSession(state.sessions[0]);
+        if (state.consoleView === 'sessions')
+            updateCurrentRequest();
         setSidebarOpen(false);
     }
     function resourceAge(createdAt) {
@@ -916,6 +921,7 @@
         refreshSessionProgress();
         renderRuntimeStatus();
         renderHistoryControl();
+        updateCurrentRequest();
     }
     function cachedSessionView(session) {
         const key = sessionViewKey(session);
@@ -967,6 +973,7 @@
         elements.messages.replaceChildren();
         elements.pending.replaceChildren();
         elements.pending.hidden = true;
+        hideCurrentRequest();
         renderFileChanges();
         if (view) {
             view.historyLoaded = false;
@@ -3375,6 +3382,7 @@ spec:
         messages.style.scrollBehavior = 'auto';
         messages.scrollTop = Math.max(0, previousTop + (Number(messages.scrollHeight) || 0) - previousHeight);
         messages.style.scrollBehavior = scrollBehavior;
+        updateCurrentRequest();
         refreshSessionProgress();
         updateComposerAction();
     }
@@ -3408,6 +3416,7 @@ spec:
         if (pinToBottom)
             scheduleBottomAnchor();
         state.pinHistoryToBottom = false;
+        updateCurrentRequest();
     }
     function handleEvent(event) {
         if (state.historyPageReading) {
@@ -3555,10 +3564,65 @@ spec:
         }
         renderAcceptedUser(event);
     }
+    let currentRequestRow = null;
+    let currentRequestUpdateFrame = null;
+    function hideCurrentRequest() {
+        if (!currentRequestRow && elements.currentRequest.hidden)
+            return;
+        currentRequestRow = null;
+        elements.currentRequest.hidden = true;
+    }
+    function updateCurrentRequest() {
+        if (elements.sessionsView.hidden)
+            return;
+        if (elements.messages.hidden) {
+            hideCurrentRequest();
+            return;
+        }
+        const viewportTop = elements.messages.getBoundingClientRect().top;
+        let request = null;
+        for (const row of elements.messages.querySelectorAll('.event-row.user')) {
+            const bounds = row.getBoundingClientRect();
+            if (bounds.top > viewportTop)
+                break;
+            if (bounds.bottom > viewportTop) {
+                request = null;
+                break;
+            }
+            request = row;
+        }
+        const text = request?.dataset.requestText || '';
+        if (!request || !text) {
+            hideCurrentRequest();
+            return;
+        }
+        if (currentRequestRow === request && !elements.currentRequest.hidden && elements.currentRequestText.textContent === text)
+            return;
+        currentRequestRow = request;
+        elements.currentRequestText.textContent = text;
+        elements.currentRequestButton.title = text;
+        elements.currentRequest.hidden = false;
+    }
+    function scheduleCurrentRequestUpdate() {
+        if (currentRequestUpdateFrame !== null)
+            return;
+        currentRequestUpdateFrame = window.requestAnimationFrame(() => {
+            currentRequestUpdateFrame = null;
+            updateCurrentRequest();
+        });
+    }
+    function jumpToCurrentRequest() {
+        const request = currentRequestRow;
+        if (!request)
+            return;
+        hideCurrentRequest();
+        request.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
     function renderAcceptedUser(event) {
         ensureConversation();
         const row = document.createElement('div');
         row.className = 'event-row user';
+        row.dataset.requestText = event.text || (event.attachments || []).map(attachment => attachment.name).join(', ');
         const message = document.createElement('div');
         message.className = 'user-message';
         const bubble = document.createElement('div');
@@ -4215,6 +4279,10 @@ spec:
         elements.changesTab.setAttribute('aria-selected', String(changesActive));
         elements.conversationTab.tabIndex = changesActive ? -1 : 0;
         elements.changesTab.tabIndex = changesActive ? 0 : -1;
+        if (changesActive)
+            hideCurrentRequest();
+        else
+            updateCurrentRequest();
     }
     function handleViewTabKeydown(event) {
         const tabs = [elements.conversationTab, elements.changesTab].filter(tab => !tab.disabled);
@@ -4879,6 +4947,8 @@ spec:
     elements.conversationTab.addEventListener('click', () => setActiveView('conversation'));
     elements.changesTab.addEventListener('click', () => setActiveView('changes'));
     elements.viewTabs.addEventListener('keydown', handleViewTabKeydown);
+    elements.currentRequestButton.addEventListener('click', jumpToCurrentRequest);
+    elements.messages.addEventListener('scroll', scheduleCurrentRequestUpdate);
     function interruptActiveTurn() {
         if (!state.socket || state.socket.readyState !== WebSocket.OPEN || !state.activeTurn || state.interrupting)
             return;
@@ -4925,7 +4995,10 @@ spec:
     elements.closeSidebar.addEventListener('click', () => setSidebarOpen(false));
     elements.sidebarScrim.addEventListener('click', () => setSidebarOpen(false));
     elements.sidebarScroll.addEventListener('scroll', () => closeSessionActionsMenu());
-    window.addEventListener('resize', () => closeSessionActionsMenu());
+    window.addEventListener('resize', () => {
+        closeSessionActionsMenu();
+        scheduleCurrentRequestUpdate();
+    });
     document.addEventListener('pointerdown', event => {
         if (elements.sessionActionsMenu.hidden)
             return;

--- a/internal/consoleserver/web/index.html
+++ b/internal/consoleserver/web/index.html
@@ -169,6 +169,14 @@
         </div>
       </header>
 
+      <div class="current-request" id="current-request" hidden>
+        <button id="current-request-button" type="button" aria-label="Jump to current request">
+          <span class="current-request-label">Current request</span>
+          <span class="current-request-text" id="current-request-text"></span>
+          <span class="current-request-jump" aria-hidden="true">↑</span>
+        </button>
+      </div>
+
       <section class="messages" id="messages" role="tabpanel" aria-labelledby="conversation-tab" aria-live="polite">
         <div class="welcome" id="welcome">
           <div class="welcome-orbit"><span>K</span></div>

--- a/internal/consoleserver/web/styles.css
+++ b/internal/consoleserver/web/styles.css
@@ -223,7 +223,7 @@ button { color: inherit; }
 .resource-empty { min-height: 210px; display: grid; place-items: center; padding: 28px; color: var(--muted); font-size: 12px; text-align: center; }
 .conversation { min-width: 0; min-height: 0; display: grid; grid-template-rows: auto minmax(0, 1fr) auto; background: var(--canvas); }
 .conversation[hidden] { display: none; }
-.conversation-header { position: relative; z-index: 3; min-height: 60px; display: flex; align-items: center; gap: 12px; padding: 8px 16px; background: color-mix(in srgb, var(--canvas) 92%, transparent); backdrop-filter: blur(12px); }
+.conversation-header { position: relative; z-index: 3; grid-row: 1; min-height: 60px; display: flex; align-items: center; gap: 12px; padding: 8px 16px; background: color-mix(in srgb, var(--canvas) 92%, transparent); backdrop-filter: blur(12px); }
 .session-heading { flex: 1; min-width: 0; }
 .session-title-row { display: flex; align-items: center; gap: 7px; }
 .session-title { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 15px; font-weight: 600; line-height: 1.25; }
@@ -262,7 +262,14 @@ button { color: inherit; }
 .icon-button:hover { background: var(--line-soft); }
 .icon-button:disabled { opacity: .38; cursor: default; }
 .icon-button.danger:not(:disabled):hover { color: var(--danger); border-color: rgba(167,63,63,.3); background: #fff6f6; }
-.messages { min-height: 0; overflow-y: auto; padding: 28px max(24px, calc((100% - 768px) / 2)) 36px; scroll-behavior: smooth; }
+.current-request { z-index: 2; grid-row: 2; grid-column: 1; width: min(calc(100% - 48px), 768px); align-self: start; justify-self: center; margin-top: 10px; pointer-events: none; }
+.current-request[hidden] { display: none; }
+.current-request button { width: 100%; display: grid; grid-template-columns: auto minmax(0, 1fr) auto; align-items: center; gap: 9px; padding: 8px 11px; overflow: hidden; border: 1px solid var(--line); border-radius: 11px; background: color-mix(in srgb, var(--card) 94%, transparent); color: var(--ink); box-shadow: 0 4px 18px rgba(0,0,0,.1); text-align: left; backdrop-filter: blur(12px); cursor: pointer; pointer-events: auto; }
+.current-request button:hover, .current-request button:focus-visible { border-color: #c5ccc6; }
+.current-request-label { color: var(--accent-2); font-size: 9px; font-weight: 800; letter-spacing: .07em; text-transform: uppercase; white-space: nowrap; }
+.current-request-text { overflow: hidden; font-size: 11.5px; line-height: 1.35; text-overflow: ellipsis; white-space: nowrap; }
+.current-request-jump { color: var(--muted); font-size: 13px; }
+.messages { min-height: 0; grid-row: 2; grid-column: 1; overflow-y: auto; padding: 28px max(24px, calc((100% - 768px) / 2)) 36px; scroll-behavior: smooth; }
 .history-page-control { display: flex; justify-content: center; margin: -12px 0 24px; }
 .history-page-control button { padding: 7px 12px; border: 1px solid var(--line); border-radius: 999px; background: var(--card); color: var(--muted); font-size: 10.5px; font-weight: 700; cursor: pointer; }
 .history-page-control button:hover:not(:disabled) { border-color: #c5ccc6; color: var(--ink); }
@@ -356,7 +363,7 @@ button { color: inherit; }
 .diff-card .changes-list { gap: 0; }
 .diff-card .file-change { border: 0; border-top: 1px solid var(--line); border-radius: 0; box-shadow: none; }
 .diff-card .diff-lines { max-height: 430px; }
-.changes-view { min-height: 0; overflow-y: auto; padding: 28px max(24px, calc((100% - 980px) / 2)) 40px; }
+.changes-view { min-height: 0; grid-row: 2; grid-column: 1; overflow-y: auto; padding: 28px max(24px, calc((100% - 980px) / 2)) 40px; }
 .changes-view[hidden], .messages[hidden], .composer-wrap[hidden] { display: none; }
 .changes-header { display: flex; align-items: flex-end; justify-content: space-between; gap: 20px; margin-bottom: 18px; }
 .changes-header h2 { margin: 0; font-size: 20px; font-weight: 600; line-height: 1.3; letter-spacing: -.01em; }
@@ -388,7 +395,7 @@ button { color: inherit; }
 .turn-divider:not(:empty)::before, .turn-divider:not(:empty)::after { height: 1px; background: var(--line); content: ""; }
 .turn-divider:not(:empty)::before { flex: 0 0 10px; }
 .turn-divider:not(:empty)::after { flex: 1; }
-.composer-wrap { position: relative; z-index: 2; min-width: 0; padding: 12px max(24px, calc((100% - 768px) / 2)) 10px; background: linear-gradient(transparent, var(--canvas) 24%); }
+.composer-wrap { position: relative; z-index: 2; min-width: 0; grid-row: 3; padding: 12px max(24px, calc((100% - 768px) / 2)) 10px; background: linear-gradient(transparent, var(--canvas) 24%); }
 .composer-wrap.attachment-drop-target .composer { border-color: var(--accent); box-shadow: 0 0 0 3px rgba(0,0,0,.1); }
 .session-progress { display: flex; align-items: center; gap: 5px; min-height: 18px; margin: 0 4px 7px; color: var(--muted); font-size: 11px; font-weight: 650; font-variant-numeric: tabular-nums; }
 .session-progress[hidden] { display: none; }
@@ -575,6 +582,9 @@ button { color: inherit; }
   .connection-pill span { width: 7px; height: 7px; }
   .icon-button { width: 44px; height: 44px; }
   .view-tabs button { min-height: 44px; padding: 5px 8px; }
+  .current-request { width: calc(100% - 24px - env(safe-area-inset-left) - env(safe-area-inset-right)); }
+  .current-request button { align-items: start; }
+  .current-request-text { display: -webkit-box; white-space: normal; -webkit-box-orient: vertical; -webkit-line-clamp: 2; }
   .messages { padding: 20px calc(12px + env(safe-area-inset-right)) 24px calc(12px + env(safe-area-inset-left)); overscroll-behavior: contain; }
   .changes-view { padding: 20px calc(12px + env(safe-area-inset-right)) 32px calc(12px + env(safe-area-inset-left)); overscroll-behavior: contain; }
   .composer-wrap { padding: 8px calc(8px + env(safe-area-inset-right)) calc(7px + env(safe-area-inset-bottom)) calc(8px + env(safe-area-inset-left)); }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds a compact Current request bar to the console conversation view when the request for the visible response has scrolled out of view. The bar follows the relevant request while browsing conversation history and scrolls back to the full request when clicked.

The bar stays hidden while the original request is visible and while viewing file changes, so it does not consume conversation space unnecessarily.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

- Includes a focused frontend test for request selection, visibility, and click-to-scroll behavior.
- Regenerated `internal/consoleserver/web/app.js` with `make update`.
- Verified with `make test` and `make verify`. The unit test command was run without inherited Codex runtime configuration variables so the entrypoint isolation tests use their intended fixtures.

#### Does this PR introduce a user-facing change?

```release-note
The web console now shows a compact link to the current request while reading long agent responses.
```
