### PR TITLE
Add a native Session terminal tab with shell completion

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -483,13 +483,20 @@ connect to Sessions across namespaces while operating on one active namespace
 at a time. Users can switch the active namespace live from the sidebar.
 `consoleServer.defaultNamespace` sets its initial value, and resource inventory,
 Session form options, and credential options are loaded only from the active namespace.
-Select a Ready Session and click **Terminal** to open an interactive `/bin/sh`
-shell in its agent container. The shell uses the agent container's workspace
-and permissions. It supports terminal resizing and keyboard input,
-including Ctrl+C. Closing the terminal disconnects the shell stream; the Session
-conversation continues independently. Suspended, resetting, and unready Sessions
-cannot open a terminal. After a disconnect or shell exit, close and reopen the
-terminal to start another shell.
+Sessions open in the **Conversation** view. Select the **Terminal** tab alongside
+**Conversation** and **Changes** on a Ready Session to start an interactive shell
+in its agent container. The shell uses the agent container's workspace and
+permissions. On mobile, use the view picker beside the Session title to choose
+**Conversation**, **Changes**, or **Terminal**. The shell uses `/bin/bash` when
+available, providing command and filename completion with Tab, and falls back
+to `/bin/sh` for images without Bash.
+The terminal supports resizing and keyboard input, including Ctrl+C. Switching
+between the Session's views preserves the shell and its output. Selecting another
+Session or namespace, leaving the page, or the Session becoming unavailable
+disconnects the shell stream; the Session conversation continues independently.
+Suspended, resetting, and unready Sessions cannot open a terminal. After a
+disconnect or shell exit, click **Reconnect** in the Terminal tab to start
+another shell.
 The Resources page shows the incoming and outgoing relationships for one
 selected object, with a searchable inventory for inspecting the full namespace.
 Selecting a Task from either resource view shows its agent container logs and

--- a/internal/consoleserver/frontend/app.ts
+++ b/internal/consoleserver/frontend/app.ts
@@ -330,7 +330,6 @@ const elements = requireElements({
   title: document.querySelector('#session-title'),
   meta: document.querySelector('#session-meta'),
   displayNameButton: document.querySelector('#session-display-name'),
-  terminalButton: document.querySelector('#open-terminal'),
   displayNameDialog: document.querySelector('#display-name-dialog'),
   displayNameForm: document.querySelector('#display-name-form'),
   displayNameDialogDescription: document.querySelector('#display-name-dialog-description'),
@@ -397,6 +396,11 @@ const elements = requireElements({
   viewTabs: document.querySelector('.view-tabs'),
   conversationTab: document.querySelector('#conversation-tab'),
   changesTab: document.querySelector('#changes-tab'),
+  terminalTab: document.querySelector('#terminal-tab'),
+  terminalView: document.querySelector('#terminal-view'),
+  viewPicker: document.querySelector('#session-view-picker'),
+  viewChoice: document.querySelector('#session-view-choice'),
+  terminalChoice: document.querySelector('#terminal-view-choice'),
   welcome: document.querySelector('#welcome'),
   composerWrap: document.querySelector('.composer-wrap'),
   composer: document.querySelector('#composer'),
@@ -2729,8 +2733,11 @@ function createWelcome() {
 
 function renderHeader() {
   const session = state.selected;
-  elements.terminalButton.disabled = !sessionTerminal.available(session);
+  elements.terminalTab.disabled = !sessionTerminal.available(session);
+  elements.viewChoice.disabled = !session;
+  elements.terminalChoice.disabled = elements.terminalTab.disabled;
   sessionTerminal.sync(session);
+  if (elements.terminalTab.disabled && !elements.terminalView.hidden) setActiveView('conversation');
   elements.displayNameButton.hidden = !session;
   elements.displayNameButton.disabled = !session;
   renderSelectedSessionSection(session);
@@ -2873,7 +2880,7 @@ function connectSocket() {
     setComposer(true);
     updateComposerAction();
     renderHistoryControl();
-    elements.input.focus();
+    if (!elements.messages.hidden) elements.input.focus();
   });
   socket.addEventListener('message', event => {
     if (generation !== state.socketGeneration) return;
@@ -4578,20 +4585,27 @@ function renderDiffLines(diff) {
 }
 
 function setActiveView(view) {
+  elements.viewChoice.value = view;
+  elements.viewPicker.dataset.view = view;
+  const conversationActive = view === 'conversation';
   const changesActive = view === 'changes';
-  elements.messages.hidden = changesActive;
-  elements.composerWrap.hidden = changesActive;
+  const terminalActive = view === 'terminal';
+  elements.messages.hidden = !conversationActive;
+  elements.composerWrap.hidden = !conversationActive;
   elements.changes.hidden = !changesActive;
-  elements.conversationTab.setAttribute('aria-selected', String(!changesActive));
-  elements.changesTab.setAttribute('aria-selected', String(changesActive));
-  elements.conversationTab.tabIndex = changesActive ? -1 : 0;
-  elements.changesTab.tabIndex = changesActive ? 0 : -1;
-  if (changesActive) hideCurrentRequest();
-  else updateCurrentRequest();
+  elements.terminalView.hidden = !terminalActive;
+  for (const [tab, active] of [[elements.conversationTab, conversationActive],
+    [elements.changesTab, changesActive], [elements.terminalTab, terminalActive]] as const) {
+    tab.setAttribute('aria-selected', String(active));
+    tab.tabIndex = active ? 0 : -1;
+  }
+  if (conversationActive) updateCurrentRequest();
+  else hideCurrentRequest();
+  if (terminalActive) sessionTerminal.show(state.selected);
 }
 
 function handleViewTabKeydown(event) {
-  const tabs = [elements.conversationTab, elements.changesTab].filter(tab => !tab.disabled);
+  const tabs = [elements.conversationTab, elements.changesTab, elements.terminalTab].filter(tab => !tab.disabled);
   const current = tabs.indexOf(event.target);
   if (current < 0) return;
 
@@ -5206,7 +5220,6 @@ async function resetSession(session: SessionSummary | null) {
 elements.resumeButton.addEventListener('click', resumeSelectedSession);
 elements.suspendButton.addEventListener('click', suspendSelectedSession);
 elements.deleteButton.addEventListener('click', () => deleteSession(state.selected));
-elements.terminalButton.addEventListener('click', () => sessionTerminal.open(state.selected));
 elements.resetButton.addEventListener('click', () => resetSession(state.selected));
 elements.sessionActionRename.addEventListener('click', () => {
   const session = sessionActionsTarget();
@@ -5242,9 +5255,16 @@ elements.sessionActionsMenu.addEventListener('keydown', event => {
 elements.sessionActionsMenu.addEventListener('focusout', handleSessionActionsFocusOut);
 elements.conversationTab.addEventListener('click', () => setActiveView('conversation'));
 elements.changesTab.addEventListener('click', () => setActiveView('changes'));
+elements.terminalTab.addEventListener('click', () => setActiveView('terminal'));
+elements.viewChoice.addEventListener('change', () => setActiveView(elements.viewChoice.value));
 elements.viewTabs.addEventListener('keydown', handleViewTabKeydown);
 elements.currentRequestButton.addEventListener('click', jumpToCurrentRequest);
 elements.messages.addEventListener('scroll', scheduleCurrentRequestUpdate);
+
+window.addEventListener('pagehide', () => {
+  sessionTerminal.close();
+  if (!elements.terminalView.hidden) setActiveView('conversation');
+});
 
 function interruptActiveTurn() {
   if (!state.socket || state.socket.readyState !== WebSocket.OPEN || !state.activeTurn || state.interrupting) return;

--- a/internal/consoleserver/frontend/terminal.ts
+++ b/internal/consoleserver/frontend/terminal.ts
@@ -3,11 +3,10 @@ declare const FitAddon: typeof import('@xterm/addon-fit');
 
 const sessionTerminal = (() => {
   type Session = {namespace: string; name: string; uid?: string; phase?: string; resetting?: boolean; userSuspended?: boolean};
-  const dialog = document.querySelector<HTMLDialogElement>('#terminal-dialog')!;
   const container = document.querySelector<HTMLElement>('#terminal-container')!;
-  const title = document.querySelector<HTMLElement>('#terminal-title')!;
   const status = document.querySelector<HTMLElement>('#terminal-status')!;
-  let active: {session: Session; dispose: () => void} | null = null;
+  const reconnect = document.querySelector<HTMLButtonElement>('#reconnect-terminal')!;
+  let active: {session: Session; focus: () => void; dispose: () => void} | null = null;
 
   function available(session: Session | null) {
     return Boolean(session && session.phase === 'Ready' && !session.resetting && !session.userSuspended);
@@ -16,8 +15,8 @@ const sessionTerminal = (() => {
   function close() {
     active?.dispose();
     active = null;
-    if (dialog.open) dialog.close();
     container.replaceChildren();
+    reconnect.disabled = true;
   }
 
   function sync(session: Session | null) {
@@ -25,12 +24,15 @@ const sessionTerminal = (() => {
       session?.name !== active.session.name || session?.uid !== active.session.uid)) close();
   }
 
-  function open(session: Session | null) {
+  function show(session: Session | null) {
+    sync(session);
     if (!session || !available(session)) return;
-    close();
-    title.textContent = `Terminal · ${session.namespace}/${session.name}`;
+    if (active) {
+      active.focus();
+      return;
+    }
     status.textContent = 'Connecting…';
-    dialog.showModal();
+    reconnect.disabled = true;
     const nonce = document.querySelector<HTMLMetaElement>('meta[name="terminal-style-nonce"]')!.content;
     const terminal = new Terminal({
       cursorBlink: true,
@@ -54,12 +56,17 @@ const sessionTerminal = (() => {
     } finally {
       document.createElement = createElement;
     }
-    fit.fit();
     const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
     const socket = new WebSocket(`${protocol}//${location.host}/api/sessions/${encodeURIComponent(session.namespace)}/${encodeURIComponent(session.name)}/exec`);
     socket.binaryType = 'arraybuffer';
     let disposed = false;
     let finished = false;
+    const visible = () => !disposed && container.clientWidth > 0 && container.clientHeight > 0;
+    const focus = () => {
+      if (!visible()) return;
+      fit.fit();
+      terminal.focus();
+    };
     const send = (data: string | Uint8Array<ArrayBuffer>) => {
       if (disposed || finished || socket.readyState !== WebSocket.OPEN) return;
       if (typeof data === 'string') socket.send(data);
@@ -73,19 +80,20 @@ const sessionTerminal = (() => {
     const binary = terminal.onBinary(data => send(Uint8Array.from(data, character => character.charCodeAt(0))));
     const resize = terminal.onResize(sendResize);
     const observer = new ResizeObserver(() => {
-      if (!disposed) fit.fit();
+      if (visible()) fit.fit();
     });
     observer.observe(container);
     const finish = (message: string) => {
       finished = true;
       status.textContent = message;
       terminal.options.disableStdin = true;
+      reconnect.disabled = false;
     };
     socket.addEventListener('open', () => {
       if (disposed) return;
       status.textContent = 'Connected';
       sendResize();
-      terminal.focus();
+      focus();
     });
     socket.addEventListener('message', event => {
       if (disposed) return;
@@ -98,12 +106,12 @@ const sessionTerminal = (() => {
       }
     });
     socket.addEventListener('error', () => {
-      if (!disposed && !finished) finish('Could not connect to the session terminal. Close and reopen to try again.');
+      if (!disposed && !finished) finish('Could not connect to the session terminal. Reconnect to try again.');
     });
     socket.addEventListener('close', () => {
-      if (!disposed && !finished) finish('Disconnected. Close and reopen to start a shell.');
+      if (!disposed && !finished) finish('Disconnected. Reconnect to start a shell.');
     });
-    active = {session, dispose: () => {
+    active = {session, focus, dispose: () => {
       disposed = true;
       observer.disconnect();
       input.dispose();
@@ -112,14 +120,14 @@ const sessionTerminal = (() => {
       socket.close();
       terminal.dispose();
     }};
+    focus();
   }
 
-  document.querySelector('#close-terminal')!.addEventListener('click', close);
-  dialog.addEventListener('close', () => {
-    if (!dialog.open) close();
+  reconnect.addEventListener('click', () => {
+    if (!active || reconnect.disabled) return;
+    const session = active.session;
+    close();
+    show(session);
   });
-  // Escape is input for terminal applications; the Close button ends the connection.
-  dialog.addEventListener('cancel', event => event.preventDefault());
-  window.addEventListener('pagehide', close);
-  return {available, open, sync, close};
+  return {available, show, sync, close};
 })();

--- a/internal/consoleserver/server_test.go
+++ b/internal/consoleserver/server_test.go
@@ -1532,6 +1532,7 @@ func TestSessionUIAdaptsToPhoneViewport(t *testing.T) {
 		"Android keyboard resizing":     `interactive-widget=resizes-content`,
 		"dismissible sidebar backdrop":  `id="sidebar-scrim"`,
 		"compact session list header":   `class="session-sidebar-header"`,
+		"mobile session view picker":    `id="session-view-choice" aria-label="Session view" disabled`,
 	} {
 		if !strings.Contains(string(index), expected) {
 			t.Errorf("Session page is missing %s: %s", description, expected)
@@ -1569,10 +1570,10 @@ func TestSessionUIAdaptsToPhoneViewport(t *testing.T) {
 		"phone create touch target":          `.new-session-button { min-height: 44px; margin-top: 4px; padding: 8px 10px; }`,
 		"fixed new Session action":           `.new-session-button { flex: none;`,
 		"section reorder touch target":       `.session-section-order-button { width: 44px; height: 44px; }`,
-		"single-row phone header":            `grid-template-areas: "menu heading actions"`,
+		"single-row phone header":            `grid-template-areas: "menu heading actions";`,
 		"phone lifecycle actions in sidebar": `.session-lifecycle-action, #reset-session, #delete-session { display: none !important; }`,
 		"44-pixel touch targets":             `.icon-button { width: 44px; height: 44px; }`,
-		"44-pixel view tabs":                 `.view-tabs button { min-height: 44px; padding: 5px 8px; }`,
+		"44-pixel view picker":               `.session-view-picker { position: relative; width: 44px; height: 44px;`,
 		"Session action touch target":        `.session-item-actions { top: 5px; right: 1px; width: 44px; height: 44px; }`,
 		"phone safe-area padding":            `env(safe-area-inset-bottom)`,
 		"non-zooming form fields":            `.composer textarea, .pending-message-input, .yaml-panel textarea, .form-grid input`,

--- a/internal/consoleserver/terminal.go
+++ b/internal/consoleserver/terminal.go
@@ -32,7 +32,7 @@ func (s *Server) execSession(writer http.ResponseWriter, request *http.Request, 
 		Resource("pods").Namespace(namespace).Name(session.Status.PodName).SubResource("exec")
 	execRequest.VersionedParams(&corev1.PodExecOptions{
 		Container: kelos.AgentContainerName,
-		Command:   []string{"/bin/sh", "-c", "export TERM=xterm-256color; exec /bin/sh -i"},
+		Command:   []string{"/bin/sh", "-c", "export TERM=xterm-256color; if [ -x /bin/bash ]; then exec /bin/bash -i; fi; exec /bin/sh -i"},
 		Stdin:     true,
 		Stdout:    true,
 		TTY:       true,

--- a/internal/consoleserver/terminal_test.go
+++ b/internal/consoleserver/terminal_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"os/exec"
 	"reflect"
 	"regexp"
@@ -78,7 +79,7 @@ func dialTerminal(t *testing.T, server *Server) *websocket.Conn {
 
 func TestSessionTerminalStreamsInputOutputAndResize(t *testing.T) {
 	s := terminalTestServer(t, terminalTestSession())
-	input := "echo héllo\r\x03"
+	input := "echo héllo\t\r\x03"
 	output := []byte("\x1b[32mhéllo\x1b[0m\r\n")
 	s.terminalExecutor = func(config *rest.Config, method string, target *url.URL) (remotecommand.Executor, error) {
 		if config != s.restConfig || method != http.MethodPost || target.Path != "/api/v1/namespaces/team-a/pods/chat-pod/exec" {
@@ -89,7 +90,7 @@ func TestSessionTerminalStreamsInputOutputAndResize(t *testing.T) {
 			query.Get("stdout") != "true" || query.Get("tty") != "true" || query.Get("stderr") == "true" {
 			t.Errorf("exec options = %v", query)
 		}
-		if !reflect.DeepEqual(query["command"], []string{"/bin/sh", "-c", "export TERM=xterm-256color; exec /bin/sh -i"}) {
+		if !reflect.DeepEqual(query["command"], []string{"/bin/sh", "-c", "export TERM=xterm-256color; if [ -x /bin/bash ]; then exec /bin/bash -i; fi; exec /bin/sh -i"}) {
 			t.Errorf("command = %v", query["command"])
 		}
 		return terminalTestExecutor{stream: func(ctx context.Context, options remotecommand.StreamOptions) error {
@@ -407,6 +408,38 @@ func TestApplicationTerminalBehavior(t *testing.T) {
 	}
 	if output, err := exec.Command(node, "testdata/terminal_test.js").CombinedOutput(); err != nil {
 		t.Fatalf("terminal behavior: %v\n%s", err, output)
+	}
+}
+
+func TestSessionTerminalShellCompletion(t *testing.T) {
+	python, err := exec.LookPath("python3")
+	if err != nil {
+		t.Skip("python3 is not installed")
+	}
+	if _, err := os.Stat("/bin/bash"); err != nil {
+		t.Skip("/bin/bash is not installed")
+	}
+	s := terminalTestServer(t, terminalTestSession())
+	var command []string
+	s.terminalExecutor = func(_ *rest.Config, _ string, target *url.URL) (remotecommand.Executor, error) {
+		command = target.Query()["command"]
+		return nil, errors.New("capture shell command")
+	}
+	request := httptest.NewRequest(http.MethodGet, "/api/sessions/team-a/chat/exec", nil)
+	request.Header.Set("Authorization", "Bearer secret-token")
+	s.ServeHTTP(httptest.NewRecorder(), request)
+	if len(command) == 0 {
+		t.Fatal("Session terminal did not request a shell")
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	defer cancel()
+	args := append([]string{"testdata/terminal_shell_test.py"}, command...)
+	if output, err := exec.CommandContext(ctx, python, args...).CombinedOutput(); err != nil {
+		t.Fatalf("shell completion: %v\n%s", err, output)
+	}
+	output, err := exec.CommandContext(ctx, python, "testdata/terminal_shell_test.py", "/bin/sh", "-c", "printf 'startup failed\\n'; exit 1").CombinedOutput()
+	if err == nil || !strings.Contains(string(output), "Shell exited before its prompt: b'startup failed\\r\\n'") {
+		t.Fatalf("shell exit diagnostics: %v\n%s", err, output)
 	}
 }
 

--- a/internal/consoleserver/testdata/session_history_test.js
+++ b/internal/consoleserver/testdata/session_history_test.js
@@ -195,7 +195,10 @@ function resetHarness() {
     runtimeStatus: new TestNode('div'),
     sidebar: new TestNode('aside'),
     displayNameButton: new TestNode('button'),
-    terminalButton: new TestNode('button'),
+    terminalTab: new TestNode('button'),
+    terminalView: new TestNode('section'),
+    viewChoice: new TestNode('select'),
+    terminalChoice: new TestNode('option'),
     suspendButton: new TestNode('button'),
     resumeButton: new TestNode('button'),
     resetButton: new TestNode('button'),
@@ -208,6 +211,7 @@ function resetHarness() {
     welcome: null,
   };
   elements.currentRequest.hidden = true;
+  elements.terminalView.hidden = true;
   elements.connection.append(new TestNode('span'), new TestNode('span'));
   global.state = {
     sessions: [],
@@ -474,6 +478,42 @@ function testFailedSessionComposerRejectsDraft() {
   assert.equal(elements.input.disabled, true);
   assert.equal(elements.attachFiles.disabled, true);
   assert.equal(elements.send.disabled, true);
+}
+
+function testSessionViewPickerAvailability() {
+  for (const phase of ['Ready', 'Pending', 'Suspended', 'Failed']) {
+    resetHarness();
+    state.selected = {namespace: 'default', name: 'one', uid: 'uid-one', provider: 'codex', phase};
+    renderSessionHeader();
+    assert.equal(elements.viewChoice.disabled, false);
+    assert.equal(elements.terminalChoice.disabled, phase !== 'Ready');
+  }
+  state.selected = null;
+  renderSessionHeader();
+  assert.equal(elements.viewChoice.disabled, true);
+  assert.equal(elements.terminalChoice.disabled, true);
+}
+
+function testUnavailableSessionLeavesTerminalView() {
+  const setView = global.setActiveView;
+  try {
+    for (const change of [{phase: 'Pending'}, {phase: 'Suspended'}, {phase: 'Failed'}, {resetting: true}, {userSuspended: true}]) {
+      resetHarness();
+      state.selected = {namespace: 'default', name: 'one', uid: 'uid-one', provider: 'codex', phase: 'Ready'};
+      elements.terminalView.hidden = false;
+      const views = [];
+      global.setActiveView = view => views.push(view);
+      renderSessionHeader();
+      assert.deepEqual(views, []);
+      Object.assign(state.selected, change);
+      renderSessionHeader();
+      assert.deepEqual(views, ['conversation']);
+      assert.equal(elements.terminalTab.disabled, true);
+      assert.equal(elements.terminalChoice.disabled, true);
+    }
+  } finally {
+    global.setActiveView = setView;
+  }
 }
 
 async function testReadySessionDisconnectsWhenItBecomesPending() {
@@ -1056,6 +1096,8 @@ testComposerInterruptsWhileInputIsDisabled();
 testComposerLabelsPendingSubmission();
 testPendingSessionComposerAllowsDraft();
 testFailedSessionComposerRejectsDraft();
+testSessionViewPickerAvailability();
+testUnavailableSessionLeavesTerminalView();
 testSessionProgressSurvivesCachedViewSwitch();
 testSessionProgressElapsedFormatting();
 testRuntimeStatusLifecycle();

--- a/internal/consoleserver/testdata/terminal_shell_test.py
+++ b/internal/consoleserver/testdata/terminal_shell_test.py
@@ -1,0 +1,62 @@
+import errno
+import os
+import pty
+import select
+import signal
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+
+def read_prompt(fd):
+    output = b""
+    deadline = time.monotonic() + 5
+    while b"kelos-test> " not in output:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0 or not select.select([fd], [], [], remaining)[0]:
+            raise AssertionError(f"Shell did not return to its prompt: {output!r}")
+        try:
+            chunk = os.read(fd, 65536)
+        except OSError as error:
+            if error.errno != errno.EIO:
+                raise
+            chunk = b""
+        if not chunk:
+            raise AssertionError(f"Shell exited before its prompt: {output!r}")
+        output += chunk
+    return output
+
+
+with tempfile.TemporaryDirectory() as directory:
+    Path(directory, ".bashrc").write_text("PS1='kelos-test> '\n")
+    Path(directory, ".hushlogin").touch()
+    Path(directory, "completion-file").write_text("file-completed\n")
+    command = Path(directory, "kelos-completion-command")
+    command.write_text("#!/bin/sh\nprintf 'command-completed\\n'\n")
+    command.chmod(0o755)
+    pid, fd = pty.fork()
+    if pid == 0:
+        os.chdir(directory)
+        os.execve(sys.argv[1], sys.argv[1:], {
+            "PATH": f"{directory}:/usr/bin:/bin",
+            "HOME": directory,
+            "INPUTRC": "/dev/null",
+            "HISTFILE": "/dev/null",
+        })
+    try:
+        read_prompt(fd)
+        for line, expected in [
+            (b"cat completion-fi\t\r", b"file-completed\r\n"),
+            (b"kelos-completion-com\t\r", b"command-completed\r\n"),
+        ]:
+            os.write(fd, line)
+            output = read_prompt(fd)
+            assert expected in output, f"Tab completion failed: {output!r}"
+    finally:
+        os.close(fd)
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        os.waitpid(pid, 0)

--- a/internal/consoleserver/testdata/terminal_test.js
+++ b/internal/consoleserver/testdata/terminal_test.js
@@ -10,14 +10,20 @@ class Events {
 }
 
 class Element extends Events {
-  open = false;
+  hidden = false;
+  disabled = false;
+  attributes = {};
+  dataset = {};
+  get clientWidth() { return elements['terminal-view'].hidden ? 0 : 1000; }
+  get clientHeight() { return elements['terminal-view'].hidden ? 0 : 600; }
+  setAttribute(name, value) { this.attributes[name] = value; }
+  focus() { this.focused = true; }
+  click() { this.emit('click'); }
   textContent = '';
-  showModal() { this.open = true; }
-  close() { this.open = false; this.emit('close'); }
   replaceChildren() {}
 }
 
-const elements = Object.fromEntries(['terminal-dialog', 'terminal-container', 'terminal-title', 'terminal-status', 'close-terminal']
+const elements = Object.fromEntries(['terminal-view', 'terminal-container', 'terminal-status', 'reconnect-terminal']
   .map(id => [id, new Element()]));
 global.document = {
   querySelector: selector => selector.startsWith('meta') ? {content: 'test-style-nonce'} : elements[selector.slice(1)],
@@ -78,25 +84,24 @@ const session = {namespace: 'team-a', name: 'chat', uid: 'uid-1', phase: 'Ready'
 for (const unavailable of [null, {...session, phase: 'Pending'}, {...session, phase: 'Suspended'},
   {...session, phase: 'Failed'}, {...session, resetting: true}, {...session, userSuspended: true}]) {
   assert.equal(controller.available(unavailable), false);
-  controller.open(unavailable);
+  controller.show(unavailable);
 }
 assert.equal(sockets.length, 0);
 
-controller.open(session);
+controller.show(session);
 const socket = sockets[0];
 const terminal = terminals[0];
 assert.equal(terminal.style.nonce, 'test-style-nonce');
 assert.equal(document.createElement('style').nonce, undefined);
-assert.equal(elements['terminal-dialog'].open, true);
-assert.equal(elements['terminal-title'].textContent, 'Terminal · team-a/chat');
+assert.equal(elements['reconnect-terminal'].disabled, true);
 assert.equal(socket.url, 'wss://console.example/api/sessions/team-a/chat/exec');
 assert.equal(socket.binaryType, 'arraybuffer');
 socket.connect();
 assert.equal(terminal.focused, true);
 assert.equal(elements['terminal-status'].textContent, 'Connected');
 assert.deepEqual(JSON.parse(socket.sent[0]), {type: 'resize', cols: 100, rows: 30});
-terminal.input('héllo\r\x03');
-assert.equal(new TextDecoder().decode(socket.sent[1]), 'héllo\r\x03');
+terminal.input('héllo\t\r\x03\x1b');
+assert.equal(new TextDecoder().decode(socket.sent[1]), 'héllo\t\r\x03\x1b');
 terminal.binary('\x80\xff');
 assert.deepEqual([...socket.sent[2]], [128, 255]);
 terminal.cols = 120;
@@ -104,13 +109,23 @@ terminal.rows = 40;
 terminal.resize();
 assert.deepEqual(JSON.parse(socket.sent[3]), {type: 'resize', cols: 120, rows: 40});
 observers[0].callback();
-assert.equal(terminal.addon.fits, 2);
+assert.equal(terminal.addon.fits, 3);
 const output = new TextEncoder().encode('\x1b[32mhello\x1b[0m\r\n');
 socket.emit('message', {data: output.buffer});
 assert.deepEqual(terminal.output[0], output);
-let prevented = false;
-elements['terminal-dialog'].emit('cancel', {preventDefault() { prevented = true; }});
-assert.equal(prevented, true);
+const fits = terminal.addon.fits;
+terminal.focused = false;
+elements['terminal-view'].hidden = true;
+observers[0].callback();
+assert.equal(terminal.addon.fits, fits);
+assert.equal(terminal.focused, false);
+socket.emit('message', {data: output.buffer});
+assert.deepEqual(terminal.output[1], output);
+elements['terminal-view'].hidden = false;
+controller.show(session);
+assert.equal(sockets.length, 1);
+assert.equal(terminal.addon.fits, fits + 1);
+assert.equal(terminal.focused, true);
 assert.equal(socket.closed, undefined);
 
 socket.emit('message', {data: JSON.stringify({type: 'exit'})});
@@ -120,13 +135,16 @@ assert.equal(terminal.options.disableStdin, true);
 terminal.input('ignored');
 assert.equal(socket.sent.length, 4);
 assert.equal(sockets.length, 1);
-elements['close-terminal'].emit('click');
-assert.equal(elements['terminal-dialog'].open, false);
+controller.show(session);
+assert.equal(sockets.length, 1, 'Revisiting the tab must preserve exited shell output');
+assert.equal(elements['reconnect-terminal'].disabled, false);
+elements['reconnect-terminal'].emit('click');
+assert.equal(elements['reconnect-terminal'].disabled, true);
 assert.equal(terminal.disposed, true);
 assert.ok(terminal.subscriptions.every(subscription => subscription.disposed));
 assert.equal(observers[0].disconnected, true);
 
-controller.open(session);
+controller.show(session);
 const current = sockets[1];
 current.connect();
 socket.emit('message', {data: JSON.stringify({type: 'error', text: 'stale error'})});
@@ -140,15 +158,15 @@ controller.close();
 
 for (const changed of [null, {...session, namespace: 'team-b'}, {...session, name: 'other'},
   {...session, uid: 'replacement'}, {...session, phase: 'Suspended'}, {...session, resetting: true}, {...session, userSuspended: true}]) {
-  controller.open(session);
+  controller.show(session);
   const connection = sockets.at(-1);
   controller.sync(changed);
   assert.equal(connection.closed, true);
   assert.equal(terminals.at(-1).disposed, true);
-  assert.equal(elements['terminal-dialog'].open, false);
+  assert.equal(elements['reconnect-terminal'].disabled, true);
 }
 
-controller.open(session);
+controller.show(session);
 sockets.at(-1).connect();
 const pasted = 'héllo'.repeat(20000);
 terminals.at(-1).input(pasted);
@@ -157,21 +175,121 @@ assert.ok(chunks.length > 1 && chunks.every(chunk => chunk.length <= 32 * 1024))
 assert.equal(Buffer.concat(chunks).toString('utf8'), pasted);
 controller.close();
 
-controller.open(session);
+controller.show(session);
 sockets.at(-1).close();
 assert.match(elements['terminal-status'].textContent, /^Disconnected/);
 controller.close();
-controller.open(session);
+controller.show(session);
 sockets.at(-1).emit('error');
 assert.match(elements['terminal-status'].textContent, /^Could not connect/);
-window.emit('pagehide');
+controller.close();
 assert.equal(sockets.at(-1).closed, true);
 
 const index = fs.readFileSync(path.join(__dirname, '../web/index.html'), 'utf8');
 const app = fs.readFileSync(path.join(__dirname, '../web/app.js'), 'utf8');
-assert.match(index, /id="open-terminal"[^>]*disabled/);
-assert.match(index, /id="terminal-dialog"[^>]*aria-labelledby="terminal-title"/);
-assert.match(app, /terminalButton.addEventListener\('click', \(\) => sessionTerminal.open\(state.selected\)\)/);
+assert.match(index, /id="terminal-tab"[^>]*role="tab"[^>]*aria-controls="terminal-view"[^>]*disabled/);
+assert.match(index, /id="terminal-view"[^>]*role="tabpanel"[^>]*aria-labelledby="terminal-tab"[^>]*hidden/);
+assert.match(app, /terminalTab.addEventListener\('click', \(\) => setActiveView\('terminal'\)\)/);
+
+const viewElements = {
+  messages: new Element(), composerWrap: new Element(), changes: new Element(),
+  terminalView: elements['terminal-view'], conversationTab: new Element(), changesTab: new Element(), terminalTab: new Element(),
+  viewPicker: new Element(), viewChoice: new Element(),
+};
+global.elements = viewElements;
+global.state = {selected: session};
+let currentRequestHidden = false;
+global.hideCurrentRequest = () => { currentRequestHidden = true; };
+global.updateCurrentRequest = () => { currentRequestHidden = false; };
+vm.runInThisContext(app.slice(app.indexOf('function setActiveView('), app.indexOf('function renderError(')), {filename: 'app.js'});
+const choiceListener = app.indexOf("elements.viewChoice.addEventListener('change'");
+assert.notEqual(choiceListener, -1);
+vm.runInThisContext(app.slice(choiceListener, app.indexOf('\n', choiceListener)), {filename: 'app.js'});
+const pageHideListener = app.indexOf("window.addEventListener('pagehide'");
+assert.notEqual(pageHideListener, -1);
+vm.runInThisContext(app.slice(pageHideListener, app.indexOf('function interruptActiveTurn(', pageHideListener)), {filename: 'app.js'});
+for (const [name, tab] of [['conversation', viewElements.conversationTab], ['changes', viewElements.changesTab], ['terminal', viewElements.terminalTab]]) {
+  tab.addEventListener('click', () => setActiveView(name));
+}
+const beforeTabs = sockets.length;
+setActiveView('conversation');
+assert.equal(sockets.length, beforeTabs, 'Conversation must not start a shell');
+assert.equal(viewElements.messages.hidden, false);
+assert.equal(viewElements.composerWrap.hidden, false);
+assert.equal(viewElements.terminalView.hidden, true);
+viewElements.viewChoice.value = 'terminal';
+viewElements.viewChoice.emit('change');
+assert.equal(sockets.length, beforeTabs + 1);
+assert.equal(viewElements.messages.hidden, true);
+assert.equal(viewElements.composerWrap.hidden, true);
+assert.equal(viewElements.changes.hidden, true);
+assert.equal(viewElements.terminalView.hidden, false);
+assert.equal(viewElements.viewPicker.dataset.view, 'terminal');
+assert.equal(currentRequestHidden, true);
+assert.equal(viewElements.terminalTab.attributes['aria-selected'], 'true');
+assert.equal(viewElements.terminalTab.tabIndex, 0);
+assert.equal(viewElements.conversationTab.tabIndex, -1);
+assert.equal(viewElements.changesTab.tabIndex, -1);
+setActiveView('changes');
+assert.equal(viewElements.viewChoice.value, 'changes');
+assert.equal(viewElements.viewPicker.dataset.view, 'changes');
+assert.equal(viewElements.changes.hidden, false);
+assert.equal(viewElements.terminalView.hidden, true);
+assert.equal(viewElements.composerWrap.hidden, true);
+terminals.at(-1).focused = false;
+sockets.at(-1).connect();
+assert.equal(terminals.at(-1).focused, false, 'Connecting a hidden terminal must not steal focus');
+setActiveView('terminal');
+assert.equal(sockets.length, beforeTabs + 1, 'Switching tabs must reuse the shell');
+setActiveView('conversation');
+assert.equal(viewElements.viewChoice.value, 'conversation');
+assert.equal(viewElements.viewPicker.dataset.view, 'conversation');
+assert.equal(currentRequestHidden, false);
+assert.equal(viewElements.composerWrap.hidden, false);
+function tabKey(key, target) {
+  let prevented = false;
+  handleViewTabKeydown({key, target, preventDefault() { prevented = true; }});
+  assert.equal(prevented, true);
+}
+tabKey('End', viewElements.conversationTab);
+assert.equal(viewElements.terminalTab.focused, true);
+assert.equal(viewElements.terminalTab.attributes['aria-selected'], 'true');
+tabKey('ArrowRight', viewElements.terminalTab);
+assert.equal(viewElements.conversationTab.attributes['aria-selected'], 'true');
+tabKey('ArrowLeft', viewElements.conversationTab);
+assert.equal(viewElements.terminalTab.attributes['aria-selected'], 'true');
+tabKey('Home', viewElements.terminalTab);
+assert.equal(viewElements.conversationTab.attributes['aria-selected'], 'true');
+viewElements.terminalTab.disabled = true;
+tabKey('End', viewElements.conversationTab);
+assert.equal(viewElements.changesTab.attributes['aria-selected'], 'true');
+controller.close();
+
+viewElements.terminalTab.disabled = false;
+for (const view of ['terminal', 'conversation', 'changes']) {
+  setActiveView('terminal');
+  const connection = sockets.at(-1);
+  const terminal = terminals.at(-1);
+  connection.connect();
+  setActiveView(view);
+  window.emit('pagehide', {persisted: true});
+  window.emit('pageshow', {persisted: true});
+  assert.equal(connection.closed, true);
+  assert.equal(terminal.disposed, true);
+  assert.equal(viewElements.terminalView.hidden, true);
+  assert.equal(viewElements.viewChoice.value, view === 'terminal' ? 'conversation' : view);
+  assert.equal(viewElements.messages.hidden, view === 'changes');
+  assert.equal(viewElements.composerWrap.hidden, view === 'changes');
+  assert.equal(viewElements.changes.hidden, view !== 'changes');
+  const connections = sockets.length;
+  setActiveView('terminal');
+  assert.equal(sockets.length, connections + 1);
+  sockets.at(-1).connect();
+  assert.equal(elements['terminal-status'].textContent, 'Connected');
+  assert.equal(terminals.at(-1).focused, true);
+  controller.close();
+}
+
 for (const asset of ['xterm.css', 'xterm.js', 'xterm-addon-fit.js', 'terminal.js']) {
   assert.ok(index.includes(`/assets/${asset}`));
   assert.ok(fs.statSync(path.join(__dirname, '../web', asset)).size > 0);

--- a/internal/consoleserver/web/app.js
+++ b/internal/consoleserver/web/app.js
@@ -21,7 +21,6 @@
         title: document.querySelector('#session-title'),
         meta: document.querySelector('#session-meta'),
         displayNameButton: document.querySelector('#session-display-name'),
-        terminalButton: document.querySelector('#open-terminal'),
         displayNameDialog: document.querySelector('#display-name-dialog'),
         displayNameForm: document.querySelector('#display-name-form'),
         displayNameDialogDescription: document.querySelector('#display-name-dialog-description'),
@@ -88,6 +87,11 @@
         viewTabs: document.querySelector('.view-tabs'),
         conversationTab: document.querySelector('#conversation-tab'),
         changesTab: document.querySelector('#changes-tab'),
+        terminalTab: document.querySelector('#terminal-tab'),
+        terminalView: document.querySelector('#terminal-view'),
+        viewPicker: document.querySelector('#session-view-picker'),
+        viewChoice: document.querySelector('#session-view-choice'),
+        terminalChoice: document.querySelector('#terminal-view-choice'),
         welcome: document.querySelector('#welcome'),
         composerWrap: document.querySelector('.composer-wrap'),
         composer: document.querySelector('#composer'),
@@ -2420,8 +2424,12 @@ spec:
     }
     function renderHeader() {
         const session = state.selected;
-        elements.terminalButton.disabled = !sessionTerminal.available(session);
+        elements.terminalTab.disabled = !sessionTerminal.available(session);
+        elements.viewChoice.disabled = !session;
+        elements.terminalChoice.disabled = elements.terminalTab.disabled;
         sessionTerminal.sync(session);
+        if (elements.terminalTab.disabled && !elements.terminalView.hidden)
+            setActiveView('conversation');
         elements.displayNameButton.hidden = !session;
         elements.displayNameButton.disabled = !session;
         renderSelectedSessionSection(session);
@@ -2566,7 +2574,8 @@ spec:
             setComposer(true);
             updateComposerAction();
             renderHistoryControl();
-            elements.input.focus();
+            if (!elements.messages.hidden)
+                elements.input.focus();
         });
         socket.addEventListener('message', event => {
             if (generation !== state.socketGeneration)
@@ -4274,21 +4283,29 @@ spec:
         return lines;
     }
     function setActiveView(view) {
+        elements.viewChoice.value = view;
+        elements.viewPicker.dataset.view = view;
+        const conversationActive = view === 'conversation';
         const changesActive = view === 'changes';
-        elements.messages.hidden = changesActive;
-        elements.composerWrap.hidden = changesActive;
+        const terminalActive = view === 'terminal';
+        elements.messages.hidden = !conversationActive;
+        elements.composerWrap.hidden = !conversationActive;
         elements.changes.hidden = !changesActive;
-        elements.conversationTab.setAttribute('aria-selected', String(!changesActive));
-        elements.changesTab.setAttribute('aria-selected', String(changesActive));
-        elements.conversationTab.tabIndex = changesActive ? -1 : 0;
-        elements.changesTab.tabIndex = changesActive ? 0 : -1;
-        if (changesActive)
-            hideCurrentRequest();
-        else
+        elements.terminalView.hidden = !terminalActive;
+        for (const [tab, active] of [[elements.conversationTab, conversationActive],
+            [elements.changesTab, changesActive], [elements.terminalTab, terminalActive]]) {
+            tab.setAttribute('aria-selected', String(active));
+            tab.tabIndex = active ? 0 : -1;
+        }
+        if (conversationActive)
             updateCurrentRequest();
+        else
+            hideCurrentRequest();
+        if (terminalActive)
+            sessionTerminal.show(state.selected);
     }
     function handleViewTabKeydown(event) {
-        const tabs = [elements.conversationTab, elements.changesTab].filter(tab => !tab.disabled);
+        const tabs = [elements.conversationTab, elements.changesTab, elements.terminalTab].filter(tab => !tab.disabled);
         const current = tabs.indexOf(event.target);
         if (current < 0)
             return;
@@ -4913,7 +4930,6 @@ spec:
     elements.resumeButton.addEventListener('click', resumeSelectedSession);
     elements.suspendButton.addEventListener('click', suspendSelectedSession);
     elements.deleteButton.addEventListener('click', () => deleteSession(state.selected));
-    elements.terminalButton.addEventListener('click', () => sessionTerminal.open(state.selected));
     elements.resetButton.addEventListener('click', () => resetSession(state.selected));
     elements.sessionActionRename.addEventListener('click', () => {
         const session = sessionActionsTarget();
@@ -4956,9 +4972,16 @@ spec:
     elements.sessionActionsMenu.addEventListener('focusout', handleSessionActionsFocusOut);
     elements.conversationTab.addEventListener('click', () => setActiveView('conversation'));
     elements.changesTab.addEventListener('click', () => setActiveView('changes'));
+    elements.terminalTab.addEventListener('click', () => setActiveView('terminal'));
+    elements.viewChoice.addEventListener('change', () => setActiveView(elements.viewChoice.value));
     elements.viewTabs.addEventListener('keydown', handleViewTabKeydown);
     elements.currentRequestButton.addEventListener('click', jumpToCurrentRequest);
     elements.messages.addEventListener('scroll', scheduleCurrentRequestUpdate);
+    window.addEventListener('pagehide', () => {
+        sessionTerminal.close();
+        if (!elements.terminalView.hidden)
+            setActiveView('conversation');
+    });
     function interruptActiveTurn() {
         if (!state.socket || state.socket.readyState !== WebSocket.OPEN || !state.activeTurn || state.interrupting)
             return;

--- a/internal/consoleserver/web/index.html
+++ b/internal/consoleserver/web/index.html
@@ -159,11 +159,21 @@
           </form>
         </div>
         <div class="header-actions">
-          <button class="secondary-button" id="open-terminal" type="button" title="Open a shell in the session" disabled>Terminal</button>
           <div class="view-tabs" role="tablist" aria-label="Session view">
             <button id="conversation-tab" type="button" role="tab" aria-selected="true" aria-controls="messages" tabindex="0" disabled>Conversation</button>
             <button id="changes-tab" type="button" role="tab" aria-selected="false" aria-controls="changes-view" tabindex="-1" disabled>Changes <span id="changes-count">0</span></button>
+            <button id="terminal-tab" type="button" role="tab" aria-selected="false" aria-controls="terminal-view" tabindex="-1" disabled>Terminal</button>
           </div>
+          <label class="session-view-picker" id="session-view-picker" data-view="conversation" title="Session view">
+            <svg class="conversation-view-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M5 4h14a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H9l-6 4V6a2 2 0 0 1 2-2Z"/></svg>
+            <svg class="changes-view-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8ZM14 2v6h6M8 12h8M8 16h8"/></svg>
+            <svg class="terminal-view-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="m4 6 6 6-6 6m9 0h7"/></svg>
+            <select id="session-view-choice" aria-label="Session view" disabled>
+              <option value="conversation">Conversation</option>
+              <option value="changes">Changes</option>
+              <option value="terminal" id="terminal-view-choice" disabled>Terminal</option>
+            </select>
+          </label>
           <span class="connection-pill" id="connection-pill" data-state="idle"><span></span>Not connected</span>
           <button class="icon-button session-lifecycle-action" id="suspend-session" aria-label="Suspend session" title="Suspend session" disabled hidden>⏸</button>
           <button class="icon-button session-lifecycle-action" id="resume-session" aria-label="Resume session" title="Resume session" disabled hidden>▶</button>
@@ -199,6 +209,14 @@
         <div class="changes-list" id="changes-list" aria-live="polite">
           <div class="changes-empty">No file changes yet.</div>
         </div>
+      </section>
+
+      <section class="terminal-view" id="terminal-view" role="tabpanel" aria-labelledby="terminal-tab" hidden>
+        <header class="terminal-header">
+          <span id="terminal-status" role="status">Connecting…</span>
+          <button class="secondary-button" id="reconnect-terminal" type="button" disabled>Reconnect</button>
+        </header>
+        <div id="terminal-container"></div>
       </section>
 
       <footer class="composer-wrap">
@@ -413,17 +431,6 @@
         <button class="secondary-button close-resource-detail" type="button">Close</button>
       </div>
     </div>
-  </dialog>
-
-  <dialog class="session-dialog terminal-dialog" id="terminal-dialog" aria-labelledby="terminal-title" aria-describedby="terminal-status">
-    <div class="dialog-header">
-      <div>
-        <h2 id="terminal-title">Terminal</h2>
-        <p id="terminal-status" role="status">Connecting…</p>
-      </div>
-      <button class="secondary-button" id="close-terminal" type="button">Close</button>
-    </div>
-    <div id="terminal-container"></div>
   </dialog>
 
   <div class="session-actions-menu" id="session-actions-menu" role="menu" hidden>

--- a/internal/consoleserver/web/styles.css
+++ b/internal/consoleserver/web/styles.css
@@ -246,6 +246,7 @@ button { color: inherit; }
 .session-section-control .session-section-cancel { display: none; }
 .session-section-control :disabled { opacity: .55; cursor: wait; }
 .header-actions { display: flex; align-items: center; gap: 8px; }
+.session-view-picker { display: none; }
 .view-tabs { display: flex; padding: 2px; border-radius: 9px; background: var(--panel); }
 .view-tabs button { padding: 6px 9px; border: 0; border-radius: 7px; background: transparent; color: var(--muted); font-size: 11px; font-weight: 500; cursor: pointer; }
 .view-tabs button[aria-selected="true"] { background: var(--card); color: var(--ink); box-shadow: 0 1px 3px rgba(0,0,0,.08); }
@@ -363,6 +364,12 @@ button { color: inherit; }
 .diff-card .changes-list { gap: 0; }
 .diff-card .file-change { border: 0; border-top: 1px solid var(--line); border-radius: 0; box-shadow: none; }
 .diff-card .diff-lines { max-height: 430px; }
+.terminal-view { min-width: 0; min-height: 0; grid-row: 2; grid-column: 1; display: grid; grid-template-rows: auto minmax(0, 1fr); }
+.terminal-view[hidden] { display: none; }
+.terminal-header { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 8px 16px; border-bottom: 1px solid var(--line); color: var(--muted); font-size: 11px; }
+#terminal-status { min-width: 0; overflow-wrap: anywhere; }
+#terminal-container { min-width: 0; min-height: 0; overflow: hidden; background: #161b22; }
+#terminal-container .xterm { height: 100%; padding: 8px; }
 .changes-view { min-height: 0; grid-row: 2; grid-column: 1; overflow-y: auto; padding: 28px max(24px, calc((100% - 980px) / 2)) 40px; }
 .changes-view[hidden], .messages[hidden], .composer-wrap[hidden] { display: none; }
 .changes-header { display: flex; align-items: flex-end; justify-content: space-between; gap: 20px; margin-bottom: 18px; }
@@ -440,11 +447,6 @@ button { color: inherit; }
 .secondary-button { border: 1px solid var(--line); background: var(--card); }
 .session-dialog { width: min(94vw, 610px); max-height: calc(100dvh - 32px); overflow-y: auto; padding: 0; border: 1px solid var(--line); border-radius: 16px; background: var(--card); color: var(--ink); box-shadow: 0 24px 70px rgba(0,0,0,.2); }
 .session-dialog::backdrop { background: rgba(0,0,0,.36); backdrop-filter: blur(3px); }
-.terminal-dialog { width: min(94vw, 1100px); padding: 18px; }
-.terminal-dialog .dialog-header { margin-bottom: 16px; }
-.terminal-dialog .dialog-header > div { min-width: 0; overflow-wrap: anywhere; }
-#terminal-container { height: min(65dvh, 700px); background: #161b22; }
-#terminal-container .xterm { height: 100%; padding: 8px; }
 .session-dialog form { padding: 23px; }
 .display-name-dialog { width: min(94vw, 420px); }
 .resource-detail-dialog { width: min(94vw, 820px); }
@@ -582,11 +584,18 @@ button { color: inherit; }
   .session-section-control.mobile-open select { max-width: min(100%, 220px); min-height: 36px; }
   .session-section-control.mobile-open .session-section-cancel { width: 36px; height: 36px; display: grid; place-items: center; padding: 0; border: 0; background: transparent; color: var(--muted); font-size: 18px; }
   .header-actions { grid-area: actions; gap: 4px; }
+  .view-tabs { display: none; }
+  .session-view-picker { position: relative; width: 44px; height: 44px; display: flex; align-items: center; justify-content: center; gap: 5px; border-radius: 9px; background: var(--panel); }
+  .session-view-picker:focus-within { outline: 2px solid var(--accent); outline-offset: 2px; }
+  .session-view-picker:has(select:disabled) { opacity: .45; }
+  .session-view-picker::after { width: 4px; height: 4px; border-right: 1px solid currentColor; border-bottom: 1px solid currentColor; transform: rotate(45deg); content: ""; }
+  .session-view-picker svg { display: none; width: 18px; height: 18px; fill: none; stroke: currentColor; stroke-width: 1.8; stroke-linecap: round; stroke-linejoin: round; }
+  .session-view-picker[data-view="conversation"] .conversation-view-icon, .session-view-picker[data-view="changes"] .changes-view-icon, .session-view-picker[data-view="terminal"] .terminal-view-icon { display: block; }
+  .session-view-picker select { position: absolute; inset: 0; width: 100%; height: 100%; opacity: 0; font-size: 16px; cursor: pointer; }
   .session-lifecycle-action, #reset-session, #delete-session { display: none !important; }
   .connection-pill { width: 36px; height: 36px; justify-content: center; overflow: hidden; padding: 0; color: transparent; font-size: 0; gap: 0; }
   .connection-pill span { width: 7px; height: 7px; }
   .icon-button { width: 44px; height: 44px; }
-  .view-tabs button { min-height: 44px; padding: 5px 8px; }
   .current-request { width: calc(100% - 24px - env(safe-area-inset-left) - env(safe-area-inset-right)); }
   .current-request button { align-items: start; }
   .current-request-text { display: -webkit-box; white-space: normal; -webkit-box-orient: vertical; -webkit-line-clamp: 2; }

--- a/internal/consoleserver/web/terminal.js
+++ b/internal/consoleserver/web/terminal.js
@@ -1,9 +1,8 @@
 "use strict";
 const sessionTerminal = (() => {
-    const dialog = document.querySelector('#terminal-dialog');
     const container = document.querySelector('#terminal-container');
-    const title = document.querySelector('#terminal-title');
     const status = document.querySelector('#terminal-status');
+    const reconnect = document.querySelector('#reconnect-terminal');
     let active = null;
     function available(session) {
         return Boolean(session && session.phase === 'Ready' && !session.resetting && !session.userSuspended);
@@ -11,22 +10,24 @@ const sessionTerminal = (() => {
     function close() {
         active?.dispose();
         active = null;
-        if (dialog.open)
-            dialog.close();
         container.replaceChildren();
+        reconnect.disabled = true;
     }
     function sync(session) {
         if (active && (!available(session) || session?.namespace !== active.session.namespace ||
             session?.name !== active.session.name || session?.uid !== active.session.uid))
             close();
     }
-    function open(session) {
+    function show(session) {
+        sync(session);
         if (!session || !available(session))
             return;
-        close();
-        title.textContent = `Terminal · ${session.namespace}/${session.name}`;
+        if (active) {
+            active.focus();
+            return;
+        }
         status.textContent = 'Connecting…';
-        dialog.showModal();
+        reconnect.disabled = true;
         const nonce = document.querySelector('meta[name="terminal-style-nonce"]').content;
         const terminal = new Terminal({
             cursorBlink: true,
@@ -52,12 +53,18 @@ const sessionTerminal = (() => {
         finally {
             document.createElement = createElement;
         }
-        fit.fit();
         const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
         const socket = new WebSocket(`${protocol}//${location.host}/api/sessions/${encodeURIComponent(session.namespace)}/${encodeURIComponent(session.name)}/exec`);
         socket.binaryType = 'arraybuffer';
         let disposed = false;
         let finished = false;
+        const visible = () => !disposed && container.clientWidth > 0 && container.clientHeight > 0;
+        const focus = () => {
+            if (!visible())
+                return;
+            fit.fit();
+            terminal.focus();
+        };
         const send = (data) => {
             if (disposed || finished || socket.readyState !== WebSocket.OPEN)
                 return;
@@ -74,7 +81,7 @@ const sessionTerminal = (() => {
         const binary = terminal.onBinary(data => send(Uint8Array.from(data, character => character.charCodeAt(0))));
         const resize = terminal.onResize(sendResize);
         const observer = new ResizeObserver(() => {
-            if (!disposed)
+            if (visible())
                 fit.fit();
         });
         observer.observe(container);
@@ -82,13 +89,14 @@ const sessionTerminal = (() => {
             finished = true;
             status.textContent = message;
             terminal.options.disableStdin = true;
+            reconnect.disabled = false;
         };
         socket.addEventListener('open', () => {
             if (disposed)
                 return;
             status.textContent = 'Connected';
             sendResize();
-            terminal.focus();
+            focus();
         });
         socket.addEventListener('message', event => {
             if (disposed)
@@ -106,13 +114,13 @@ const sessionTerminal = (() => {
         });
         socket.addEventListener('error', () => {
             if (!disposed && !finished)
-                finish('Could not connect to the session terminal. Close and reopen to try again.');
+                finish('Could not connect to the session terminal. Reconnect to try again.');
         });
         socket.addEventListener('close', () => {
             if (!disposed && !finished)
-                finish('Disconnected. Close and reopen to start a shell.');
+                finish('Disconnected. Reconnect to start a shell.');
         });
-        active = { session, dispose: () => {
+        active = { session, focus, dispose: () => {
                 disposed = true;
                 observer.disconnect();
                 input.dispose();
@@ -121,14 +129,14 @@ const sessionTerminal = (() => {
                 socket.close();
                 terminal.dispose();
             } };
+        focus();
     }
-    document.querySelector('#close-terminal').addEventListener('click', close);
-    dialog.addEventListener('close', () => {
-        if (!dialog.open)
-            close();
+    reconnect.addEventListener('click', () => {
+        if (!active || reconnect.disabled)
+            return;
+        const session = active.session;
+        close();
+        show(session);
     });
-    // Escape is input for terminal applications; the Close button ends the connection.
-    dialog.addEventListener('cancel', event => event.preventDefault());
-    window.addEventListener('pagehide', close);
-    return { available, open, sync, close };
+    return { available, show, sync, close };
 })();


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Add Terminal alongside Conversation and Changes in the Session view. Opening the tab starts a shell; switching tabs retains the shell and its output. Conversation remains the default, and a Reconnect button starts another shell after exit or disconnection. Leaving the page closes the shell and returns the Session view to Conversation when Terminal was selected. On mobile, a compact view picker beside the Session title keeps the header in one row while preserving a 44 px touch target.

Use interactive Bash when available so Tab completes commands and filenames. Custom agent images without `/bin/bash` continue to use `/bin/sh`.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Validation passed:

- `make update`
- `env -u CODEX_HOME -u CODEX_AUTH_JSON make test` (isolates the suite from agent credentials inherited by this environment)
- `make verify build WHAT=cmd/kelos-console-server`
- Chromium smoke checks with mocked Session APIs and WebSockets at desktop, 390 px, and 320 px widths: native tabs, keyboard input, shell persistence, reconnect, Session switching, mobile view selection, a 58 px mobile header, availability, resize, simulated page lifecycle restoration, and CSP

The unit suite includes a real Bash PTY test for command and filename completion, plus WebSocket input, shell startup failure diagnostics, page restoration, and unavailable-Session fallback coverage.

#### Does this PR introduce a user-facing change?

```release-note
The Console provides a Terminal tab alongside Conversation and Changes, preserving the shell while switching views. Mobile users switch views with a compact picker in the Session header. Session shells use Bash when available for command and filename tab completion, with a Reconnect action after shell exit or disconnection.
```
