### PR TITLE
Add chat navigation from console prompt history

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -260,6 +260,9 @@ browsing; recalled multiline prompts can be browsed with Up/Down directly.
 
 In a connected console Session, select **Prompt history** beside the attachment
 button inside the composer to browse prompts newest first and load earlier pages.
+**Jump to message** navigates to that prompt in the conversation, loading earlier
+messages as needed. Pending prompts navigate to their queued message. Closing
+Prompt history cancels navigation while messages are loading.
 **Copy text** copies a prompt;
 **Use text** adds it to your draft without sending it or attaching the original
 files. Both interfaces include prompts from earlier connections, with the

--- a/internal/consoleserver/frontend/app.ts
+++ b/internal/consoleserver/frontend/app.ts
@@ -262,6 +262,7 @@ interface ConsoleEvent {
 
 interface SessionPrompt {
   id: number;
+  turnId?: string;
   text: string;
   timestamp?: string;
   attachments?: Attachment[];
@@ -503,6 +504,7 @@ const state = {
   historyPageLoading: false,
   promptsRequestID: '',
   promptsCursor: '',
+  promptJumpTarget: null as SessionPrompt | null,
   historyPageReading: false,
   historyPageCursor: '',
   historyPageEvents: [] as ConsoleEvent[],
@@ -3609,6 +3611,7 @@ function renderHistoryControl() {
 }
 
 function cancelOlderHistoryPage() {
+  if (state.promptJumpTarget) stopPromptJump('Could not load messages for this prompt; try again');
   state.historyPageLoading = false;
   state.historyPageReading = false;
   state.historyPageCursor = '';
@@ -3743,6 +3746,7 @@ function finishOlderHistoryPage(event) {
   state.historyRequestID = '';
   if (state.currentView) state.currentView.historyCursor = state.historyCursor;
   replayOlderHistoryPage(events);
+  continuePromptJump();
 }
 
 function finishHistoryReplay(historyState) {
@@ -3761,10 +3765,12 @@ function finishHistoryReplay(historyState) {
   if (pinToBottom) scheduleBottomAnchor();
   state.pinHistoryToBottom = false;
   updateCurrentRequest();
+  continuePromptJump();
 }
 
 function openPromptHistory() {
   if (!state.selected || !state.socket || state.socket.readyState !== WebSocket.OPEN) return;
+  state.promptJumpTarget = null;
   state.promptsCursor = '';
   state.promptsRequestID = '';
   elements.promptsTitle.textContent = `Prompt history · ${sessionDisplayName(state.selected)}`;
@@ -3774,14 +3780,61 @@ function openPromptHistory() {
 }
 
 function closePromptHistory() {
+  state.promptJumpTarget = null;
   state.promptsRequestID = '';
   state.promptsCursor = '';
   elements.promptsDialog.close();
   elements.promptsList.replaceChildren();
 }
 
+function stopPromptJump(message: string) {
+  state.promptJumpTarget = null;
+  elements.promptsStatus.textContent = message;
+  elements.promptsMore.disabled = false;
+}
+
+function jumpToPrompt(prompt: SessionPrompt) {
+  state.promptJumpTarget = prompt;
+  state.pinHistoryToBottom = false;
+  elements.promptsStatus.textContent = `Loading messages for prompt ${prompt.id}…`;
+  elements.promptsMore.disabled = true;
+  continuePromptJump();
+}
+
+function continuePromptJump() {
+  const prompt = state.promptJumpTarget;
+  if (!prompt || state.replayingHistory || state.historyPageLoading) return;
+  const row = [...elements.messages.querySelectorAll<HTMLElement>('.event-row.user')].find(row =>
+    row.dataset.eventId === String(prompt.id) || (prompt.turnId && row.dataset.turnId === prompt.turnId));
+  const pending = state.pendingMessage;
+  const target = row || (pending && (pending.event.id === prompt.id || (prompt.turnId && pending.event.turnId === prompt.turnId))
+    ? pending.item : null);
+  if (target) {
+    closePromptHistory();
+    setActiveView('conversation');
+    hideCurrentRequest();
+    if (state.bottomScrollFrame !== null) {
+      window.cancelAnimationFrame(state.bottomScrollFrame);
+      state.bottomScrollFrame = null;
+    }
+    target.tabIndex = -1;
+    target.focus({preventScroll: true});
+    target.scrollIntoView({behavior: 'instant', block: 'start'});
+    return;
+  }
+  if (!state.historyCursor) {
+    stopPromptJump('This prompt is no longer available in the conversation');
+    return;
+  }
+  if (!state.socket || state.socket.readyState !== WebSocket.OPEN) {
+    stopPromptJump('Session is disconnected');
+    return;
+  }
+  requestOlderHistory();
+}
+
 function requestPromptHistory() {
-  if (state.promptsRequestID || !state.socket || state.socket.readyState !== WebSocket.OPEN) return;
+  if (state.promptJumpTarget || state.promptsRequestID || !state.socket || state.socket.readyState !== WebSocket.OPEN) return;
   state.promptsRequestID = sessionRequestID('prompts');
   elements.promptsStatus.textContent = 'Loading prompts…';
   elements.promptsMore.disabled = true;
@@ -3798,6 +3851,7 @@ function receivePromptHistory(event: ConsoleEvent) {
   state.promptsRequestID = '';
   elements.promptsMore.disabled = false;
   if (event.type === 'error') {
+    state.promptJumpTarget = null;
     state.promptsCursor = '';
     elements.promptsList.replaceChildren();
     elements.promptsStatus.textContent = event.text || 'Could not load prompts';
@@ -3813,6 +3867,12 @@ function receivePromptHistory(event: ConsoleEvent) {
     const label = document.createElement('span');
     label.textContent = `Prompt ${prompt.id}${prompt.timestamp ? ` · ${new Date(prompt.timestamp).toLocaleString()}` : ''}`;
     heading.append(label);
+    const jump = document.createElement('button');
+    jump.type = 'button';
+    jump.className = 'secondary-button';
+    jump.textContent = 'Jump to message';
+    jump.addEventListener('click', () => jumpToPrompt(prompt));
+    heading.append(jump);
     const text = document.createElement('pre');
     text.textContent = prompt.text;
     item.append(heading, text);
@@ -3855,6 +3915,10 @@ function receivePromptHistory(event: ConsoleEvent) {
   elements.promptsStatus.textContent = !elements.promptsList.hasChildNodes()
     ? 'No retained prompts.'
     : (state.promptsCursor ? '' : 'All retained prompts are loaded.');
+  if (state.promptJumpTarget) {
+    elements.promptsStatus.textContent = `Loading messages for prompt ${state.promptJumpTarget.id}…`;
+    elements.promptsMore.disabled = true;
+  }
 }
 
 function handleEvent(event) {
@@ -4057,6 +4121,8 @@ function renderAcceptedUser(event) {
   ensureConversation();
   const row = document.createElement('div');
   row.className = 'event-row user';
+  if (event.id) row.dataset.eventId = String(event.id);
+  if (event.turnId) row.dataset.turnId = event.turnId;
   row.dataset.requestText = event.text || (event.attachments || []).map(attachment => attachment.name).join(', ');
   const message = document.createElement('div');
   message.className = 'user-message';

--- a/internal/consoleserver/testdata/session_history_test.js
+++ b/internal/consoleserver/testdata/session_history_test.js
@@ -118,7 +118,7 @@ class TestNode {
 
   showModal() { this.open = true; }
   close() { this.open = false; }
-  focus() { this.focused = true; }
+  focus(options) { this.focused = true; this.focusOptions = options; }
   select() { this.selected = true; }
 
   getBoundingClientRect() {
@@ -163,6 +163,7 @@ let toasts;
 let closeSocketRequests;
 
 global.window = {
+  cancelAnimationFrame: frame => { animationFrames[frame - 1] = () => {}; },
   clearInterval: (timer) => progressTimers.delete(timer),
   confirm: () => true,
   matchMedia: () => ({matches: false}),
@@ -231,6 +232,7 @@ function resetHarness() {
     currentView: null,
     sessionViews: new Map(),
     socket: null,
+    bottomScrollFrame: null,
     promptDrafts: new Map(),
     attachmentDrafts: new Map(),
     sendingMessage: false,
@@ -255,6 +257,7 @@ function resetHarness() {
     historyPageLoading: false,
     promptsRequestID: '',
     promptsCursor: '',
+    promptJumpTarget: null,
     historyPageReading: false,
     historyPageCursor: '',
     historyPageEvents: [],
@@ -317,6 +320,7 @@ function applicationSlice(start, end) {
   return application.slice(startIndex, endIndex);
 }
 
+vm.runInThisContext(applicationSlice('function errorMessage', 'function requireElements'), {filename: 'app.js'});
 vm.runInThisContext(applicationSlice('function sessionKey', 'function savePromptDraft'), {filename: 'app.js'});
 vm.runInThisContext(applicationSlice('function savePromptDraft', 'function providerLabel'), {filename: 'app.js'});
 vm.runInThisContext(applicationSlice('function providerLabel', 'function parseSessionTimestamp'), {filename: 'app.js'});
@@ -394,13 +398,13 @@ async function testPromptHistoryBrowseAndReuse() {
       copied = textarea.value;
       return true;
     };
-    await items[1].querySelectorAll('button')[0].listeners.get('click')();
+    await items[1].querySelectorAll('button').find(button => button.textContent === 'Copy text').listeners.get('click')();
     assert.equal(copied, 'first\nrequest');
     assert.equal(toasts.at(-1), 'Prompt copied');
     assert.equal(elements.promptsDialog.querySelector('textarea'), null);
     assert.equal(document.body.hasChildNodes(), false);
   }
-  items[1].querySelectorAll('button')[1].listeners.get('click')();
+  items[1].querySelectorAll('button').find(button => button.textContent === 'Use text').listeners.get('click')();
   assert.equal(elements.input.value, 'unsent draft\n\nfirst\nrequest');
   assert.equal(state.promptDrafts.get(sessionKey(state.selected)), elements.input.value);
   assert.equal(elements.input.focused, true);
@@ -455,6 +459,165 @@ function testPromptHistoryReloadsAfterPageError() {
   assert.equal(elements.promptsList.querySelectorAll('.prompt-history-item').length, 1);
   assert.equal(elements.promptsList.querySelector('pre').textContent, 'current prompt');
   assert.equal(elements.messages.hasChildNodes(), false);
+}
+
+function openPromptNavigation(prompts) {
+  state.selected = {namespace: 'default', name: 'one', uid: 'uid-one', phase: 'Ready'};
+  const sent = [];
+  state.socket = {readyState: WebSocket.OPEN, send: payload => sent.push(JSON.parse(payload))};
+  openPromptHistory();
+  handleEvent({type: 'prompts', requestId: sent[0].requestId, prompts});
+  return sent;
+}
+
+function clickPromptJump() {
+  elements.promptsList.querySelectorAll('button').find(button => button.textContent === 'Jump to message').listeners.get('click')();
+}
+
+function receiveTranscriptPage(request, events, historyCursor = '') {
+  handleEvent({type: 'history.start', historyPage: true, requestId: request.requestId, historyCursor});
+  for (const event of events) handleEvent(event);
+  handleEvent({type: 'history.end', historyPage: true, requestId: request.requestId});
+}
+
+function testPromptJumpToLoadedMessage() {
+  for (const prompt of [{id: 7, text: 'repeated text'}, {id: 7, text: '', attachments: [{id: 'file-1', name: 'notes.txt'}]}]) {
+    resetHarness();
+    const sent = openPromptNavigation([prompt]);
+    elements.input.value = 'unsent draft';
+    renderAcceptedUser({...prompt, id: 2});
+    renderAcceptedUser(prompt);
+    const rows = elements.messages.querySelectorAll('.event-row.user');
+    state.bottomScrollFrame = window.requestAnimationFrame(() => assert.fail('Jump must cancel bottom anchoring'));
+
+    clickPromptJump();
+
+    assert.equal(rows[0].scrollIntoViewOptions, null);
+    assert.deepEqual(rows[1].scrollIntoViewOptions, {behavior: 'instant', block: 'start'});
+    assert.equal(rows[1].focused, true);
+    assert.deepEqual(rows[1].focusOptions, {preventScroll: true});
+    assert.equal(rows[1].tabIndex, -1);
+    assert.equal(elements.promptsDialog.open, false);
+    assert.equal(state.promptJumpTarget, null);
+    assert.equal(elements.input.value, 'unsent draft');
+    assert.equal(sent.length, 1);
+    assert.equal(state.bottomScrollFrame, null);
+    animationFrames.forEach(callback => callback());
+  }
+}
+
+function testPromptJumpLoadsEarlierPages() {
+  resetHarness();
+  const sent = openPromptNavigation([{id: 5, text: 'earliest prompt'}]);
+  state.historyCursor = 'recent-cursor';
+  state.activeTurn = true;
+  state.activeTurnID = 'live-turn';
+  state.lastEventID = 100;
+  renderAcceptedUser({id: 90, text: 'recent prompt'});
+  requestOlderHistory();
+
+  clickPromptJump();
+
+  assert.equal(sent.length, 2, 'An in-flight page must be reused');
+  assert.equal(elements.promptsDialog.open, true);
+  assert.equal(elements.promptsStatus.textContent, 'Loading messages for prompt 5…');
+  assert.equal(elements.promptsMore.disabled, true);
+  requestPromptHistory();
+  assert.equal(sent.length, 2);
+  receiveTranscriptPage(sent[1], [{type: 'user.message', id: 50, text: 'middle prompt'}], 'older-cursor');
+  assert.equal(sent.length, 3);
+  assert.equal(sent[2].type, 'history');
+  assert.equal(sent[2].historyCursor, 'older-cursor');
+  receiveTranscriptPage(sent[2], [{type: 'user.message', id: 5, text: 'earliest prompt'}], 'more-cursor');
+
+  const rows = elements.messages.querySelectorAll('.event-row.user');
+  assert.deepEqual(rows.map(row => row.dataset.eventId), ['5', '50', '90']);
+  assert.deepEqual(rows[0].scrollIntoViewOptions, {behavior: 'instant', block: 'start'});
+  assert.equal(rows[1].scrollIntoViewOptions, null);
+  assert.equal(rows[2].scrollIntoViewOptions, null);
+  assert.equal(elements.promptsDialog.open, false);
+  assert.equal(state.activeTurn, true);
+  assert.equal(state.activeTurnID, 'live-turn');
+  assert.equal(state.lastEventID, 100);
+  assert.equal(state.historyCursor, 'more-cursor');
+  assert.equal(sent.length, 3, 'Stop loading as soon as the target is found');
+}
+
+function testPromptJumpToEditedPendingMessage() {
+  for (const accepted of [false, true]) {
+    resetHarness();
+    const sent = openPromptNavigation([{id: 5, turnId: 'queued-turn', text: 'draft'}]);
+    applyHistoryState({pendingTurn: {turnId: 'queued-turn', text: 'draft', revision: 1}});
+    handleEvent({type: 'user.message.updated', id: 8, turnId: 'queued-turn', text: 'edited draft', revision: 2});
+    if (accepted) handleEvent({type: 'turn.started', id: 9, turnId: 'queued-turn'});
+    const target = accepted ? elements.messages.querySelectorAll('.event-row.user')[0] : state.pendingMessage.item;
+
+    clickPromptJump();
+
+    assert.deepEqual(target.scrollIntoViewOptions, {behavior: 'instant', block: 'start'});
+    assert.equal(target.focused, true);
+    assert.match(target.textContent, /edited draft/);
+    assert.equal(elements.promptsDialog.open, false);
+    assert.equal(sent.length, 1);
+  }
+}
+
+function testPromptJumpWaitsForInitialHistory() {
+  resetHarness();
+  handleEvent({type: 'history.start', historyCursor: 'older-cursor', lastEventId: 10});
+  const sent = openPromptNavigation([{id: 5, text: 'prompt'}]);
+  clickPromptJump();
+  assert.equal(sent.length, 1);
+  handleEvent({type: 'user.message', id: 5, text: 'prompt'});
+  handleEvent({type: 'history.end', historyState: {}});
+  assert.equal(elements.promptsDialog.open, false);
+  assert.equal(elements.messages.querySelectorAll('.event-row.user')[0].focused, true);
+  assert.equal(sent.length, 1);
+}
+
+function testPromptJumpCancellation() {
+  for (const cancel of [
+    closePromptHistory,
+    () => selectSession({namespace: 'default', name: 'two', uid: 'uid-two', phase: 'Pending'}),
+    resetCurrentSessionView,
+    closeSocket,
+  ]) {
+    resetHarness();
+    const sent = openPromptNavigation([{id: 5, text: 'prompt'}]);
+    state.historyCursor = 'older-cursor';
+    clickPromptJump();
+    assert.equal(sent.length, 2);
+    cancel();
+    assert.equal(state.promptJumpTarget, null);
+    receiveTranscriptPage(sent[1], [{type: 'user.message', id: 5, text: 'prompt'}], 'more-cursor');
+    assert.equal(sent.length, 2);
+    assert.equal(elements.promptsDialog.open, false);
+    for (const row of elements.messages.querySelectorAll('.event-row.user')) assert.equal(row.scrollIntoViewOptions, null);
+  }
+}
+
+function testPromptJumpUnavailableAndPageError() {
+  for (const failure of ['unavailable', 'page-error', 'send-error']) {
+    resetHarness();
+    const sent = openPromptNavigation([{id: 5, text: 'prompt'}]);
+    state.historyCursor = 'older-cursor';
+    if (failure === 'send-error') state.socket.send = () => { throw new Error('connection lost'); };
+    clickPromptJump();
+    if (failure === 'unavailable') receiveTranscriptPage(sent[1], []);
+    if (failure === 'page-error') handleEvent({type: 'error', requestId: sent[1].requestId, text: 'Cursor expired'});
+
+    assert.equal(state.promptJumpTarget, null);
+    assert.equal(state.historyPageLoading, false);
+    assert.equal(elements.promptsDialog.open, true);
+    assert.equal(elements.promptsMore.disabled, false);
+    assert.equal(elements.promptsStatus.textContent, failure === 'unavailable'
+      ? 'This prompt is no longer available in the conversation'
+      : 'Could not load messages for this prompt; try again');
+    renderAcceptedUser({id: 5, text: 'prompt'});
+    clickPromptJump();
+    assert.equal(elements.promptsDialog.open, false);
+    assert.equal(elements.messages.querySelectorAll('.event-row.user')[0].focused, true);
+  }
 }
 
 function testSessionViewSaveAndRestore() {
@@ -1262,6 +1425,12 @@ testPendingMessageRemoval();
 testPendingMessageSurvivesCompletedHistoryReplay();
 testPromptHistoryErrorEmptyAndSessionSwitch();
 testPromptHistoryReloadsAfterPageError();
+testPromptJumpToLoadedMessage();
+testPromptJumpLoadsEarlierPages();
+testPromptJumpToEditedPendingMessage();
+testPromptJumpWaitsForInitialHistory();
+testPromptJumpCancellation();
+testPromptJumpUnavailableAndPageError();
 testReadySessionDisconnectsWhenItBecomesPending()
   .then(testComposerIgnoresReentrantSubmission)
   .then(testPromptHistoryBrowseAndReuse)

--- a/internal/consoleserver/web/app.js
+++ b/internal/consoleserver/web/app.js
@@ -185,6 +185,7 @@
         historyPageLoading: false,
         promptsRequestID: '',
         promptsCursor: '',
+        promptJumpTarget: null,
         historyPageReading: false,
         historyPageCursor: '',
         historyPageEvents: [],
@@ -3286,6 +3287,8 @@ spec:
         elements.messages.prepend(control);
     }
     function cancelOlderHistoryPage() {
+        if (state.promptJumpTarget)
+            stopPromptJump('Could not load messages for this prompt; try again');
         state.historyPageLoading = false;
         state.historyPageReading = false;
         state.historyPageCursor = '';
@@ -3424,6 +3427,7 @@ spec:
         if (state.currentView)
             state.currentView.historyCursor = state.historyCursor;
         replayOlderHistoryPage(events);
+        continuePromptJump();
     }
     function finishHistoryReplay(historyState) {
         const pinToBottom = state.pinHistoryToBottom;
@@ -3442,10 +3446,12 @@ spec:
             scheduleBottomAnchor();
         state.pinHistoryToBottom = false;
         updateCurrentRequest();
+        continuePromptJump();
     }
     function openPromptHistory() {
         if (!state.selected || !state.socket || state.socket.readyState !== WebSocket.OPEN)
             return;
+        state.promptJumpTarget = null;
         state.promptsCursor = '';
         state.promptsRequestID = '';
         elements.promptsTitle.textContent = `Prompt history · ${sessionDisplayName(state.selected)}`;
@@ -3454,13 +3460,57 @@ spec:
         requestPromptHistory();
     }
     function closePromptHistory() {
+        state.promptJumpTarget = null;
         state.promptsRequestID = '';
         state.promptsCursor = '';
         elements.promptsDialog.close();
         elements.promptsList.replaceChildren();
     }
+    function stopPromptJump(message) {
+        state.promptJumpTarget = null;
+        elements.promptsStatus.textContent = message;
+        elements.promptsMore.disabled = false;
+    }
+    function jumpToPrompt(prompt) {
+        state.promptJumpTarget = prompt;
+        state.pinHistoryToBottom = false;
+        elements.promptsStatus.textContent = `Loading messages for prompt ${prompt.id}…`;
+        elements.promptsMore.disabled = true;
+        continuePromptJump();
+    }
+    function continuePromptJump() {
+        const prompt = state.promptJumpTarget;
+        if (!prompt || state.replayingHistory || state.historyPageLoading)
+            return;
+        const row = [...elements.messages.querySelectorAll('.event-row.user')].find(row => row.dataset.eventId === String(prompt.id) || (prompt.turnId && row.dataset.turnId === prompt.turnId));
+        const pending = state.pendingMessage;
+        const target = row || (pending && (pending.event.id === prompt.id || (prompt.turnId && pending.event.turnId === prompt.turnId))
+            ? pending.item : null);
+        if (target) {
+            closePromptHistory();
+            setActiveView('conversation');
+            hideCurrentRequest();
+            if (state.bottomScrollFrame !== null) {
+                window.cancelAnimationFrame(state.bottomScrollFrame);
+                state.bottomScrollFrame = null;
+            }
+            target.tabIndex = -1;
+            target.focus({ preventScroll: true });
+            target.scrollIntoView({ behavior: 'instant', block: 'start' });
+            return;
+        }
+        if (!state.historyCursor) {
+            stopPromptJump('This prompt is no longer available in the conversation');
+            return;
+        }
+        if (!state.socket || state.socket.readyState !== WebSocket.OPEN) {
+            stopPromptJump('Session is disconnected');
+            return;
+        }
+        requestOlderHistory();
+    }
     function requestPromptHistory() {
-        if (state.promptsRequestID || !state.socket || state.socket.readyState !== WebSocket.OPEN)
+        if (state.promptJumpTarget || state.promptsRequestID || !state.socket || state.socket.readyState !== WebSocket.OPEN)
             return;
         state.promptsRequestID = sessionRequestID('prompts');
         elements.promptsStatus.textContent = 'Loading prompts…';
@@ -3479,6 +3529,7 @@ spec:
         state.promptsRequestID = '';
         elements.promptsMore.disabled = false;
         if (event.type === 'error') {
+            state.promptJumpTarget = null;
             state.promptsCursor = '';
             elements.promptsList.replaceChildren();
             elements.promptsStatus.textContent = event.text || 'Could not load prompts';
@@ -3494,6 +3545,12 @@ spec:
             const label = document.createElement('span');
             label.textContent = `Prompt ${prompt.id}${prompt.timestamp ? ` · ${new Date(prompt.timestamp).toLocaleString()}` : ''}`;
             heading.append(label);
+            const jump = document.createElement('button');
+            jump.type = 'button';
+            jump.className = 'secondary-button';
+            jump.textContent = 'Jump to message';
+            jump.addEventListener('click', () => jumpToPrompt(prompt));
+            heading.append(jump);
             const text = document.createElement('pre');
             text.textContent = prompt.text;
             item.append(heading, text);
@@ -3537,6 +3594,10 @@ spec:
         elements.promptsStatus.textContent = !elements.promptsList.hasChildNodes()
             ? 'No retained prompts.'
             : (state.promptsCursor ? '' : 'All retained prompts are loaded.');
+        if (state.promptJumpTarget) {
+            elements.promptsStatus.textContent = `Loading messages for prompt ${state.promptJumpTarget.id}…`;
+            elements.promptsMore.disabled = true;
+        }
     }
     function handleEvent(event) {
         if (event.type === 'prompts' || (event.type === 'error' && event.requestId?.startsWith('prompts-'))) {
@@ -3746,6 +3807,10 @@ spec:
         ensureConversation();
         const row = document.createElement('div');
         row.className = 'event-row user';
+        if (event.id)
+            row.dataset.eventId = String(event.id);
+        if (event.turnId)
+            row.dataset.turnId = event.turnId;
         row.dataset.requestText = event.text || (event.attachments || []).map(attachment => attachment.name).join(', ');
         const message = document.createElement('div');
         message.className = 'user-message';

--- a/internal/consoleserver/web/index.html
+++ b/internal/consoleserver/web/index.html
@@ -249,7 +249,7 @@
     <div class="dialog-header">
       <div>
         <h2 id="prompts-title">Prompt history</h2>
-        <p>Your previous prompts, newest first. Choose <strong>Use text</strong> to add a prompt to your draft.</p>
+        <p>Your previous prompts, newest first. Jump to a message in the conversation or use its text in your draft.</p>
       </div>
       <button class="icon-button" id="prompts-close" type="button" aria-label="Close prompt history">×</button>
     </div>

--- a/internal/sessionruntime/prompts.go
+++ b/internal/sessionruntime/prompts.go
@@ -19,7 +19,7 @@ func (s *Server) loadPrompts(requestID, value string) (Event, error) {
 	page, beforeEventID := historyItemsPage(promptHistoryItems(events), cursor.BeforeEventID, cursor.ItemLimit, cursor.ByteLimit)
 	prompts := make([]Prompt, 0, len(page))
 	for _, event := range page {
-		prompts = append(prompts, Prompt{ID: event.ID, Text: event.Text, Timestamp: event.Timestamp, Attachments: event.Attachments})
+		prompts = append(prompts, Prompt{ID: event.ID, TurnID: event.TurnID, Text: event.Text, Timestamp: event.Timestamp, Attachments: event.Attachments})
 	}
 	nextCursor := ""
 	if beforeEventID > 0 {

--- a/internal/sessionruntime/prompts_test.go
+++ b/internal/sessionruntime/prompts_test.go
@@ -79,7 +79,7 @@ func TestPromptHistoryPreservesLatestTextAndAttachments(t *testing.T) {
 func TestServerReturnsPromptPagesWithoutSubscribing(t *testing.T) {
 	journal := NewJournal()
 	for index := 0; index < DefaultHistoryItemLimit+3; index++ {
-		if err := journal.Append(Event{Type: EventUserMessage, Text: fmt.Sprintf("prompt %d", index)}); err != nil {
+		if err := journal.Append(Event{Type: EventUserMessage, TurnID: fmt.Sprintf("turn-%d", index), Text: fmt.Sprintf("prompt %d", index)}); err != nil {
 			t.Fatal(err)
 		}
 		if err := journal.Append(Event{Type: EventToolCompleted, Output: "tool output"}); err != nil {
@@ -113,7 +113,7 @@ func TestServerReturnsPromptPagesWithoutSubscribing(t *testing.T) {
 			first = 0
 		}
 		for index, prompt := range event.Prompts {
-			if prompt.Text != fmt.Sprintf("prompt %d", first+index) {
+			if prompt.ID != int64((first+index)*2+1) || prompt.TurnID != fmt.Sprintf("turn-%d", first+index) || prompt.Text != fmt.Sprintf("prompt %d", first+index) {
 				t.Fatalf("prompt %d = %#v", index, prompt)
 			}
 		}

--- a/internal/sessionruntime/protocol.go
+++ b/internal/sessionruntime/protocol.go
@@ -68,6 +68,7 @@ type Event struct {
 // Prompt is a retained user submission, with its latest accepted text.
 type Prompt struct {
 	ID          int64        `json:"id"`
+	TurnID      string       `json:"turnId,omitempty"`
 	Text        string       `json:"text"`
 	Timestamp   *time.Time   `json:"timestamp,omitempty"`
 	Attachments []Attachment `json:"attachments,omitempty"`

--- a/test/e2e/session_test.go
+++ b/test/e2e/session_test.go
@@ -153,14 +153,24 @@ var _ = Describe("Session remote control", func() {
 
 		connection := connectSessionWebSocket(webClient, baseURL, f.Namespace, sessionName)
 		DeferCleanup(func() { _ = connection.Close() })
-		sendSessionRequest(connection, sessionruntime.ClientRequest{Type: "subscribe"})
+		sendSessionRequest(connection, sessionruntime.ClientRequest{
+			Type:          "subscribe",
+			HistoryBounds: true,
+			HistoryItems:  sessionruntime.DefaultHistoryItemLimit,
+			HistoryBytes:  sessionruntime.DefaultHistoryByteLimit,
+		})
 		seenFirstTurn := false
 		seenSecondTurn := false
+		retainedPrompts := make(map[int64]string)
 		for {
 			event := readSessionEvent(connection)
+			if event.Type == sessionruntime.EventUserMessage {
+				retainedPrompts[event.ID] = event.Text
+			}
 			seenFirstTurn = seenFirstTurn || strings.Contains(event.Text, "turn 1: terminal-one")
 			seenSecondTurn = seenSecondTurn || strings.Contains(event.Text, "turn 2: terminal-two")
 			if event.Type == sessionruntime.EventHistoryEnd {
+				Expect(event.HistoryState).NotTo(BeNil())
 				break
 			}
 		}
@@ -175,6 +185,10 @@ var _ = Describe("Session remote control", func() {
 		Expect(promptPage.Prompts).To(HaveLen(2))
 		Expect(promptPage.Prompts[0].Text).To(Equal("terminal-one"))
 		Expect(promptPage.Prompts[1].Text).To(Equal("terminal-two"))
+		for _, prompt := range promptPage.Prompts {
+			Expect(retainedPrompts).To(HaveKeyWithValue(prompt.ID, prompt.Text))
+			Expect(prompt.TurnID).NotTo(BeEmpty())
+		}
 
 		By("continuing the terminal conversation through web chat")
 		sendSessionRequest(connection, sessionruntime.ClientRequest{Type: "message", Text: "web"})


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds **Jump to message** to each entry in the console's Prompt history. Selecting it loads earlier transcript pages as needed, closes the dialog, and scrolls to and focuses the matching message. Closing the dialog cancels navigation.

Matches retained messages by event ID and includes the turn ID in prompt responses so queued and edited messages remain navigable. Documents the action and covers loaded messages, pagination, duplicate text, attachments, pending messages, cancellation, and errors.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

- Validation: `make update`, `env -u CODEX_HOME -u CODEX_AUTH_JSON make test TEST_FLAGS=-count=1`, and `make verify`.
- The unit test environment excludes agent-session Codex settings because existing entrypoint tests inherit them.
- Console e2e coverage uses the browser's bounded history subscription, verifies that projected history was returned, and matches prompt IDs and text to projected transcript messages. E2e execution runs in PR CI.

#### Does this PR introduce a user-facing change?

```release-note
The console's Prompt history now lets you jump directly to a message, loading earlier conversation history as needed.
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds "Jump to message" to each entry in the console's Prompt history. Prompt history previously only offered Copy text and Use text; now you can navigate straight to the prompt's message in the conversation, loading earlier transcript pages as needed.

- Selecting the action closes the dialog and scrolls to and focuses the matching message.
- Closing the dialog cancels navigation while messages are loading.
- Prompt responses now include the turn ID, so queued and edited messages stay navigable.
- Updates the documentation and adds coverage for loaded messages, pagination, duplicates, attachments, pending prompts, cancellation, and errors.

<sup>Written for commit 02d164f0c5473da87a2218617e639f87f9682640. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1743?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

