### PR TITLE
Narrow Kelos skill discovery scope

### DIFF
--- a/skills/kelos/SKILL.md
+++ b/skills/kelos/SKILL.md
@@ -1,11 +1,14 @@
 ---
 name: kelos
 description: >-
-  Author, debug, and operate Kelos resources (Task, Session, Workspace,
-  AgentConfig, TaskSpawner) on Kubernetes. Use for Kelos CRDs, resource
-  manifests, the kelos CLI, or live cluster operations. Do not use for ordinary
-  Kelos repo code edits, tests, reviews, build/CI, or git tasks unless they
-  involve those resources.
+  Install and configure Kelos; author, document, inspect, troubleshoot, and
+  operate its Kubernetes custom resources and CRD schemas in the kelos.dev API
+  group using manifests, kubectl, or the kelos CLI. Use when a request names
+  Kelos or a distinctive Kelos kind such as AgentConfig or TaskSpawner and
+  concerns an installation, CLI command, API or CRD schema, manifest or example,
+  resource-field documentation, or live custom resource. Do not use for ordinary
+  code, test, build, review, CI, or Git work, even in the Kelos repository or on
+  a service hosted under kelos.dev.
 ---
 
 # Kelos Skill


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Narrows the Kelos skill discovery description to requests specifically involving Kelos installations, CLI commands, CRD schemas, manifests, or live custom resources.

It also excludes ordinary development and CI work, including unrelated services hosted under kelos.dev, so the skill is not implicitly invoked from product ownership or URL context alone.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

`make verify` passes.

#### Does this PR introduce a user-facing change?

```release-note
Narrow Kelos skill discovery so it does not activate for unrelated development, CI runs, or services hosted under kelos.dev.
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Narrows the `kelos` skill's discovery description so it only activates for requests specifically about Kelos installations, CLI commands, CRD schemas, manifests, or live custom resources. This prevents it from being triggered by ordinary development, CI, or services hosted under kelos.dev.

<sup>Written for commit af57f9af9803830523b8cd2e2e13e7b53c5c6fde. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1720?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

