### PR TITLE
Pin new session button in console

### DIFF
--- a/internal/consoleserver/server_test.go
+++ b/internal/consoleserver/server_test.go
@@ -1521,9 +1521,12 @@ func TestSessionUIAdaptsToPhoneViewport(t *testing.T) {
 	if scrollStart < 0 || scrollEnd <= scrollStart {
 		t.Fatal("Session page does not define sidebar scrolling before the fixed footer")
 	}
+	newSessionAction := bytes.Index(index, []byte(`id="new-session"`))
+	if newSessionAction < 0 || newSessionAction >= scrollStart {
+		t.Fatal("Session page does not pin the new Session action above the scrolling sidebar content")
+	}
 	scrollContent := string(index[scrollStart:scrollEnd])
 	for description, expected := range map[string]string{
-		"new Session action":    `id="new-session"`,
 		"namespace switcher":    `id="namespace-form"`,
 		"console navigation":    `class="console-nav"`,
 		"Session conversations": `id="session-list"`,
@@ -1543,6 +1546,7 @@ func TestSessionUIAdaptsToPhoneViewport(t *testing.T) {
 		"phone navigation touch target":      `.console-nav button { min-height: 44px; padding: 8px 10px; font-size: 14px; }`,
 		"compact phone session row":          `.session-item-select { min-height: 60px; padding: 7px 48px 7px 8px; }`,
 		"phone create touch target":          `.new-session-button { min-height: 44px; margin-top: 4px; padding: 8px 10px; }`,
+		"fixed new Session action":           `.new-session-button { flex: none;`,
 		"section reorder touch target":       `.session-section-order-button { width: 44px; height: 44px; }`,
 		"single-row phone header":            `grid-template-areas: "menu heading actions"`,
 		"phone lifecycle actions in sidebar": `.session-lifecycle-action, #reset-session, #delete-session { display: none !important; }`,

--- a/internal/consoleserver/web/index.html
+++ b/internal/consoleserver/web/index.html
@@ -18,10 +18,10 @@
         </div>
         <button class="icon-button mobile-only" id="close-sidebar" aria-label="Close navigation">×</button>
       </div>
+      <button class="new-session-button" id="new-session" type="button">
+        <span aria-hidden="true">＋</span> New session
+      </button>
       <div class="sidebar-scroll">
-        <button class="new-session-button" id="new-session" type="button">
-          <span aria-hidden="true">＋</span> New session
-        </button>
         <form class="namespace-form" id="namespace-form">
           <label for="active-namespace">Namespace</label>
           <div>

--- a/internal/consoleserver/web/styles.css
+++ b/internal/consoleserver/web/styles.css
@@ -39,7 +39,7 @@ button { color: inherit; }
 .brand { font-size: 15px; font-weight: 650; letter-spacing: -.01em; }
 .brand-subtitle { margin-top: 1px; color: var(--muted); font-size: 11px; }
 .sidebar-scroll { flex: 1; min-height: 0; overflow-y: auto; scrollbar-width: thin; }
-.new-session-button { width: 100%; min-height: 40px; display: flex; align-items: center; justify-content: flex-start; gap: 9px; margin: 0; padding: 9px 10px; border: 0; border-radius: 9px; background: transparent; font-size: 13px; font-weight: 500; cursor: pointer; transition: background .15s; }
+.new-session-button { flex: none; width: 100%; min-height: 40px; display: flex; align-items: center; justify-content: flex-start; gap: 9px; margin: 0; padding: 9px 10px; border: 0; border-radius: 9px; background: transparent; font-size: 13px; font-weight: 500; cursor: pointer; transition: background .15s; }
 .new-session-button:hover { background: var(--line-soft); }
 .new-session-button span { width: 20px; font-size: 18px; text-align: center; }
 .namespace-form { margin: 8px 0; padding: 0 3px; }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Pins the New session action above the kelos-console sidebar's scrollable content so it remains visible while navigating long conversation lists on desktop and mobile.

Updates the sidebar layout test to enforce the fixed action boundary.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

- `make verify` passes.
- `make test TEST_FLAGS='-run TestSessionUIAdaptsToPhoneViewport'` passes.
- The console package passed during `make test`, but the full target reported unrelated Codex fixture failures in `TestCodexEntrypointUsesPersistentSessionHome` and `TestAgentEntrypointsPreserveSkillReferenceFiles/codex`.

#### Does this PR introduce a user-facing change?

```release-note
Keep the New session action visible while scrolling the console sidebar.
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the New session button above the console sidebar's scrollable content so it stays visible while scrolling through long conversation lists.

- Moves the button out of the sidebar's scroll area and adds `flex: none` to keep it from shrinking.
- Updates the sidebar layout test to enforce the pinned button position.

<sup>Written for commit fc29b6c8999871f1b41c1fcbddf7a76319be49aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1714?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

