### PR TITLE
Open the Session section picker from row actions

### DIFF
--- a/internal/consoleserver/frontend/app.ts
+++ b/internal/consoleserver/frontend/app.ts
@@ -25,6 +25,7 @@ type ConsoleElement = HTMLElement & {
   elements: NamedFormControls;
   open: boolean;
   showModal(): void;
+  showPicker?(): void;
   close(): void;
   reportValidity(): boolean;
   reset(): void;
@@ -5074,6 +5075,11 @@ function openSessionSectionEditor(session: SessionSummary) {
   if (!state.selected || sessionKey(state.selected) !== sessionKey(session)) selectSession(session);
   elements.sectionForm.classList.add('mobile-open');
   elements.sectionChoice.focus();
+  try {
+    elements.sectionChoice.showPicker?.();
+  } catch (_) {
+    // Keep the focused select usable when the browser refuses to open its picker.
+  }
 }
 
 function renderSelectedSessionSection(session: SessionSummary | null, preserveEditing = true) {

--- a/internal/consoleserver/testdata/session_actions_test.js
+++ b/internal/consoleserver/testdata/session_actions_test.js
@@ -428,6 +428,8 @@ function testSectionActionOpensTouchEditorForTargetSession() {
   state.sessionActionTrigger = new TestNode('button');
   elements.sessionActionsMenu.hidden = false;
   global.selectSession = session => { state.selected = session; };
+  let pickerOpenCount = 0;
+  elements.sectionChoice.showPicker = () => { pickerOpenCount++; };
 
   openSessionSectionEditor(target);
 
@@ -435,6 +437,7 @@ function testSectionActionOpensTouchEditorForTargetSession() {
   assert.equal(elements.sessionActionsMenu.hidden, true);
   assert.equal(elements.sectionForm.classList.contains('mobile-open'), true);
   assert.equal(document.activeElement, elements.sectionChoice);
+  assert.equal(pickerOpenCount, 1);
 
   closeSessionSectionEditor();
   assert.equal(elements.sectionForm.classList.contains('mobile-open'), false);

--- a/internal/consoleserver/web/app.js
+++ b/internal/consoleserver/web/app.js
@@ -4781,6 +4781,12 @@ spec:
             selectSession(session);
         elements.sectionForm.classList.add('mobile-open');
         elements.sectionChoice.focus();
+        try {
+            elements.sectionChoice.showPicker?.();
+        }
+        catch (_) {
+            // Keep the focused select usable when the browser refuses to open its picker.
+        }
     }
     function renderSelectedSessionSection(session, preserveEditing = true) {
         elements.sectionForm.hidden = !session;


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Opens the native section picker when a user selects **Move to section…** from a Session row action menu. The control keeps its existing focus fallback when programmatic picker opening is unavailable.

Adds regression coverage that verifies the row action opens the picker for the targeted Session.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Validated with:

- `make test TEST_FLAGS='-run=TestApplication.*Behavior'`
- `make verify`

#### Does this PR introduce a user-facing change?

```release-note
Fixed the Console Session action so Move to section displays the available section choices immediately.
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Opens the native section picker when a user selects **Move to section…** from a Session row action menu. Previously the control only received focus; now it calls `showPicker()` when available, keeping the focus fallback when programmatic opening is unsupported.

- Adds regression coverage verifying the row action opens the picker for the targeted Session.

<sup>Written for commit 335af2d4692814bcd9627e39bd9df7517eecf07b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1732?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

