### PR TITLE
Keep Console sessions awake while connected

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -218,8 +218,8 @@ the Session resource and is visible through the Kubernetes API.
 | `spec.initialBranch` | Git branch used to initialize the Session workspace. Checks out the branch from `origin` when it exists, or creates it from the Workspace ref. Requires `spec.worker.workspaceRef` | No |
 | `spec.initialPrompt` | Prompt submitted when the Session starts without retained conversation history. An `emptyDir` workspace may submit it again after Pod replacement | No |
 | `spec.volumeClaimTemplate` | PersistentVolumeClaimSpec for the Session workspace. Recommended for durable Sessions; omit to use an ephemeral `emptyDir` workspace | No |
-| `spec.idlePolicy.suspendAfterSeconds` | Automatically stop the Session runtime once it has been continuously idle for this many seconds without changing `spec.suspend`. Persistent workspace storage is retained. Selecting the Session in the web interface or starting a terminal connection resumes it. Omit to never suspend; zero suspends as soon as it goes idle. When deletion is also configured, this value must be less than `deleteAfterSeconds` | No |
-| `spec.idlePolicy.deleteAfterSeconds` | Automatically delete the Session once it has been continuously idle (no active turn, no reported activity) for this many seconds, measured from the later of `status.lastActivityTime` and the creation time. Renewed activity resets the idle period. Before deletion the runtime stops accepting new turns and any in-flight turn completes. Deleting the Session removes its workspace storage. Omit to never delete; zero deletes as soon as it goes idle. When suspension is also configured, this value must be greater than `suspendAfterSeconds` | No |
+| `spec.idlePolicy.suspendAfterSeconds` | Automatically stop the Session runtime once it has been continuously idle for this many seconds without changing `spec.suspend`. Persistent workspace storage is retained. Selecting the Session in the web interface or starting a terminal connection resumes it; an open Console conversation refreshes its idle period. Omit to never suspend; zero suspends as soon as it goes idle. When deletion is also configured, this value must be less than `deleteAfterSeconds` | No |
+| `spec.idlePolicy.deleteAfterSeconds` | Automatically delete the Session once it has been continuously idle (no active turn, no reported activity) for this many seconds, measured from the latest of `status.lastActivityTime`, the creation time, and connected Console activity. Before deletion the runtime stops accepting new turns and any in-flight turn completes. Deleting the Session removes its workspace storage. Omit to never delete; zero deletes as soon as it goes idle. When suspension is also configured, this value must be greater than `suspendAfterSeconds` | No |
 | `status.phase` | Infrastructure phase: `Pending`, `Ready`, `Suspended`, or `Failed` | Output |
 | `status.podName` | Session Pod name | Output |
 | `status.podUID` | Identity of the Pod running the live conversation | Output |
@@ -418,19 +418,21 @@ Pod does not change the order. The web client shows activity,
 `status.model`, `status.branch`, and the pull request with a colored,
 text-labeled state in both the Session sidebar and conversation header.
 
-Idle suspension and deletion use the same idle period, measured from the later
-of Session creation and `status.lastActivityTime`. Before either action, the
-runtime stops accepting new turns and waits for any in-flight turn to finish.
+Idle suspension and deletion use the same idle period, measured from the latest
+of Session creation, `status.lastActivityTime`, and connected web-client
+activity. Before either action, the runtime stops accepting new turns and waits
+for any in-flight turn to finish.
 When `spec.idlePolicy.suspendAfterSeconds` is reached, Kelos scales the runtime
 to zero and reports `status.phase: Suspended` with the `IdlePolicyTriggered`
 Ready-condition reason. `IdlePolicyTriggered` is stable and machine-readable so
 clients can distinguish idle suspension from `spec.suspend: true`. Selecting the
 Session in the web interface or starting a terminal connection resumes it; an
 existing client's automatic reconnect does not. Kelos keeps the resume request
-active until the client receives the runtime's conversation history. A resume
-acknowledgement starts a fresh idle period and keeps the runtime protected for a
-five-second connection grace. A resume request that is not acknowledged within
-10 minutes expires and safely drains any running work before returning the
+active until the client receives the runtime's conversation history. A connected
+web client refreshes the idle period while the conversation remains open. A
+resume acknowledgement starts a fresh idle period and keeps the runtime protected
+for a five-second connection grace. A resume request that is not acknowledged
+within 10 minutes expires and safely drains any running work before returning the
 Session to idle suspension, allowing its deletion deadline to proceed. When both
 idle actions are configured, `suspendAfterSeconds` must be less than
 `deleteAfterSeconds`; deletion still occurs at `deleteAfterSeconds`, including

--- a/internal/consoleserver/server.go
+++ b/internal/consoleserver/server.go
@@ -63,6 +63,7 @@ const (
 	taskLogOmittedMessage        = "[... earlier log output omitted ...]\n"
 	workerTaskLogLineLimit       = taskLogTailLineLimit + 2
 	workerTaskLogSinceMargin     = 5 * time.Second
+	consoleActivityInterval      = 20 * time.Second
 )
 
 var errTaskLogSegmentUnavailable = errors.New("Task log segment is unavailable in the recent WorkerPool log window")
@@ -1605,20 +1606,30 @@ func (s *Server) connectSession(writer http.ResponseWriter, request *http.Reques
 	}
 	socket := &sessionSocket{Conn: connection}
 	defer socket.Close()
-	var acknowledgeResume func() error
-	if sessionsuspend.ResumeRequested(&session) {
-		requestValue := session.Annotations[sessionsuspend.ResumeRequestAnnotation]
-		acknowledgeResume = func() error {
-			_, err := sessionsuspend.AcknowledgeResume(request.Context(), s.client, client.ObjectKeyFromObject(&session), requestValue)
-			return err
+	requestValue := session.Annotations[sessionsuspend.ResumeRequestAnnotation]
+	resumeAcknowledged := requestValue == ""
+	refreshIdlePeriod := session.Spec.IdlePolicy != nil &&
+		(session.Spec.IdlePolicy.SuspendAfterSeconds != nil || session.Spec.IdlePolicy.DeleteAfterSeconds != nil)
+	refreshConnection := func() error {
+		if !resumeAcknowledged {
+			if _, err := sessionsuspend.AcknowledgeResume(request.Context(), s.client, client.ObjectKeyFromObject(&session), requestValue); err != nil {
+				return err
+			}
+			resumeAcknowledged = true
 		}
+		if !refreshIdlePeriod {
+			return nil
+		}
+		return sessionsuspend.RecordConsoleActivity(request.Context(), s.client, client.ObjectKeyFromObject(&session))
 	}
-	if err := s.bridge(request.Context(), socket, namespace, session.Status.PodName, acknowledgeResume); err != nil {
+	if err := s.bridge(request.Context(), socket, namespace, session.Status.PodName, refreshConnection); err != nil {
 		_ = socket.WriteJSON(map[string]any{"type": "error", "text": err.Error(), "status": "failed"})
 	}
 }
 
-func (s *Server) bridgeExec(ctx context.Context, connection *sessionSocket, namespace, podName string, acknowledgeResume func() error) error {
+func (s *Server) bridgeExec(ctx context.Context, connection *sessionSocket, namespace, podName string, refreshConnection func() error) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	request := s.clientset.CoreV1().RESTClient().Post().
 		Resource("pods").
 		Namespace(namespace).
@@ -1660,8 +1671,9 @@ func (s *Server) bridgeExec(ctx context.Context, connection *sessionSocket, name
 	}()
 
 	outputDone := make(chan error, 2)
-	resumeAcknowledged := acknowledgeResume == nil
+	connectionReady := make(chan struct{})
 	forward := func(reader io.Reader, stderr bool) {
+		ready := false
 		scanner := newJSONLineScanner(reader)
 		for scanner.Scan() {
 			payload := append([]byte(nil), scanner.Bytes()...)
@@ -1674,14 +1686,15 @@ func (s *Server) bridgeExec(ctx context.Context, connection *sessionSocket, name
 				outputDone <- err
 				return
 			}
-			if !stderr && !resumeAcknowledged {
+			if !stderr && !ready {
 				var event sessionruntime.Event
 				if json.Unmarshal(payload, &event) == nil && event.Type == sessionruntime.EventHistoryEnd {
-					if err := acknowledgeResume(); err != nil {
+					if err := refreshConnection(); err != nil {
 						outputDone <- err
 						return
 					}
-					resumeAcknowledged = true
+					ready = true
+					close(connectionReady)
 				}
 			}
 		}
@@ -1710,6 +1723,11 @@ func (s *Server) bridgeExec(ctx context.Context, connection *sessionSocket, name
 		}
 	}()
 
+	activityDone := make(chan error, 1)
+	go func() {
+		activityDone <- refreshConsoleActivity(ctx, connectionReady, consoleActivityInterval, refreshConnection)
+	}()
+
 	select {
 	case err := <-streamDone:
 		return err
@@ -1717,8 +1735,30 @@ func (s *Server) bridgeExec(ctx context.Context, connection *sessionSocket, name
 		return err
 	case err := <-readDone:
 		return err
+	case err := <-activityDone:
+		return err
 	case <-ctx.Done():
 		return ctx.Err()
+	}
+}
+
+func refreshConsoleActivity(ctx context.Context, ready <-chan struct{}, interval time.Duration, refresh func() error) error {
+	select {
+	case <-ready:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			if err := refresh(); err != nil {
+				return err
+			}
+		case <-ctx.Done():
+			return ctx.Err()
+		}
 	}
 }
 

--- a/internal/consoleserver/server_test.go
+++ b/internal/consoleserver/server_test.go
@@ -2693,17 +2693,20 @@ func TestConnectSessionBridgesAndAcknowledgesResumedSession(t *testing.T) {
 			Namespace:   "team-a",
 			Annotations: map[string]string{sessionsuspend.ResumeRequestAnnotation: "resume-request"},
 		},
-		Spec: kelos.SessionSpec{Worker: kelos.WorkerSpec{
-			Type:        "codex",
-			Credentials: &kelos.Credentials{Type: kelos.CredentialTypeNone},
-		}},
+		Spec: kelos.SessionSpec{
+			Worker: kelos.WorkerSpec{
+				Type:        "codex",
+				Credentials: &kelos.Credentials{Type: kelos.CredentialTypeNone},
+			},
+			IdlePolicy: &kelos.SessionIdlePolicy{SuspendAfterSeconds: ptr.To(int32(60))},
+		},
 		Status: kelos.SessionStatus{Phase: kelos.SessionPhaseReady, PodName: "chat-pod"},
 	}
 	if err := server.client.Create(t.Context(), session); err != nil {
 		t.Fatal(err)
 	}
 	bridged := make(chan struct{})
-	server.bridge = func(_ context.Context, connection *sessionSocket, namespace, podName string, acknowledgeResume func() error) error {
+	server.bridge = func(_ context.Context, connection *sessionSocket, namespace, podName string, refreshConnection func() error) error {
 		defer close(bridged)
 		if namespace != "team-a" || podName != "chat-pod" {
 			t.Errorf("bridge target = %s/%s, want team-a/chat-pod", namespace, podName)
@@ -2718,10 +2721,10 @@ func TestConnectSessionBridgesAndAcknowledgesResumedSession(t *testing.T) {
 		if err := connection.WriteJSON(map[string]any{"type": "history.end"}); err != nil {
 			return err
 		}
-		if acknowledgeResume == nil {
-			return errors.New("resume acknowledgement is not configured")
+		if refreshConnection == nil {
+			return errors.New("connection refresh is not configured")
 		}
-		return acknowledgeResume()
+		return refreshConnection()
 	}
 
 	httpServer := httptest.NewServer(server)
@@ -2759,6 +2762,39 @@ func TestConnectSessionBridgesAndAcknowledgesResumedSession(t *testing.T) {
 	}
 	if !sessionsuspend.ResumeAcknowledged(&updated) {
 		t.Fatalf("resume request was not acknowledged: %#v", updated.Annotations)
+	}
+	if _, ok := sessionsuspend.ConsoleActivityTime(&updated); !ok {
+		t.Fatalf("Console activity was not recorded: %#v", updated.Annotations)
+	}
+}
+
+func TestRefreshConsoleActivityRenewsReadyConnection(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	ready := make(chan struct{})
+	refreshed := make(chan struct{}, 2)
+	done := make(chan error, 1)
+	go func() {
+		done <- refreshConsoleActivity(ctx, ready, time.Millisecond, func() error {
+			refreshed <- struct{}{}
+			return nil
+		})
+	}()
+	close(ready)
+	for range 2 {
+		select {
+		case <-refreshed:
+		case <-time.After(time.Second):
+			t.Fatal("Console activity was not renewed")
+		}
+	}
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("refreshConsoleActivity() error = %v, want context cancellation", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("refreshConsoleActivity() did not stop")
 	}
 }
 

--- a/internal/controller/session_controller.go
+++ b/internal/controller/session_controller.go
@@ -1964,13 +1964,17 @@ func sessionIdlePolicyExpired(session *kelos.Session, afterSeconds *int32) (bool
 	if afterSeconds == nil || sessionsuspend.ResumeRequested(session) {
 		return false, 0
 	}
+	now := time.Now()
+	if remaining := sessionsuspend.ConsoleActivityLeaseRemaining(session, now); remaining > 0 {
+		return false, remaining
+	}
 	active := apiMeta.FindStatusCondition(session.Status.Conditions, kelos.SessionConditionActive)
 	if (active == nil || active.Status != metav1.ConditionFalse) && !sessionsuspend.IsIdlePolicySuspended(session) {
 		return false, 0
 	}
 	ttl := time.Duration(*afterSeconds) * time.Second
 	expireAt := sessionIdleSince(session).Add(ttl)
-	remaining := time.Until(expireAt)
+	remaining := expireAt.Sub(now)
 	if remaining <= 0 {
 		return true, 0
 	}
@@ -1986,6 +1990,9 @@ func sessionIdleSince(session *kelos.Session) time.Time {
 	since := session.CreationTimestamp.Time
 	if last := session.Status.LastActivityTime; last != nil && last.After(since) {
 		since = last.Time
+	}
+	if consoleActivity, ok := sessionsuspend.ConsoleActivityTime(session); ok && consoleActivity.After(since) {
+		since = consoleActivity
 	}
 	return since
 }

--- a/internal/controller/session_controller_test.go
+++ b/internal/controller/session_controller_test.go
@@ -2575,6 +2575,28 @@ func TestSessionIdleExpired(t *testing.T) {
 			wantRequeue: true,
 		},
 		{
+			name: "connected Console protects an idle Session",
+			session: newSession(ptr.To(int32(0)), func(s *kelos.Session) {
+				idleFor(time.Hour)(s)
+				if s.Annotations == nil {
+					s.Annotations = map[string]string{}
+				}
+				s.Annotations[sessionsuspend.ConsoleActivityAnnotation] = now.UTC().Format(time.RFC3339Nano)
+			}),
+			wantRequeue: true,
+		},
+		{
+			name: "last Console activity resets the idle baseline",
+			session: newSession(ptr.To(int32(600)), func(s *kelos.Session) {
+				idleFor(time.Hour)(s)
+				if s.Annotations == nil {
+					s.Annotations = map[string]string{}
+				}
+				s.Annotations[sessionsuspend.ConsoleActivityAnnotation] = now.Add(-2 * time.Minute).UTC().Format(time.RFC3339Nano)
+			}),
+			wantRequeue: true,
+		},
+		{
 			name:        "zero TTL reaps as soon as idle",
 			session:     newSession(ptr.To(int32(0)), idleFor(time.Second)),
 			wantExpired: true,

--- a/internal/sessionsuspend/suspend.go
+++ b/internal/sessionsuspend/suspend.go
@@ -15,6 +15,10 @@ import (
 )
 
 const (
+	// ConsoleActivityAnnotation records the latest activity from a connected Console client.
+	ConsoleActivityAnnotation = "kelos.dev/session-console-activity"
+	// ConsoleActivityLeaseDuration keeps a Session awake between Console heartbeats.
+	ConsoleActivityLeaseDuration = time.Minute
 	// ResumeRequestAnnotation asks the Session controller to resume an idle-suspended Session.
 	ResumeRequestAnnotation = "kelos.dev/session-idle-resume-request"
 	// ResumeRequestTimeAnnotation records when the controller observed the resume request.
@@ -26,6 +30,25 @@ const (
 	// IdlePolicyReason identifies a Session suspended by its idle policy.
 	IdlePolicyReason = kelos.SessionReasonIdlePolicyTriggered
 )
+
+// ConsoleActivityTime returns the latest activity reported by a connected Console client.
+func ConsoleActivityTime(session *kelos.Session) (time.Time, bool) {
+	activityTime, err := time.Parse(time.RFC3339Nano, session.Annotations[ConsoleActivityAnnotation])
+	return activityTime, err == nil
+}
+
+// ConsoleActivityLeaseRemaining returns how long a recent Console heartbeat protects a Session.
+func ConsoleActivityLeaseRemaining(session *kelos.Session, now time.Time) time.Duration {
+	activityTime, ok := ConsoleActivityTime(session)
+	if !ok {
+		return 0
+	}
+	remaining := activityTime.Add(ConsoleActivityLeaseDuration).Sub(now)
+	if remaining < 0 {
+		return 0
+	}
+	return remaining
+}
 
 // IsIdlePolicySuspended reports whether the Session is suspended by its idle policy.
 func IsIdlePolicySuspended(session *kelos.Session) bool {
@@ -139,4 +162,23 @@ func AcknowledgeResume(ctx context.Context, cl client.Client, key client.ObjectK
 		return false, fmt.Errorf("acknowledging Session %q resume: %w", key.Name, err)
 	}
 	return acknowledged, nil
+}
+
+// RecordConsoleActivity refreshes the idle baseline for a connected Console client.
+func RecordConsoleActivity(ctx context.Context, cl client.Client, key client.ObjectKey) error {
+	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		var current kelos.Session
+		if err := cl.Get(ctx, key, &current); err != nil {
+			return err
+		}
+		original := current.DeepCopy()
+		if current.Annotations == nil {
+			current.Annotations = map[string]string{}
+		}
+		current.Annotations[ConsoleActivityAnnotation] = time.Now().UTC().Format(time.RFC3339Nano)
+		return cl.Patch(ctx, &current, client.MergeFromWithOptions(original, client.MergeFromWithOptimisticLock{}))
+	}); err != nil {
+		return fmt.Errorf("recording Console activity for Session %q: %w", key.Name, err)
+	}
+	return nil
 }

--- a/internal/sessionsuspend/suspend_test.go
+++ b/internal/sessionsuspend/suspend_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -181,6 +182,35 @@ func TestRequestResumeRetriesPatchConflict(t *testing.T) {
 	}
 	if cl.patches != 2 {
 		t.Fatalf("Patch() called %d times, want 2", cl.patches)
+	}
+}
+
+func TestRecordConsoleActivityRefreshesLease(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := kelos.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	session := idleSuspendedSession()
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(session).Build()
+	key := client.ObjectKeyFromObject(session)
+
+	before := time.Now().UTC()
+	if err := RecordConsoleActivity(context.Background(), cl, key); err != nil {
+		t.Fatal(err)
+	}
+	var updated kelos.Session
+	if err := cl.Get(context.Background(), key, &updated); err != nil {
+		t.Fatal(err)
+	}
+	activityTime, ok := ConsoleActivityTime(&updated)
+	if !ok || activityTime.Before(before) || activityTime.After(time.Now().UTC()) {
+		t.Fatalf("ConsoleActivityTime() = %v, %t, want a current timestamp", activityTime, ok)
+	}
+	if remaining := ConsoleActivityLeaseRemaining(&updated, activityTime); remaining != ConsoleActivityLeaseDuration {
+		t.Fatalf("ConsoleActivityLeaseRemaining() = %s, want %s", remaining, ConsoleActivityLeaseDuration)
+	}
+	if remaining := ConsoleActivityLeaseRemaining(&updated, activityTime.Add(ConsoleActivityLeaseDuration+time.Second)); remaining != 0 {
+		t.Fatalf("expired ConsoleActivityLeaseRemaining() = %s, want 0", remaining)
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Keeps Sessions with an idle policy awake while their Console conversation remains connected.

The Console records client activity after conversation history is delivered and refreshes it every 20 seconds. The Session controller treats recent Console activity as a renewable one-minute lease and as the latest idle baseline, so a resumed Session is not suspended again while it is being viewed. Heartbeats are only written for Sessions that configure an idle policy.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

- `make test` passes with `CODEX_AUTH_JSON` and `CODEX_HOME` cleared so subprocess entrypoint tests run in an isolated environment.
- `make verify` passes.

#### Does this PR introduce a user-facing change?

```release-note
Connected Kelos Console conversations now refresh Session idle activity so resumed Sessions remain available until the Console disconnects.
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps resumed Sessions from being suspended again while their Console conversation stays open, so a Session you're actively viewing remains available. The Console now writes heartbeat activity that the idle policy treats as a renewable lease; heartbeats are only sent for Sessions with an idle policy configured.

**Details**

- Console records client activity after conversation history is delivered and refreshes it every 20 seconds.
- The Session controller treats recent Console activity as a one-minute renewable lease and as the latest idle baseline for both suspend and delete policies.
- `docs/reference.md` is updated to describe the new idle baseline and resumed Session behavior.

<sup>Written for commit 6bcc49043ab6a7ee2d82078dde26ead845c45b21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1710?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

