### PR TITLE
Widen console chat view

### DIFF
--- a/internal/consoleserver/server_test.go
+++ b/internal/consoleserver/server_test.go
@@ -1535,6 +1535,9 @@ func TestSessionUIAdaptsToPhoneViewport(t *testing.T) {
 	for description, expected := range map[string]string{
 		"dynamic viewport height":            `height: 100dvh`,
 		"desktop sidebar width":              `grid-template-columns: 260px minmax(0, 1fr)`,
+		"desktop active request width":       `.current-request { z-index: 2; grid-row: 2; grid-column: 1; width: min(calc(100% - 48px), 960px);`,
+		"desktop transcript width":           `.messages { min-height: 0; grid-row: 2; grid-column: 1; overflow-y: auto; padding: 28px max(24px, calc((100% - 960px) / 2)) 36px;`,
+		"desktop composer width":             `.composer-wrap { position: relative; z-index: 2; min-width: 0; grid-row: 3; padding: 12px max(24px, calc((100% - 960px) / 2)) 10px;`,
 		"landscape phone breakpoint":         `(max-height: 500px) and (pointer: coarse)`,
 		"phone sidebar width":                `width: min(88vw, 320px)`,
 		"phone navigation touch target":      `.console-nav button { min-height: 44px; padding: 8px 10px; font-size: 14px; }`,
@@ -1552,7 +1555,6 @@ func TestSessionUIAdaptsToPhoneViewport(t *testing.T) {
 		"mobile composer alignment":          `.composer textarea { min-height: 44px; padding: 10px 2px; line-height: 24px; }`,
 		"phone-sized dialog":                 `max-height: calc(100dvh - 16px`,
 		"scrolling sidebar controls":         `.sidebar-scroll { flex: 1; min-height: 0; overflow-y: auto;`,
-		"shrinking composer content":         `z-index: 2; min-width: 0;`,
 	} {
 		if !strings.Contains(string(styles), expected) {
 			t.Errorf("Session styles are missing %s: %s", description, expected)

--- a/internal/consoleserver/web/styles.css
+++ b/internal/consoleserver/web/styles.css
@@ -262,14 +262,14 @@ button { color: inherit; }
 .icon-button:hover { background: var(--line-soft); }
 .icon-button:disabled { opacity: .38; cursor: default; }
 .icon-button.danger:not(:disabled):hover { color: var(--danger); border-color: rgba(167,63,63,.3); background: #fff6f6; }
-.current-request { z-index: 2; grid-row: 2; grid-column: 1; width: min(calc(100% - 48px), 768px); align-self: start; justify-self: center; margin-top: 10px; pointer-events: none; }
+.current-request { z-index: 2; grid-row: 2; grid-column: 1; width: min(calc(100% - 48px), 960px); align-self: start; justify-self: center; margin-top: 10px; pointer-events: none; }
 .current-request[hidden] { display: none; }
 .current-request button { width: 100%; display: grid; grid-template-columns: auto minmax(0, 1fr) auto; align-items: center; gap: 9px; padding: 8px 11px; overflow: hidden; border: 1px solid var(--line); border-radius: 11px; background: color-mix(in srgb, var(--card) 94%, transparent); color: var(--ink); box-shadow: 0 4px 18px rgba(0,0,0,.1); text-align: left; backdrop-filter: blur(12px); cursor: pointer; pointer-events: auto; }
 .current-request button:hover, .current-request button:focus-visible { border-color: #c5ccc6; }
 .current-request-label { color: var(--accent-2); font-size: 9px; font-weight: 800; letter-spacing: .07em; text-transform: uppercase; white-space: nowrap; }
 .current-request-text { overflow: hidden; font-size: 11.5px; line-height: 1.35; text-overflow: ellipsis; white-space: nowrap; }
 .current-request-jump { color: var(--muted); font-size: 13px; }
-.messages { min-height: 0; grid-row: 2; grid-column: 1; overflow-y: auto; padding: 28px max(24px, calc((100% - 768px) / 2)) 36px; scroll-behavior: smooth; }
+.messages { min-height: 0; grid-row: 2; grid-column: 1; overflow-y: auto; padding: 28px max(24px, calc((100% - 960px) / 2)) 36px; scroll-behavior: smooth; }
 .history-page-control { display: flex; justify-content: center; margin: -12px 0 24px; }
 .history-page-control button { padding: 7px 12px; border: 1px solid var(--line); border-radius: 999px; background: var(--card); color: var(--muted); font-size: 10.5px; font-weight: 700; cursor: pointer; }
 .history-page-control button:hover:not(:disabled) { border-color: #c5ccc6; color: var(--ink); }
@@ -395,7 +395,7 @@ button { color: inherit; }
 .turn-divider:not(:empty)::before, .turn-divider:not(:empty)::after { height: 1px; background: var(--line); content: ""; }
 .turn-divider:not(:empty)::before { flex: 0 0 10px; }
 .turn-divider:not(:empty)::after { flex: 1; }
-.composer-wrap { position: relative; z-index: 2; min-width: 0; grid-row: 3; padding: 12px max(24px, calc((100% - 768px) / 2)) 10px; background: linear-gradient(transparent, var(--canvas) 24%); }
+.composer-wrap { position: relative; z-index: 2; min-width: 0; grid-row: 3; padding: 12px max(24px, calc((100% - 960px) / 2)) 10px; background: linear-gradient(transparent, var(--canvas) 24%); }
 .composer-wrap.attachment-drop-target .composer { border-color: var(--accent); box-shadow: 0 0 0 3px rgba(0,0,0,.1); }
 .session-progress { display: flex; align-items: center; gap: 5px; min-height: 18px; margin: 0 4px 7px; color: var(--muted); font-size: 11px; font-weight: 650; font-variant-numeric: tabular-nums; }
 .session-progress[hidden] { display: none; }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Widens the desktop Session chat content column from 768px to 960px. The transcript, active-request banner, and composer remain aligned, while the mobile layout stays unchanged.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Pins the coordinated desktop widths in the existing Session layout test.

Verification:
- Targeted `TestSessionUIAdaptsToPhoneViewport` test
- `make verify`

#### Does this PR introduce a user-facing change?

```release-note
Widen the Console Session chat view on desktop.
```