### PR TITLE
Increase Session attachment limit to 100 MiB

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -258,9 +258,10 @@ files. In the interactive terminal UI, dragging a file into a terminal that
 supports bracketed paste stages the file directly. Use `/send` in the plain
 terminal to send staged files without message text. The web composer accepts
 files from its attachment button or by drag and drop. Each message supports up
-to eight files of 10 MiB each. A Session retains up to 128 attachments and 100
-MiB of attachment data. Attachments share the Session workspace lifecycle, so
-they survive Pod replacement only when `spec.volumeClaimTemplate` is configured
+to eight files of 100 MiB each. A Session retains up to 128 attachments and 1
+GiB of attachment data. The console allows up to 15 minutes to receive each
+uploaded file. Attachments share the Session workspace lifecycle, so they
+survive Pod replacement only when `spec.volumeClaimTemplate` is configured
 and are removed by Session reset or deletion. Retained messages show attachment
 names, and the web client provides authenticated previews or downloads while
 the Session is ready.

--- a/internal/consoleserver/frontend/app.ts
+++ b/internal/consoleserver/frontend/app.ts
@@ -4720,8 +4720,8 @@ function stageAttachments(fileList: FileList | null) {
   const existing = currentAttachmentFiles();
   const accepted: File[] = [];
   for (const file of incoming) {
-    if (file.size > 10 * 1024 * 1024) {
-      showToast(`${file.name} exceeds the 10 MiB attachment limit`);
+    if (file.size > 100 * 1024 * 1024) {
+      showToast(`${file.name} exceeds the 100 MiB attachment limit`);
       continue;
     }
     if (existing.length + accepted.length >= 8) {

--- a/internal/consoleserver/server.go
+++ b/internal/consoleserver/server.go
@@ -17,6 +17,7 @@ import (
 	"mime"
 	"net/http"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -57,6 +58,7 @@ const (
 	maxSessionSectionLength      = 64
 	requestBodyLimit             = 1024 * 1024
 	attachmentRequestLimit       = sessionruntime.MaxAttachmentBytes + 1024*1024
+	attachmentUploadTimeout      = 15 * time.Minute
 	taskLogTailLineLimit         = 2000
 	taskLogTailByteLimit         = 2 * 1024 * 1024
 	taskLogScannerMaxTokenSize   = 10 * 1024 * 1024
@@ -98,7 +100,7 @@ type Server struct {
 
 type sessionAttachmentTransfer interface {
 	Upload(context.Context, string, string, string, io.Reader) (sessionruntime.Attachment, error)
-	Download(context.Context, string, string, string) (sessionruntime.Attachment, []byte, error)
+	Download(context.Context, string, string, string) (sessionruntime.Attachment, io.ReadCloser, error)
 }
 
 type sessionSocket struct {
@@ -1497,6 +1499,10 @@ func sessionActivityTime(session *kelos.Session) time.Time {
 }
 
 func (s *Server) uploadSessionAttachment(writer http.ResponseWriter, request *http.Request, namespace, name string) {
+	if err := http.NewResponseController(writer).SetReadDeadline(time.Now().Add(attachmentUploadTimeout)); err != nil {
+		writeError(writer, http.StatusInternalServerError, fmt.Sprintf("setting upload deadline for Session %q: %v", name, err))
+		return
+	}
 	session, ok := s.readySession(writer, request, namespace, name)
 	if !ok {
 		return
@@ -1547,15 +1553,20 @@ func (s *Server) downloadSessionAttachment(writer http.ResponseWriter, request *
 		writeError(writer, status, fmt.Sprintf("downloading attachment from Session %q: %v", name, err))
 		return
 	}
+	defer data.Close()
 	disposition := "attachment"
 	if strings.HasPrefix(attachment.MediaType, "image/") {
 		disposition = "inline"
 	}
 	writer.Header().Set("Cache-Control", "private, no-store")
 	writer.Header().Set("Content-Type", attachment.MediaType)
+	writer.Header().Set("Content-Length", strconv.FormatInt(attachment.SizeBytes, 10))
 	writer.Header().Set("Content-Disposition", mime.FormatMediaType(disposition, map[string]string{"filename": attachment.Name}))
 	writer.WriteHeader(http.StatusOK)
-	_, _ = writer.Write(data)
+	written, err := io.Copy(writer, io.LimitReader(data, attachment.SizeBytes+1))
+	if err != nil || written != attachment.SizeBytes {
+		panic(http.ErrAbortHandler)
+	}
 }
 
 func attachmentUploadStatus(err error) int {

--- a/internal/consoleserver/server_test.go
+++ b/internal/consoleserver/server_test.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"testing/iotest"
 	"time"
 	"unicode/utf8"
 
@@ -40,10 +41,30 @@ import (
 )
 
 type fakeSessionAttachmentTransfer struct {
-	uploadedName string
-	uploadedData []byte
-	attachment   sessionruntime.Attachment
-	downloadData []byte
+	uploadedName   string
+	uploadedData   []byte
+	attachment     sessionruntime.Attachment
+	downloadStream io.ReadCloser
+}
+
+type attachmentResponseRecorder struct {
+	*httptest.ResponseRecorder
+	readDeadline time.Time
+}
+
+func (r *attachmentResponseRecorder) SetReadDeadline(deadline time.Time) error {
+	r.readDeadline = deadline
+	return nil
+}
+
+type attachmentReadCloser struct {
+	io.Reader
+	closed bool
+}
+
+func (r *attachmentReadCloser) Close() error {
+	r.closed = true
+	return nil
 }
 
 type patchErrorClient struct {
@@ -61,8 +82,8 @@ func (f *fakeSessionAttachmentTransfer) Upload(_ context.Context, _, _, name str
 	return f.attachment, nil
 }
 
-func (f *fakeSessionAttachmentTransfer) Download(_ context.Context, _, _, _ string) (sessionruntime.Attachment, []byte, error) {
-	return f.attachment, f.downloadData, nil
+func (f *fakeSessionAttachmentTransfer) Download(_ context.Context, _, _, _ string) (sessionruntime.Attachment, io.ReadCloser, error) {
+	return f.attachment, f.downloadStream, nil
 }
 
 func TestAuthenticationProtectsApplicationAndAPI(t *testing.T) {
@@ -2778,9 +2799,10 @@ func TestSessionAttachmentUploadAndDownload(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
+	download := &attachmentReadCloser{Reader: strings.NewReader("content")}
 	transfer := &fakeSessionAttachmentTransfer{
-		attachment:   sessionruntime.Attachment{ID: "attachment-id", Name: "screen.png", MediaType: "image/png", SizeBytes: 7},
-		downloadData: []byte("content"),
+		attachment:     sessionruntime.Attachment{ID: "attachment-id", Name: "screen.png", MediaType: "image/png", SizeBytes: 7},
+		downloadStream: download,
 	}
 	server.attachments = transfer
 
@@ -2798,7 +2820,12 @@ func TestSessionAttachmentUploadAndDownload(t *testing.T) {
 	request.Header.Set("Authorization", "Bearer secret-token")
 	request.Header.Set("Content-Type", multipartWriter.FormDataContentType())
 	response := httptest.NewRecorder()
-	server.ServeHTTP(response, request)
+	uploadResponse := &attachmentResponseRecorder{ResponseRecorder: response}
+	started := time.Now()
+	server.ServeHTTP(uploadResponse, request)
+	if uploadResponse.readDeadline.Before(started.Add(attachmentUploadTimeout)) || uploadResponse.readDeadline.After(time.Now().Add(attachmentUploadTimeout)) {
+		t.Fatalf("upload read deadline = %v, want %v from request start", uploadResponse.readDeadline, attachmentUploadTimeout)
+	}
 	if response.Code != http.StatusCreated || transfer.uploadedName != "screen.png" || string(transfer.uploadedData) != "content" {
 		t.Fatalf("upload status = %d name = %q data = %q body = %s", response.Code, transfer.uploadedName, transfer.uploadedData, response.Body.String())
 	}
@@ -2812,6 +2839,48 @@ func TestSessionAttachmentUploadAndDownload(t *testing.T) {
 	}
 	if !strings.Contains(response.Header().Get("Content-Disposition"), "inline") || !strings.Contains(response.Header().Get("Content-Disposition"), "screen.png") {
 		t.Fatalf("download content disposition = %q", response.Header().Get("Content-Disposition"))
+	}
+	if response.Header().Get("Content-Length") != "7" || !download.closed {
+		t.Fatalf("download content length = %q, stream closed = %v", response.Header().Get("Content-Length"), download.closed)
+	}
+}
+
+func TestSessionAttachmentDownloadAbortsIncompleteTransfers(t *testing.T) {
+	server := testServer(t)
+	if err := server.client.Create(t.Context(), &kelos.Session{
+		ObjectMeta: metav1.ObjectMeta{Name: "chat", Namespace: "team-a"},
+		Status:     kelos.SessionStatus{Phase: kelos.SessionPhaseReady, PodName: "chat-pod"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	for _, tt := range []struct {
+		name string
+		data io.Reader
+	}{
+		{name: "short body", data: strings.NewReader("short")},
+		{name: "long body", data: strings.NewReader("too long")},
+		{name: "stream error", data: io.MultiReader(strings.NewReader("content"), iotest.ErrReader(errors.New("transfer failed")))},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			stream := &attachmentReadCloser{Reader: tt.data}
+			server.attachments = &fakeSessionAttachmentTransfer{
+				attachment:     sessionruntime.Attachment{ID: "attachment-id", Name: "file.txt", MediaType: "text/plain", SizeBytes: 7},
+				downloadStream: stream,
+			}
+			request := httptest.NewRequest(http.MethodGet, "/api/sessions/team-a/chat/attachments/attachment-id", nil)
+			request.Header.Set("Authorization", "Bearer secret-token")
+			func() {
+				defer func() {
+					if got := recover(); got != http.ErrAbortHandler {
+						t.Errorf("download panic = %v, want http.ErrAbortHandler", got)
+					}
+				}()
+				server.ServeHTTP(httptest.NewRecorder(), request)
+			}()
+			if !stream.closed {
+				t.Fatal("download stream was not closed")
+			}
+		})
 	}
 }
 

--- a/internal/consoleserver/web/app.js
+++ b/internal/consoleserver/web/app.js
@@ -4416,8 +4416,8 @@ spec:
         const existing = currentAttachmentFiles();
         const accepted = [];
         for (const file of incoming) {
-            if (file.size > 10 * 1024 * 1024) {
-                showToast(`${file.name} exceeds the 10 MiB attachment limit`);
+            if (file.size > 100 * 1024 * 1024) {
+                showToast(`${file.name} exceeds the 100 MiB attachment limit`);
                 continue;
             }
             if (existing.length + accepted.length >= 8) {

--- a/internal/sessionattachment/client.go
+++ b/internal/sessionattachment/client.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -24,8 +25,9 @@ const runtimeExecutable = "/kelos/bin/kelos-session-runtime"
 
 // Client transfers attachments through the Session Pod exec subresource.
 type Client struct {
-	clientset  kubernetes.Interface
-	restConfig *rest.Config
+	clientset   kubernetes.Interface
+	restConfig  *rest.Config
+	newExecutor func(*rest.Config, string, *url.URL) (remotecommand.Executor, error)
 }
 
 // New creates a Session attachment client.
@@ -37,7 +39,7 @@ func New(restConfig *rest.Config) (*Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("creating Kubernetes client: %w", err)
 	}
-	return &Client{clientset: clientset, restConfig: restConfig}, nil
+	return &Client{clientset: clientset, restConfig: restConfig, newExecutor: remotecommand.NewSPDYExecutor}, nil
 }
 
 // Upload stores one attachment in a Session Pod.
@@ -57,29 +59,41 @@ func (c *Client) Upload(ctx context.Context, namespace, podName, name string, so
 	return attachment, nil
 }
 
-// Download loads one attachment and its metadata from a Session Pod.
-func (c *Client) Download(ctx context.Context, namespace, podName, id string) (sessionruntime.Attachment, []byte, error) {
-	var stdout bytes.Buffer
-	if err := c.stream(ctx, namespace, podName, []string{runtimeExecutable, "attachment", "get", id}, nil, &stdout); err != nil {
-		return sessionruntime.Attachment{}, nil, err
-	}
-	reader := bufio.NewReader(&stdout)
-	metadata, err := reader.ReadBytes('\n')
+// Download opens an attachment stream from a Session Pod. The caller must close it.
+func (c *Client) Download(ctx context.Context, namespace, podName, id string) (sessionruntime.Attachment, io.ReadCloser, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	stdout, writer := io.Pipe()
+	go func() {
+		err := c.stream(ctx, namespace, podName, []string{runtimeExecutable, "attachment", "get", id}, nil, writer)
+		_ = writer.CloseWithError(err)
+	}()
+	data := &attachmentStream{Reader: bufio.NewReader(stdout), pipe: stdout, cancel: cancel}
+	metadata, err := data.ReadSlice('\n')
 	if err != nil {
+		_ = data.Close()
 		return sessionruntime.Attachment{}, nil, fmt.Errorf("reading Session attachment metadata: %w", err)
 	}
 	var attachment sessionruntime.Attachment
 	if err := json.Unmarshal(metadata, &attachment); err != nil {
+		_ = data.Close()
 		return sessionruntime.Attachment{}, nil, fmt.Errorf("decoding Session attachment metadata: %w", err)
 	}
-	data, err := io.ReadAll(io.LimitReader(reader, sessionruntime.MaxAttachmentBytes+1))
-	if err != nil {
-		return sessionruntime.Attachment{}, nil, fmt.Errorf("reading Session attachment data: %w", err)
-	}
-	if attachment.ID != id || int64(len(data)) != attachment.SizeBytes || int64(len(data)) > sessionruntime.MaxAttachmentBytes {
-		return sessionruntime.Attachment{}, nil, errors.New("Session attachment data is invalid")
+	if attachment.ID != id || attachment.SizeBytes < 0 || attachment.SizeBytes > sessionruntime.MaxAttachmentBytes {
+		_ = data.Close()
+		return sessionruntime.Attachment{}, nil, errors.New("Session attachment metadata is invalid")
 	}
 	return attachment, data, nil
+}
+
+type attachmentStream struct {
+	*bufio.Reader
+	pipe   *io.PipeReader
+	cancel context.CancelFunc
+}
+
+func (s *attachmentStream) Close() error {
+	s.cancel()
+	return s.pipe.Close()
 }
 
 func (c *Client) stream(ctx context.Context, namespace, podName string, command []string, stdin io.Reader, stdout io.Writer) error {
@@ -96,7 +110,7 @@ func (c *Client) stream(ctx context.Context, namespace, podName string, command 
 		Stderr:    true,
 		TTY:       false,
 	}, clientgoscheme.ParameterCodec)
-	executor, err := remotecommand.NewSPDYExecutor(c.restConfig, "POST", request.URL())
+	executor, err := c.newExecutor(c.restConfig, "POST", request.URL())
 	if err != nil {
 		return fmt.Errorf("creating Session attachment exec connection: %w", err)
 	}

--- a/internal/sessionattachment/client_test.go
+++ b/internal/sessionattachment/client_test.go
@@ -1,0 +1,194 @@
+package sessionattachment
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
+
+	"github.com/kelos-dev/kelos/internal/sessionruntime"
+)
+
+type attachmentExecutor struct {
+	stream func(context.Context, remotecommand.StreamOptions) error
+}
+
+func (e attachmentExecutor) Stream(options remotecommand.StreamOptions) error {
+	return e.stream(context.Background(), options)
+}
+
+func (e attachmentExecutor) StreamWithContext(ctx context.Context, options remotecommand.StreamOptions) error {
+	return e.stream(ctx, options)
+}
+
+func testAttachmentClient(t *testing.T, stream func(context.Context, remotecommand.StreamOptions) error) *Client {
+	t.Helper()
+	client, err := New(&rest.Config{Host: "http://kubernetes.example"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.newExecutor = func(_ *rest.Config, method string, endpoint *url.URL) (remotecommand.Executor, error) {
+		if method != http.MethodPost || endpoint.Path != "/api/v1/namespaces/team-a/pods/chat-pod/exec" {
+			t.Errorf("exec request = %s %s", method, endpoint)
+		}
+		if command := endpoint.Query()["command"]; !slices.Equal(command, []string{runtimeExecutable, "attachment", "get", "attachment-id"}) {
+			t.Errorf("exec command = %q", command)
+		}
+		if container := endpoint.Query().Get("container"); container != "kelos-agent" {
+			t.Errorf("exec container = %q, want kelos-agent", container)
+		}
+		return attachmentExecutor{stream: stream}, nil
+	}
+	return client
+}
+
+func TestDownloadStreamsBeforeExecCompletes(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	contents := bytes.Repeat([]byte("file contents\x00\n"), 4096)
+	want := sessionruntime.Attachment{ID: "attachment-id", Name: "file.bin", MediaType: "application/octet-stream", SizeBytes: int64(len(contents))}
+	metadata, err := json.Marshal(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	release := make(chan struct{})
+	client := testAttachmentClient(t, func(ctx context.Context, options remotecommand.StreamOptions) error {
+		if options.Stdin != nil {
+			t.Error("download exec has stdin")
+		}
+		prefix := append(append(metadata, '\n'), contents[:1024]...)
+		if _, err := options.Stdout.Write(prefix); err != nil {
+			return err
+		}
+		select {
+		case <-release:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+		_, err := options.Stdout.Write(contents[1024:])
+		return err
+	})
+	attachment, body, err := client.Download(ctx, "team-a", "chat-pod", "attachment-id")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer body.Close()
+	if attachment != want {
+		t.Fatalf("attachment = %#v, want %#v", attachment, want)
+	}
+	close(release)
+	got, err := io.ReadAll(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, contents) {
+		t.Fatalf("downloaded %d bytes with unexpected contents", len(got))
+	}
+}
+
+func TestDownloadCloseCancelsExec(t *testing.T) {
+	for _, blockedWrite := range []bool{false, true} {
+		t.Run(fmt.Sprintf("blocked_write=%t", blockedWrite), func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+			defer cancel()
+			done := make(chan error, 1)
+			client := testAttachmentClient(t, func(ctx context.Context, options remotecommand.StreamOptions) error {
+				defer func() { done <- ctx.Err() }()
+				if _, err := io.WriteString(options.Stdout, "{\"id\":\"attachment-id\",\"sizeBytes\":1048576}\n"); err != nil {
+					return err
+				}
+				if blockedWrite {
+					_, err := options.Stdout.Write(make([]byte, 1024*1024))
+					return err
+				}
+				<-ctx.Done()
+				return ctx.Err()
+			})
+			_, body, err := client.Download(ctx, "team-a", "chat-pod", "attachment-id")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := body.Close(); err != nil {
+				t.Fatal(err)
+			}
+			select {
+			case err := <-done:
+				if !errors.Is(err, context.Canceled) {
+					t.Fatalf("exec context error = %v, want context.Canceled", err)
+				}
+			case <-ctx.Done():
+				t.Fatal("closing the download did not stop exec")
+			}
+		})
+	}
+}
+
+func TestDownloadRejectsInvalidMetadata(t *testing.T) {
+	for _, metadata := range []string{
+		"not JSON\n",
+		`{"id":"attachment-id"}`,
+		"{\"id\":\"another-id\",\"sizeBytes\":0}\n",
+		"{\"id\":\"attachment-id\",\"sizeBytes\":-1}\n",
+		fmt.Sprintf("{\"id\":\"attachment-id\",\"sizeBytes\":%d}\n", sessionruntime.MaxAttachmentBytes+1),
+		strings.Repeat(" ", 8192),
+	} {
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+		client := testAttachmentClient(t, func(_ context.Context, options remotecommand.StreamOptions) error {
+			_, err := io.WriteString(options.Stdout, metadata)
+			return err
+		})
+		_, body, err := client.Download(ctx, "team-a", "chat-pod", "attachment-id")
+		cancel()
+		if body != nil {
+			_ = body.Close()
+			t.Fatal("Download() returned a body for invalid metadata")
+		}
+		if err == nil {
+			t.Fatal("Download() accepted invalid metadata")
+		}
+	}
+}
+
+func TestDownloadPropagatesExecErrors(t *testing.T) {
+	for _, afterMetadata := range []bool{false, true} {
+		t.Run(fmt.Sprintf("after_metadata=%t", afterMetadata), func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+			defer cancel()
+			wantErr := errors.New("transfer failed")
+			client := testAttachmentClient(t, func(_ context.Context, options remotecommand.StreamOptions) error {
+				if afterMetadata {
+					if _, err := io.WriteString(options.Stdout, "{\"id\":\"attachment-id\",\"sizeBytes\":4}\npart"); err != nil {
+						return err
+					}
+				}
+				return wantErr
+			})
+			_, body, err := client.Download(ctx, "team-a", "chat-pod", "attachment-id")
+			if afterMetadata {
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer body.Close()
+				var data []byte
+				data, err = io.ReadAll(body)
+				if string(data) != "part" {
+					t.Fatalf("partial body = %q, want part", data)
+				}
+			}
+			if !errors.Is(err, wantErr) {
+				t.Fatalf("download error = %v, want %v", err, wantErr)
+			}
+		})
+	}
+}

--- a/internal/sessionruntime/attachment.go
+++ b/internal/sessionruntime/attachment.go
@@ -18,9 +18,9 @@ import (
 )
 
 const (
-	MaxAttachmentBytes         int64 = 10 * 1024 * 1024
+	MaxAttachmentBytes         int64 = 100 * 1024 * 1024
 	MaxAttachmentsPerMessage         = 8
-	maxSessionAttachmentBytes  int64 = 100 * 1024 * 1024
+	maxSessionAttachmentBytes  int64 = 1024 * 1024 * 1024
 	maxSessionAttachmentCount        = 128
 	attachmentDirectoryName          = "attachments"
 	attachmentDataFileName           = "data"

--- a/internal/sessionruntime/attachment_test.go
+++ b/internal/sessionruntime/attachment_test.go
@@ -47,6 +47,37 @@ func TestAttachmentStorePutOpenAndResolve(t *testing.T) {
 	}
 }
 
+func TestAttachmentStoreAcceptsMaximumSizeFiles(t *testing.T) {
+	store, err := NewAttachmentStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for index := 0; index < 2; index++ {
+		attachment, err := store.Put(fmt.Sprintf("file-%d.bin", index), io.LimitReader(zeroReader{}, MaxAttachmentBytes))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if attachment.SizeBytes != MaxAttachmentBytes {
+			t.Fatalf("attachment size = %d, want %d", attachment.SizeBytes, MaxAttachmentBytes)
+		}
+		opened, data, err := store.Open(attachment.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		readBytes, readErr := io.Copy(io.Discard, data)
+		closeErr := data.Close()
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		if closeErr != nil {
+			t.Fatal(closeErr)
+		}
+		if opened != attachment || readBytes != MaxAttachmentBytes {
+			t.Fatalf("opened attachment = %#v, read %d bytes, want %#v and %d bytes", opened, readBytes, attachment, MaxAttachmentBytes)
+		}
+	}
+}
+
 func TestAttachmentStoreRejectsOversizedInputAndCleansTemporaryData(t *testing.T) {
 	stateDir := t.TempDir()
 	store, err := NewAttachmentStore(stateDir)

--- a/test/e2e/session_test.go
+++ b/test/e2e/session_test.go
@@ -217,6 +217,15 @@ var _ = Describe("Session remote control", func() {
 		})
 		waitForTurnCompletion(connection, "completed")
 
+		By("uploading and downloading a large attachment")
+		largeData := bytes.Repeat([]byte("attachment data\n"), 1024*1024)
+		largeAttachment := uploadSessionAttachment(webClient, baseURL, f.Namespace, sessionName, "large-attachment.txt", largeData)
+		Expect(largeAttachment.SizeBytes).To(Equal(int64(len(largeData))))
+		largeStatus, largeHeaders, largeDownloaded := downloadSessionAttachment(webClient, baseURL, f.Namespace, sessionName, largeAttachment.ID)
+		Expect(largeStatus).To(Equal(http.StatusOK))
+		Expect(largeHeaders.Get("Content-Length")).To(Equal(fmt.Sprint(len(largeData))))
+		Expect(bytes.Equal(largeDownloaded, largeData)).To(BeTrue(), "Downloaded attachment contents differ")
+
 		By("uploading an attachment before Session Pod recovery")
 		attachmentData := []byte("web attachment persisted across recovery\n")
 		attachment := uploadSessionAttachment(webClient, baseURL, f.Namespace, sessionName, "web-attachment.txt", attachmentData)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Session attachments larger than 10 MiB are rejected. Raise the per-file limit to 100 MiB and total attachment storage per Session from 100 MiB to 1 GiB, with matching browser validation and documentation. The CLI and server use the shared runtime limit.

Give authenticated web attachment uploads a 15-minute read deadline. Stream downloads from the Session Pod to the HTTP response with bounded buffers, closing and canceling the exec stream when the consumer closes. Validate metadata before sending the response, set Content-Length, and abort failed or incorrectly sized transfers.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Validation passed:

- `make update`
- `env -u CODEX_HOME -u CODEX_AUTH_JSON make test`
- `make verify`

The test command removes inherited Codex environment settings that otherwise cause two unrelated entrypoint tests to fail. Unit coverage includes maximum-size storage, upload deadlines, streaming before exec completion, cancellation, invalid metadata, and failed or incorrectly sized transfers. The e2e Session test adds a 16 MiB upload/download round-trip; it runs in PR CI.

#### Does this PR introduce a user-facing change?

```release-note
Session attachments support files up to 100 MiB each and up to 1 GiB of total attachment storage per Session. Web uploads allow up to 15 minutes to receive each file, and downloads stream without buffering the whole attachment in console memory.
```
