### PR TITLE
Update self-development agents to GPT-6 Astra

### DIFF
--- a/self-development/README.md
+++ b/self-development/README.md
@@ -662,12 +662,12 @@ To adapt these examples for your own repository:
    spec:
      taskTemplate:
        worker:
-         model: gpt-5.6-sol
+         model: gpt-6-astra
          effort: xhigh
    ```
 
-   The checked-in spawners use `gpt-5.6-sol` for the tasks that previously used
-   Opus, and `gpt-5.4-mini` for the tasks that previously used Sonnet.
+   The checked-in spawners use `gpt-6-astra` for high-capability tasks and
+   `gpt-5.4-mini` for lower-cost routine tasks.
    They set `effort` by role: `xhigh` for complex planning, coding, strategy,
    review, PR update, and configuration update workflows; `high` for triage;
    and `medium` for routine image, fake-user, and squash workflows.

--- a/self-development/agora/agora-config-update.yaml
+++ b/self-development/agora/agora-config-update.yaml
@@ -14,7 +14,7 @@ spec:
       # learning from the kelos-dev/agora repository's recent activity.
       workspaceRef:
         name: kelos-agent
-      model: gpt-5.6-sol
+      model: gpt-6-astra
       effort: xhigh
       type: codex
       credentials:

--- a/self-development/agora/agora-fake-strategist.yaml
+++ b/self-development/agora/agora-fake-strategist.yaml
@@ -41,7 +41,7 @@ spec:
     worker:
       workspaceRef:
         name: agora-agent
-      model: gpt-5.6-sol
+      model: gpt-6-astra
       effort: xhigh
       type: codex
       credentials:

--- a/self-development/agora/agora-planner.yaml
+++ b/self-development/agora/agora-planner.yaml
@@ -49,7 +49,7 @@ spec:
     worker:
       workspaceRef:
         name: agora-agent
-      model: gpt-5.6-sol
+      model: gpt-6-astra
       effort: xhigh
       type: codex
       credentials:

--- a/self-development/agora/agora-pr-responder.yaml
+++ b/self-development/agora/agora-pr-responder.yaml
@@ -36,7 +36,7 @@ spec:
     worker:
       workspaceRef:
         name: agora-session-agent
-      model: gpt-5.6-sol
+      model: gpt-6-astra
       effort: xhigh
       type: codex
       credentials:

--- a/self-development/agora/agora-reviewer.yaml
+++ b/self-development/agora/agora-reviewer.yaml
@@ -68,7 +68,7 @@ spec:
     worker:
       workspaceRef:
         name: agora-agent
-      model: gpt-5.6-sol
+      model: gpt-6-astra
       effort: xhigh
       type: codex
       credentials:

--- a/self-development/agora/agora-self-update.yaml
+++ b/self-development/agora/agora-self-update.yaml
@@ -14,7 +14,7 @@ spec:
       # workflow files, while learning from the kelos-dev/agora repository's activity.
       workspaceRef:
         name: kelos-agent
-      model: gpt-5.6-sol
+      model: gpt-6-astra
       effort: xhigh
       type: codex
       credentials:

--- a/self-development/agora/agora-triage.yaml
+++ b/self-development/agora/agora-triage.yaml
@@ -31,7 +31,7 @@ spec:
     worker:
       workspaceRef:
         name: agora-agent
-      model: gpt-5.6-sol
+      model: gpt-6-astra
       effort: high
       type: codex
       credentials:

--- a/self-development/agora/agora-workers.yaml
+++ b/self-development/agora/agora-workers.yaml
@@ -29,7 +29,7 @@ spec:
     worker:
       workspaceRef:
         name: agora-session-agent
-      model: gpt-5.6-sol
+      model: gpt-6-astra
       effort: xhigh
       type: codex
       credentials:

--- a/self-development/cs
+++ b/self-development/cs
@@ -36,7 +36,7 @@ spec:
       - name: base-agent
     workspaceRef:
       name: kelos-session-agent
-    model: gpt-5.6-sol
+    model: gpt-6-astra
     effort: xhigh
     type: codex
     credentials:

--- a/self-development/kanon/kanon-config-update.yaml
+++ b/self-development/kanon/kanon-config-update.yaml
@@ -14,7 +14,7 @@ spec:
       # learning from the kelos-dev/kanon repository's recent activity.
       workspaceRef:
         name: kelos-agent
-      model: gpt-5.6-sol
+      model: gpt-6-astra
       effort: xhigh
       type: codex
       credentials:

--- a/self-development/kanon/kanon-fake-strategist.yaml
+++ b/self-development/kanon/kanon-fake-strategist.yaml
@@ -39,7 +39,7 @@ spec:
     worker:
       workspaceRef:
         name: kanon-agent
-      model: gpt-5.6-sol
+      model: gpt-6-astra
       effort: xhigh
       type: codex
       credentials:

--- a/self-development/kanon/kanon-planner.yaml
+++ b/self-development/kanon/kanon-planner.yaml
@@ -48,7 +48,7 @@ spec:
     worker:
       workspaceRef:
         name: kanon-agent
-      model: gpt-5.6-sol
+      model: gpt-6-astra
       effort: xhigh
       type: codex
       credentials:

--- a/self-development/kanon/kanon-pr-responder.yaml
+++ b/self-development/kanon/kanon-pr-responder.yaml
@@ -36,7 +36,7 @@ spec:
     worker:
       workspaceRef:
         name: kanon-session-agent
-      model: gpt-5.6-sol
+      model: gpt-6-astra
       effort: xhigh
       type: codex
       credentials:

--- a/self-development/kanon/kanon-reviewer.yaml
+++ b/self-development/kanon/kanon-reviewer.yaml
@@ -67,7 +67,7 @@ spec:
     worker:
       workspaceRef:
         name: kanon-agent
-      model: gpt-5.6-sol
+      model: gpt-6-astra
       effort: xhigh
       type: codex
       credentials:

--- a/self-development/kanon/kanon-self-update.yaml
+++ b/self-development/kanon/kanon-self-update.yaml
@@ -14,7 +14,7 @@ spec:
       # config files, while learning from the kelos-dev/kanon repository's activity.
       workspaceRef:
         name: kelos-agent
-      model: gpt-5.6-sol
+      model: gpt-6-astra
       effort: xhigh
       type: codex
       credentials:

--- a/self-development/kanon/kanon-triage.yaml
+++ b/self-development/kanon/kanon-triage.yaml
@@ -31,7 +31,7 @@ spec:
     worker:
       workspaceRef:
         name: kanon-agent
-      model: gpt-5.6-sol
+      model: gpt-6-astra
       effort: high
       type: codex
       credentials:

--- a/self-development/kanon/kanon-workers.yaml
+++ b/self-development/kanon/kanon-workers.yaml
@@ -29,7 +29,7 @@ spec:
     worker:
       workspaceRef:
         name: kanon-session-agent
-      model: gpt-5.6-sol
+      model: gpt-6-astra
       effort: xhigh
       type: codex
       credentials:

--- a/self-development/kelos-api-reviewer.yaml
+++ b/self-development/kelos-api-reviewer.yaml
@@ -69,7 +69,7 @@ spec:
     worker:
       workspaceRef:
         name: kelos-agent
-      model: gpt-5.6-sol
+      model: gpt-6-astra
       effort: xhigh
       type: codex
       credentials:

--- a/self-development/kelos-config-update.yaml
+++ b/self-development/kelos-config-update.yaml
@@ -11,7 +11,7 @@ spec:
     worker:
       workspaceRef:
         name: kelos-agent
-      model: gpt-5.6-sol
+      model: gpt-6-astra
       effort: xhigh
       type: codex
       credentials:

--- a/self-development/kelos-fake-strategist.yaml
+++ b/self-development/kelos-fake-strategist.yaml
@@ -43,7 +43,7 @@ spec:
     worker:
       workspaceRef:
         name: kelos-agent
-      model: gpt-5.6-sol
+      model: gpt-6-astra
       effort: xhigh
       type: codex
       credentials:

--- a/self-development/kelos-planner.yaml
+++ b/self-development/kelos-planner.yaml
@@ -48,7 +48,7 @@ spec:
     worker:
       workspaceRef:
         name: kelos-agent
-      model: gpt-5.6-sol
+      model: gpt-6-astra
       effort: xhigh
       type: codex
       credentials:

--- a/self-development/kelos-pr-responder.yaml
+++ b/self-development/kelos-pr-responder.yaml
@@ -36,7 +36,7 @@ spec:
     worker:
       workspaceRef:
         name: kelos-session-agent
-      model: gpt-5.6-sol
+      model: gpt-6-astra
       effort: xhigh
       type: codex
       credentials:

--- a/self-development/kelos-reviewer.yaml
+++ b/self-development/kelos-reviewer.yaml
@@ -70,7 +70,7 @@ spec:
     worker:
       workspaceRef:
         name: kelos-agent
-      model: gpt-5.6-sol
+      model: gpt-6-astra
       effort: xhigh
       type: codex
       credentials:

--- a/self-development/kelos-self-update.yaml
+++ b/self-development/kelos-self-update.yaml
@@ -43,7 +43,7 @@ spec:
     worker:
       workspaceRef:
         name: kelos-agent
-      model: gpt-5.6-sol
+      model: gpt-6-astra
       effort: xhigh
       type: codex
       credentials:

--- a/self-development/kelos-triage.yaml
+++ b/self-development/kelos-triage.yaml
@@ -31,7 +31,7 @@ spec:
     worker:
       workspaceRef:
         name: kelos-agent
-      model: gpt-5.6-sol
+      model: gpt-6-astra
       effort: high
       type: codex
       credentials:

--- a/self-development/kelos-workers.yaml
+++ b/self-development/kelos-workers.yaml
@@ -33,7 +33,7 @@ spec:
     worker:
       workspaceRef:
         name: kelos-session-agent
-      model: gpt-5.6-sol
+      model: gpt-6-astra
       effort: xhigh
       type: codex
       credentials:

--- a/self-development/open-actions/open-actions-api-reviewer.yaml
+++ b/self-development/open-actions/open-actions-api-reviewer.yaml
@@ -69,7 +69,7 @@ spec:
     worker:
       workspaceRef:
         name: open-actions-agent
-      model: gpt-5.6-sol
+      model: gpt-6-astra
       effort: xhigh
       type: codex
       credentials:

--- a/self-development/open-actions/open-actions-config-update.yaml
+++ b/self-development/open-actions/open-actions-config-update.yaml
@@ -14,7 +14,7 @@ spec:
       # learning from the kelos-dev/open-actions repository's recent activity.
       workspaceRef:
         name: kelos-agent
-      model: gpt-5.6-sol
+      model: gpt-6-astra
       effort: xhigh
       type: codex
       credentials:

--- a/self-development/open-actions/open-actions-fake-strategist.yaml
+++ b/self-development/open-actions/open-actions-fake-strategist.yaml
@@ -39,7 +39,7 @@ spec:
     worker:
       workspaceRef:
         name: open-actions-agent
-      model: gpt-5.6-sol
+      model: gpt-6-astra
       effort: xhigh
       type: codex
       credentials:

--- a/self-development/open-actions/open-actions-planner.yaml
+++ b/self-development/open-actions/open-actions-planner.yaml
@@ -48,7 +48,7 @@ spec:
     worker:
       workspaceRef:
         name: open-actions-agent
-      model: gpt-5.6-sol
+      model: gpt-6-astra
       effort: xhigh
       type: codex
       credentials:

--- a/self-development/open-actions/open-actions-pr-responder.yaml
+++ b/self-development/open-actions/open-actions-pr-responder.yaml
@@ -36,7 +36,7 @@ spec:
     worker:
       workspaceRef:
         name: open-actions-session-agent
-      model: gpt-5.6-sol
+      model: gpt-6-astra
       effort: xhigh
       type: codex
       credentials:

--- a/self-development/open-actions/open-actions-reviewer.yaml
+++ b/self-development/open-actions/open-actions-reviewer.yaml
@@ -71,7 +71,7 @@ spec:
     worker:
       workspaceRef:
         name: open-actions-agent
-      model: gpt-5.6-sol
+      model: gpt-6-astra
       effort: xhigh
       type: codex
       credentials:

--- a/self-development/open-actions/open-actions-self-update.yaml
+++ b/self-development/open-actions/open-actions-self-update.yaml
@@ -14,7 +14,7 @@ spec:
       # config files, while learning from the kelos-dev/open-actions repository's activity.
       workspaceRef:
         name: kelos-agent
-      model: gpt-5.6-sol
+      model: gpt-6-astra
       effort: xhigh
       type: codex
       credentials:

--- a/self-development/open-actions/open-actions-triage.yaml
+++ b/self-development/open-actions/open-actions-triage.yaml
@@ -31,7 +31,7 @@ spec:
     worker:
       workspaceRef:
         name: open-actions-agent
-      model: gpt-5.6-sol
+      model: gpt-6-astra
       effort: high
       type: codex
       credentials:

--- a/self-development/open-actions/open-actions-workers.yaml
+++ b/self-development/open-actions/open-actions-workers.yaml
@@ -29,7 +29,7 @@ spec:
     worker:
       workspaceRef:
         name: open-actions-session-agent
-      model: gpt-5.6-sol
+      model: gpt-6-astra
       effort: xhigh
       type: codex
       credentials:

--- a/self-development/tasks/fake-strategist-task.yaml
+++ b/self-development/tasks/fake-strategist-task.yaml
@@ -8,7 +8,7 @@ spec:
   worker:
     workspaceRef:
       name: kelos-agent
-    model: gpt-5.6-sol
+    model: gpt-6-astra
     effort: xhigh
     type: codex
     credentials:


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Updates the high-capability Codex self-development workloads from `gpt-5.6-sol` to `gpt-6-astra` while preserving their existing reasoning efforts. Updates the self-development documentation to match. Lower-cost routine workloads remain on `gpt-5.4-mini`.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Validated with `make verify`.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the model for high-capability self-development agents from `gpt-5.6-sol` to `gpt-6-astra` across all workflow spawners and task files, and syncs the README accordingly. Reasoning efforts are preserved, and lower-cost routine tasks remain on `gpt-5.4-mini`.

<sup>Written for commit b5fb9b6f970398e1672ef8a5b9b50a7a32b96e72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1731?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

