### PR TITLE
Add browser alerts to the console

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -609,6 +609,17 @@ connect to Sessions across namespaces while operating on one active namespace
 at a time. Users can switch the active namespace live from the sidebar.
 `consoleServer.defaultNamespace` sets its initial value, and resource inventory,
 Session form options, and credential options are loaded only from the active namespace.
+Select **Browser alerts: Off** in the sidebar to opt in to browser notifications.
+Alerts cover input requests and completed or failed work in the connected Session
+when you are away from its conversation, including in another console view,
+browser tab, or application. Clicking an alert opens that Session if it is still
+available in the active namespace. Alerts are dismissed when the console detects
+that a Session was removed or replaced. The setting is saved in this browser;
+notifications require browser permission, a secure connection (HTTPS or localhost),
+and support for notifications from an open page. Most mobile browsers do not support
+these page notifications.
+Keep the console tab open and connected: other Sessions and events replayed after
+a reconnect do not produce alerts. Interrupted work does not produce an alert.
 Sessions open in the **Conversation** view. Select the **Terminal** tab alongside
 **Conversation** and **Changes** on a Ready Session to start an interactive shell
 in its agent container. The shell uses the agent container's workspace and

--- a/internal/consoleserver/frontend/app.ts
+++ b/internal/consoleserver/frontend/app.ts
@@ -467,6 +467,8 @@ const elements = requireElements({
   openSidebar: document.querySelector('#open-sidebar'),
   closeSidebar: document.querySelector('#close-sidebar'),
   sidebarScrim: document.querySelector('#sidebar-scrim'),
+  browserAlerts: document.querySelector('#browser-alerts'),
+  browserAlertsStatus: document.querySelector('#browser-alerts-status'),
   toast: document.querySelector('#toast'),
 });
 
@@ -541,6 +543,9 @@ const state = {
   sectionAssignments: new Set<string>(),
   sectionOrders: new Map<string, string[]>(),
   sidebarDrag: null as SidebarDrag | null,
+  browserAlertsEnabled: false,
+  browserAlertsPending: false,
+  browserAlertsUnavailable: '',
 };
 
 const customOption = '__custom__';
@@ -592,6 +597,136 @@ function showToast(message: string) {
   elements.toast.classList.add('show');
   window.clearTimeout(toastTimer);
   toastTimer = window.setTimeout(() => elements.toast.classList.remove('show'), 3200);
+}
+
+const browserAlertsStorageKey = 'kelos-console-browser-alerts';
+const browserNotifications = new Map<string, Notification>();
+
+function browserAlertSupportError() {
+  if (!window.isSecureContext) return 'Browser alerts require HTTPS or localhost.';
+  if (typeof window.Notification !== 'function') return 'This browser does not support browser alerts.';
+  return state.browserAlertsUnavailable;
+}
+
+function renderBrowserAlerts() {
+  const unavailable = browserAlertSupportError();
+  const blocked = !unavailable && Notification.permission === 'denied';
+  const enabled = !unavailable && state.browserAlertsEnabled && Notification.permission === 'granted';
+  elements.browserAlerts.disabled = Boolean(unavailable || blocked || state.browserAlertsPending);
+  elements.browserAlerts.setAttribute('aria-pressed', String(Boolean(enabled)));
+  elements.browserAlerts.textContent = `Browser alerts: ${unavailable ? 'Unavailable' : blocked ? 'Blocked' : state.browserAlertsPending ? 'Enabling…' : enabled ? 'On' : 'Off'}`;
+  elements.browserAlertsStatus.textContent = unavailable || (blocked
+    ? 'Allow notifications in your browser’s site settings to enable alerts.'
+    : 'Notify when the connected Session needs input or finishes while you’re away. Keep this tab open.');
+}
+
+function closeBrowserNotifications() {
+  for (const notification of browserNotifications.values()) notification.close();
+  browserNotifications.clear();
+}
+
+function pruneBrowserNotifications(sessions: SessionSummary[]) {
+  const current = new Set(sessions.map(sessionViewKey));
+  for (const [key, notification] of browserNotifications) {
+    if (current.has(key)) continue;
+    notification.close();
+    browserNotifications.delete(key);
+  }
+}
+
+function loadBrowserAlertPreference() {
+  try {
+    state.browserAlertsEnabled = window.localStorage.getItem(browserAlertsStorageKey) === 'true';
+  } catch (_) {
+    state.browserAlertsEnabled = false;
+  }
+  if (!state.browserAlertsEnabled) closeBrowserNotifications();
+  renderBrowserAlerts();
+}
+
+async function toggleBrowserAlerts() {
+  if (state.browserAlertsPending || browserAlertSupportError()) return;
+  if (state.browserAlertsEnabled && Notification.permission === 'granted') {
+    state.browserAlertsEnabled = false;
+    closeBrowserNotifications();
+  } else {
+    state.browserAlertsPending = true;
+    renderBrowserAlerts();
+    try {
+      const permission = Notification.permission === 'default'
+        ? await Notification.requestPermission()
+        : Notification.permission;
+      state.browserAlertsEnabled = permission === 'granted';
+      if (!state.browserAlertsEnabled) {
+        showToast(permission === 'denied'
+          ? 'Browser alerts are blocked in your browser’s site settings'
+          : 'Browser alerts were not enabled');
+      }
+    } catch (error) {
+      state.browserAlertsEnabled = false;
+      showToast(`Could not enable browser alerts: ${errorMessage(error)}`);
+    } finally {
+      state.browserAlertsPending = false;
+    }
+  }
+  try {
+    window.localStorage.setItem(browserAlertsStorageKey, String(state.browserAlertsEnabled));
+  } catch (_) {
+    showToast('Browser alert preference applies to this tab only because it could not be saved');
+  }
+  renderBrowserAlerts();
+}
+
+function notifySessionEvent(event: ConsoleEvent) {
+  if (!state.selected || state.replayingHistory || (event.id && event.id <= state.lastEventID)) return;
+  let title: string;
+  let body: string;
+  if (event.type === 'input.requested') {
+    title = 'Input needed';
+    body = 'Your Session is waiting for an answer.';
+  } else if (event.type === 'turn.completed' && event.status === 'completed') {
+    title = 'Work completed';
+    body = 'Your Session has finished its work.';
+  } else if (event.type === 'turn.completed' && event.status === 'failed') {
+    title = 'Work failed';
+    body = 'Open the conversation to see the error.';
+  } else {
+    return;
+  }
+  if (!state.browserAlertsEnabled || browserAlertSupportError() || Notification.permission !== 'granted') return;
+  if (document.visibilityState === 'visible' && document.hasFocus()
+      && state.consoleView === 'sessions' && !elements.messages.hidden) return;
+
+  const session = state.selected;
+  const key = sessionViewKey(session);
+  try {
+    browserNotifications.get(key)?.close();
+    const notification = new Notification(`${title} · ${sessionDisplayName(session)}`, {
+      body: `${session.namespace} · ${body}`,
+      tag: `kelos-session-${key}`,
+    });
+    browserNotifications.set(key, notification);
+    notification.addEventListener('close', () => {
+      if (browserNotifications.get(key) === notification) browserNotifications.delete(key);
+    });
+    notification.addEventListener('click', () => {
+      notification.close();
+      window.focus();
+      if (session.namespace !== state.namespace) return;
+      const current = state.sessions.find(item => sessionViewKey(item) === key);
+      if (!current) {
+        showToast(`Session ${session.name} is no longer available`);
+        return;
+      }
+      selectSession(current);
+      setConsoleView('sessions');
+    });
+  } catch (error) {
+    state.browserAlertsUnavailable = 'This browser could not display alerts from the console.';
+    closeBrowserNotifications();
+    renderBrowserAlerts();
+    showToast(`Could not display browser alert: ${errorMessage(error)}`);
+  }
 }
 
 const allResourceKind = '__all__';
@@ -2168,6 +2303,7 @@ async function loadSessions({quiet = false} = {}) {
     const sessions = await api<SessionSummary[]>(`/api/sessions?namespace=${encodeURIComponent(namespace)}`);
     if (generation !== state.namespaceGeneration || listGeneration !== state.sessionListGeneration) return;
     state.sessions = sessions;
+    pruneBrowserNotifications(sessions);
     renderSectionOptions();
     if (state.selected) {
       const selected = state.selected;
@@ -2282,6 +2418,7 @@ function resetNamespaceReferences() {
 async function switchNamespace(namespace) {
   namespace = namespace.trim();
   if (!namespace || namespace === state.namespace) return;
+  closeBrowserNotifications();
   const hadLoadedSource = Boolean(state.loadedSource);
   state.namespace = namespace;
   state.namespaceGeneration += 1;
@@ -3940,6 +4077,7 @@ function handleEvent(event) {
       return;
     }
   }
+  notifySessionEvent(event);
   if (event.id) state.lastEventID = Math.max(state.lastEventID, event.id);
   const recoveredCompletion = state.runtimeRecoveryActive && event.type === 'turn.completed' && event.status === 'interrupted';
   if (state.runtimeRecoveryActive && !isRuntimeRecoveryEvent(event)) state.runtimeRecoveryActive = false;
@@ -5485,6 +5623,7 @@ requiredElement('#refresh-console').addEventListener('click', () => {
   void refreshConsole();
 });
 requiredElement('#logout').addEventListener('click', async () => {
+  closeBrowserNotifications();
   await api<void>('/api/logout', {method: 'POST'}).catch(() => {});
   window.location.replace('/login');
 });
@@ -5519,6 +5658,14 @@ document.addEventListener('keydown', event => {
   }
   if (event.key === 'Escape' && elements.sidebar.classList.contains('open')) setSidebarOpen(false);
 });
+
+elements.browserAlerts.addEventListener('click', toggleBrowserAlerts);
+window.addEventListener('focus', renderBrowserAlerts);
+window.addEventListener('pagehide', closeBrowserNotifications);
+window.addEventListener('storage', event => {
+  if (event.key === browserAlertsStorageKey || event.key === null) loadBrowserAlertPreference();
+});
+loadBrowserAlertPreference();
 
 const configReady = loadConfig();
 configReady.then(() => Promise.all([loadOptions(), loadSessions(), loadResources()])).then(() => {

--- a/internal/consoleserver/server_test.go
+++ b/internal/consoleserver/server_test.go
@@ -1036,6 +1036,17 @@ func TestApplicationConsoleResourcesBehavior(t *testing.T) {
 	}
 }
 
+func TestApplicationBrowserAlertsBehavior(t *testing.T) {
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("Node.js is not installed")
+	}
+	command := exec.Command(node, "testdata/browser_alerts_test.js")
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("running browser alert tests: %v\n%s", err, output)
+	}
+}
+
 func TestApplicationMarkdownBehavior(t *testing.T) {
 	node, err := exec.LookPath("node")
 	if err != nil {

--- a/internal/consoleserver/testdata/browser_alerts_test.js
+++ b/internal/consoleserver/testdata/browser_alerts_test.js
@@ -1,0 +1,353 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const application = fs.readFileSync(path.join(__dirname, '..', 'web', 'app.js'), 'utf8');
+function applicationSlice(start, end) {
+  const startIndex = application.indexOf(start);
+  const endIndex = application.indexOf(end, startIndex);
+  assert.notEqual(startIndex, -1, `${start} not found`);
+  assert.notEqual(endIndex, -1, `${end} not found`);
+  return application.slice(startIndex, endIndex);
+}
+
+vm.runInThisContext(applicationSlice('function errorMessage', 'function requireElements'));
+vm.runInThisContext(applicationSlice('const browserAlertsStorageKey', 'const allResourceKind'));
+vm.runInThisContext(applicationSlice('function sessionKey', 'function moveChildren'));
+vm.runInThisContext(applicationSlice('function handleEvent', 'function renderUser'));
+vm.runInThisContext(applicationSlice('async function loadSessions', 'async function loadConfig'));
+
+let notifications;
+let toasts;
+let permissionRequests;
+let rendered;
+let focused;
+let selected;
+let view;
+let storage;
+
+class TestNotification {
+  static permission = 'granted';
+  static requestPermission = async () => {
+    permissionRequests++;
+    return TestNotification.permission = 'granted';
+  };
+
+  constructor(title, options) {
+    this.title = title;
+    this.options = options;
+    this.listeners = new Map();
+    this.closed = false;
+    notifications.push(this);
+  }
+
+  addEventListener(type, listener) { this.listeners.set(type, listener); }
+  close() { this.closed = true; this.listeners.get('close')?.(); }
+  click() { this.listeners.get('click')?.(); }
+}
+
+function resetHarness() {
+  closeBrowserNotifications();
+  notifications = [];
+  toasts = [];
+  permissionRequests = 0;
+  rendered = [];
+  focused = false;
+  selected = null;
+  view = '';
+  storage = new Map();
+  TestNotification.permission = 'granted';
+  TestNotification.requestPermission = async () => {
+    permissionRequests++;
+    return TestNotification.permission = 'granted';
+  };
+  global.Notification = TestNotification;
+  global.window = {
+    Notification: TestNotification,
+    isSecureContext: true,
+    focus() { focused = true; },
+    localStorage: {
+      getItem: key => storage.get(key) ?? null,
+      setItem: (key, value) => storage.set(key, value),
+    },
+  };
+  global.document = {visibilityState: 'hidden', hasFocus: () => false};
+  global.elements = {
+    browserAlerts: {setAttribute(name, value) { this[name] = value; }},
+    browserAlertsStatus: {},
+    messages: {hidden: false},
+  };
+  const session = {namespace: 'team', name: 'worker', displayName: 'Fix tests', uid: 'session-1'};
+  global.state = {
+    selected: session,
+    sessions: [session],
+    namespace: 'team',
+    namespaceGeneration: 0,
+    sessionListGeneration: 0,
+    consoleView: 'sessions',
+    replayingHistory: false,
+    lastEventID: 0,
+    browserAlertsEnabled: true,
+    browserAlertsPending: false,
+    browserAlertsUnavailable: '',
+  };
+  global.showToast = message => toasts.push(message);
+  global.selectSession = session => { selected = session; };
+  global.setConsoleView = value => { view = value; };
+  global.endAssistantSegment = () => {};
+  global.refreshSessionProgress = () => {};
+  global.renderInputRequest = event => rendered.push(event);
+  global.renderTurnEnd = event => rendered.push(event);
+  global.renderError = event => rendered.push(event);
+  global.finishHistoryReplay = () => { state.replayingHistory = false; };
+  global.renderSectionOptions = () => {};
+  global.renderHeader = () => {};
+  global.renderSessions = () => {};
+  global.discardSessionView = () => {};
+}
+
+async function testPreferenceAndPermission() {
+  resetHarness();
+  loadBrowserAlertPreference();
+  assert.equal(state.browserAlertsEnabled, false, 'Browser permission alone must not opt in');
+  assert.equal(elements.browserAlerts.textContent, 'Browser alerts: Off');
+  assert.equal(permissionRequests, 0);
+
+  TestNotification.permission = 'default';
+  await toggleBrowserAlerts();
+  assert.equal(permissionRequests, 1);
+  assert.equal(state.browserAlertsEnabled, true);
+  assert.equal(storage.get('kelos-console-browser-alerts'), 'true');
+  assert.equal(elements.browserAlerts.textContent, 'Browser alerts: On');
+  assert.equal(elements.browserAlerts['aria-pressed'], 'true');
+
+  state.browserAlertsEnabled = false;
+  loadBrowserAlertPreference();
+  assert.equal(state.browserAlertsEnabled, true);
+  assert.equal(permissionRequests, 1, 'Loading the preference must not request permission');
+
+  handleEvent({id: 1, type: 'input.requested'});
+  await toggleBrowserAlerts();
+  assert.equal(state.browserAlertsEnabled, false);
+  assert.equal(storage.get('kelos-console-browser-alerts'), 'false');
+  assert.equal(notifications[0].closed, true);
+  assert.equal(elements.browserAlerts['aria-pressed'], 'false');
+}
+
+async function testPermissionFailures() {
+  for (const permission of ['default', 'denied']) {
+    resetHarness();
+    state.browserAlertsEnabled = false;
+    TestNotification.permission = 'default';
+    TestNotification.requestPermission = async () => TestNotification.permission = permission;
+    await toggleBrowserAlerts();
+    assert.equal(state.browserAlertsEnabled, false);
+    assert.equal(state.browserAlertsPending, false);
+    assert.equal(elements.browserAlerts.disabled, permission === 'denied');
+    assert.equal(notifications.length, 0);
+    assert.equal(toasts.length, 1);
+  }
+
+  resetHarness();
+  TestNotification.permission = 'default';
+  TestNotification.requestPermission = async () => { throw new Error('Permission unavailable'); };
+  await toggleBrowserAlerts();
+  assert.equal(state.browserAlertsEnabled, false);
+  assert.equal(state.browserAlertsPending, false);
+  assert.deepEqual(toasts, ['Could not enable browser alerts: Permission unavailable']);
+
+  resetHarness();
+  TestNotification.permission = 'default';
+  let resolve;
+  TestNotification.requestPermission = () => {
+    permissionRequests++;
+    return new Promise(done => { resolve = done; });
+  };
+  const pending = toggleBrowserAlerts();
+  assert.equal(elements.browserAlerts.disabled, true);
+  await toggleBrowserAlerts();
+  assert.equal(permissionRequests, 1);
+  TestNotification.permission = 'granted';
+  resolve('granted');
+  await pending;
+  assert.equal(elements.browserAlerts.disabled, false);
+}
+
+function testLiveEventsAndClick() {
+  resetHarness();
+  const input = {id: 1, type: 'input.requested', questions: [{question: 'Private question'}]};
+  handleEvent(input);
+  assert.equal(notifications.length, 1);
+  assert.equal(notifications[0].title, 'Input needed · Fix tests');
+  assert.deepEqual(notifications[0].options, {
+    body: 'team · Your Session is waiting for an answer.',
+    tag: 'kelos-session-team/worker/session-1',
+  });
+  assert.deepEqual(rendered, [input]);
+  handleEvent(input);
+  assert.equal(notifications.length, 1, 'Duplicate events must not notify twice');
+
+  handleEvent({id: 2, type: 'turn.completed', status: 'completed'});
+  assert.equal(notifications[1].title, 'Work completed · Fix tests');
+  assert.equal(notifications[0].closed, true);
+  handleEvent({id: 3, type: 'error', text: 'Private error'});
+  assert.equal(notifications.length, 2);
+  handleEvent({id: 4, type: 'turn.completed', status: 'failed'});
+  assert.equal(notifications[2].title, 'Work failed · Fix tests');
+  assert.equal(notifications[2].options.body, 'team · Open the conversation to see the error.');
+
+  const current = {...state.selected, displayName: 'Renamed'};
+  state.sessions = [current];
+  state.selected = {name: 'another-session', namespace: 'team', uid: 'another-uid'};
+  notifications[2].click();
+  assert.equal(focused, true);
+  assert.equal(notifications[2].closed, true);
+  assert.equal(selected, current);
+  assert.equal(view, 'sessions');
+}
+
+function testHistoryAndIrrelevantEvents() {
+  resetHarness();
+  handleEvent({type: 'history.start'});
+  handleEvent({id: 1, type: 'input.requested'});
+  handleEvent({id: 2, type: 'turn.completed', status: 'failed'});
+  handleEvent({id: 3, type: 'turn.completed', status: 'completed'});
+  handleEvent({type: 'history.end'});
+  handleEvent({id: 3, type: 'turn.completed', status: 'completed'});
+  handleEvent({id: 4, type: 'turn.completed', status: 'interrupted'});
+  handleEvent({id: 5, type: 'turn.completed', status: 'merged'});
+  assert.equal(notifications.length, 0);
+  handleEvent({id: 6, type: 'turn.completed', status: 'completed'});
+  assert.equal(notifications.length, 1);
+
+  state.historyPageReading = true;
+  state.historyPageEvents = [];
+  handleEvent({id: 7, type: 'input.requested'});
+  assert.equal(notifications.length, 1, 'Buffered history must not produce alerts');
+  assert.equal(state.historyPageEvents.length, 1);
+}
+
+function testVisibilityAndAvailability() {
+  const cases = [
+    {setup() { state.browserAlertsEnabled = false; }, expected: 0},
+    {setup() { TestNotification.permission = 'denied'; }, expected: 0},
+    {setup() { TestNotification.permission = 'default'; }, expected: 0},
+    {setup() { state.selected = null; }, expected: 0},
+    {setup() { window.isSecureContext = false; }, expected: 0},
+    {setup() { delete window.Notification; delete global.Notification; }, expected: 0},
+    {setup() { document.visibilityState = 'visible'; document.hasFocus = () => true; }, expected: 0},
+    {setup() { document.visibilityState = 'visible'; }, expected: 1},
+    {setup() { document.visibilityState = 'visible'; document.hasFocus = () => true; state.consoleView = 'resources'; }, expected: 1},
+    {setup() { document.visibilityState = 'visible'; document.hasFocus = () => true; elements.messages.hidden = true; }, expected: 1},
+  ];
+  for (const {setup, expected} of cases) {
+    resetHarness();
+    setup();
+    renderBrowserAlerts();
+    handleEvent({id: 1, type: 'turn.completed', status: 'completed'});
+    assert.equal(notifications.length, expected, setup.toString());
+    assert.equal(rendered.length, 1, 'Conversation rendering must still run');
+    assert.equal(permissionRequests, 0);
+  }
+}
+
+function testStaleNotificationTargets() {
+  for (const change of [
+    () => { state.sessions = []; },
+    () => { state.sessions = [{...state.selected, uid: 'replacement'}]; },
+    () => { state.namespace = 'another-team'; },
+  ]) {
+    resetHarness();
+    handleEvent({id: 1, type: 'input.requested'});
+    change();
+    notifications[0].click();
+    assert.equal(selected, null);
+    assert.equal(view, '');
+    assert.equal(notifications[0].closed, true);
+  }
+}
+
+async function testSessionRefreshClosesStaleNotifications() {
+  for (const selectedSession of [true, false]) {
+    for (const replaced of [true, false]) {
+      resetHarness();
+      const first = state.selected;
+      const second = {...first, name: 'other', uid: 'session-2'};
+      handleEvent({id: 1, type: 'input.requested'});
+      state.selected = second;
+      handleEvent({id: 2, type: 'input.requested'});
+      state.sessions = [first, second];
+      state.selected = selectedSession ? first : second;
+      const sessions = [{...second, displayName: 'Renamed'}];
+      if (replaced) sessions.push({...first, uid: 'replacement'});
+      global.api = async () => sessions;
+
+      await loadSessions();
+
+      assert.equal(notifications[0].closed, true, 'Removed or replaced Session alerts must close');
+      assert.equal(notifications[1].closed, false, 'Alerts for an existing Session must remain');
+      assert.deepEqual(toasts, []);
+      assert.equal(state.sessions, sessions);
+      if (selectedSession) assert.equal(selected, replaced ? sessions[1] : null);
+
+      global.api = async () => [];
+      await loadSessions();
+      assert.equal(notifications[1].closed, true);
+    }
+  }
+}
+
+async function testSessionRefreshKeepsAlertsOnFailedOrStaleResponses() {
+  for (const response of ['failed', 'namespace-changed', 'superseded']) {
+    resetHarness();
+    handleEvent({id: 1, type: 'input.requested'});
+    global.api = async () => {
+      if (response === 'failed') throw new Error('List unavailable');
+      if (response === 'namespace-changed') state.namespaceGeneration++;
+      if (response === 'superseded') state.sessionListGeneration++;
+      return [];
+    };
+
+    await loadSessions({quiet: true});
+
+    assert.equal(notifications[0].closed, false, response);
+    assert.equal(state.sessions.length, 1);
+    assert.deepEqual(toasts, []);
+  }
+}
+
+async function testUnavailableStorageAndNotification() {
+  resetHarness();
+  window.localStorage.getItem = () => { throw new Error('Storage blocked'); };
+  window.localStorage.setItem = () => { throw new Error('Storage blocked'); };
+  loadBrowserAlertPreference();
+  assert.equal(state.browserAlertsEnabled, false);
+  await toggleBrowserAlerts();
+  assert.equal(state.browserAlertsEnabled, true);
+  assert.deepEqual(toasts, ['Browser alert preference applies to this tab only because it could not be saved']);
+
+  global.Notification = window.Notification = class extends TestNotification {
+    constructor() { throw new TypeError('Page notifications unavailable'); }
+  };
+  handleEvent({id: 1, type: 'turn.completed', status: 'completed'});
+  assert.equal(rendered.length, 1, 'Notification failures must not break the conversation');
+  assert.equal(elements.browserAlerts.textContent, 'Browser alerts: Unavailable');
+  assert.equal(elements.browserAlerts.disabled, true);
+  assert.equal(toasts.at(-1), 'Could not display browser alert: Page notifications unavailable');
+}
+
+(async () => {
+  await testPreferenceAndPermission();
+  await testPermissionFailures();
+  testLiveEventsAndClick();
+  testHistoryAndIrrelevantEvents();
+  testVisibilityAndAvailability();
+  testStaleNotificationTargets();
+  await testSessionRefreshClosesStaleNotifications();
+  await testSessionRefreshKeepsAlertsOnFailedOrStaleResponses();
+  await testUnavailableStorageAndNotification();
+})().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/internal/consoleserver/testdata/session_history_test.js
+++ b/internal/consoleserver/testdata/session_history_test.js
@@ -308,6 +308,8 @@ global.resolveInputCard = () => {};
 global.scrollToBottom = () => {};
 global.interruptActiveTurn = () => { interruptRequests++; };
 global.showToast = (message) => { toasts.push(message); };
+global.notifySessionEvent = () => {};
+global.pruneBrowserNotifications = () => {};
 global.closeSessionSectionEditor = () => {};
 
 const application = fs.readFileSync(path.join(__dirname, '..', 'web', 'app.js'), 'utf8');

--- a/internal/consoleserver/web/app.js
+++ b/internal/consoleserver/web/app.js
@@ -149,6 +149,8 @@
         openSidebar: document.querySelector('#open-sidebar'),
         closeSidebar: document.querySelector('#close-sidebar'),
         sidebarScrim: document.querySelector('#sidebar-scrim'),
+        browserAlerts: document.querySelector('#browser-alerts'),
+        browserAlertsStatus: document.querySelector('#browser-alerts-status'),
         toast: document.querySelector('#toast'),
     });
     const state = {
@@ -222,6 +224,9 @@
         sectionAssignments: new Set(),
         sectionOrders: new Map(),
         sidebarDrag: null,
+        browserAlertsEnabled: false,
+        browserAlertsPending: false,
+        browserAlertsUnavailable: '',
     };
     const customOption = '__custom__';
     const maxCachedSessionViews = 5;
@@ -270,6 +275,147 @@
         elements.toast.classList.add('show');
         window.clearTimeout(toastTimer);
         toastTimer = window.setTimeout(() => elements.toast.classList.remove('show'), 3200);
+    }
+    const browserAlertsStorageKey = 'kelos-console-browser-alerts';
+    const browserNotifications = new Map();
+    function browserAlertSupportError() {
+        if (!window.isSecureContext)
+            return 'Browser alerts require HTTPS or localhost.';
+        if (typeof window.Notification !== 'function')
+            return 'This browser does not support browser alerts.';
+        return state.browserAlertsUnavailable;
+    }
+    function renderBrowserAlerts() {
+        const unavailable = browserAlertSupportError();
+        const blocked = !unavailable && Notification.permission === 'denied';
+        const enabled = !unavailable && state.browserAlertsEnabled && Notification.permission === 'granted';
+        elements.browserAlerts.disabled = Boolean(unavailable || blocked || state.browserAlertsPending);
+        elements.browserAlerts.setAttribute('aria-pressed', String(Boolean(enabled)));
+        elements.browserAlerts.textContent = `Browser alerts: ${unavailable ? 'Unavailable' : blocked ? 'Blocked' : state.browserAlertsPending ? 'Enabling…' : enabled ? 'On' : 'Off'}`;
+        elements.browserAlertsStatus.textContent = unavailable || (blocked
+            ? 'Allow notifications in your browser’s site settings to enable alerts.'
+            : 'Notify when the connected Session needs input or finishes while you’re away. Keep this tab open.');
+    }
+    function closeBrowserNotifications() {
+        for (const notification of browserNotifications.values())
+            notification.close();
+        browserNotifications.clear();
+    }
+    function pruneBrowserNotifications(sessions) {
+        const current = new Set(sessions.map(sessionViewKey));
+        for (const [key, notification] of browserNotifications) {
+            if (current.has(key))
+                continue;
+            notification.close();
+            browserNotifications.delete(key);
+        }
+    }
+    function loadBrowserAlertPreference() {
+        try {
+            state.browserAlertsEnabled = window.localStorage.getItem(browserAlertsStorageKey) === 'true';
+        }
+        catch (_) {
+            state.browserAlertsEnabled = false;
+        }
+        if (!state.browserAlertsEnabled)
+            closeBrowserNotifications();
+        renderBrowserAlerts();
+    }
+    async function toggleBrowserAlerts() {
+        if (state.browserAlertsPending || browserAlertSupportError())
+            return;
+        if (state.browserAlertsEnabled && Notification.permission === 'granted') {
+            state.browserAlertsEnabled = false;
+            closeBrowserNotifications();
+        }
+        else {
+            state.browserAlertsPending = true;
+            renderBrowserAlerts();
+            try {
+                const permission = Notification.permission === 'default'
+                    ? await Notification.requestPermission()
+                    : Notification.permission;
+                state.browserAlertsEnabled = permission === 'granted';
+                if (!state.browserAlertsEnabled) {
+                    showToast(permission === 'denied'
+                        ? 'Browser alerts are blocked in your browser’s site settings'
+                        : 'Browser alerts were not enabled');
+                }
+            }
+            catch (error) {
+                state.browserAlertsEnabled = false;
+                showToast(`Could not enable browser alerts: ${errorMessage(error)}`);
+            }
+            finally {
+                state.browserAlertsPending = false;
+            }
+        }
+        try {
+            window.localStorage.setItem(browserAlertsStorageKey, String(state.browserAlertsEnabled));
+        }
+        catch (_) {
+            showToast('Browser alert preference applies to this tab only because it could not be saved');
+        }
+        renderBrowserAlerts();
+    }
+    function notifySessionEvent(event) {
+        if (!state.selected || state.replayingHistory || (event.id && event.id <= state.lastEventID))
+            return;
+        let title;
+        let body;
+        if (event.type === 'input.requested') {
+            title = 'Input needed';
+            body = 'Your Session is waiting for an answer.';
+        }
+        else if (event.type === 'turn.completed' && event.status === 'completed') {
+            title = 'Work completed';
+            body = 'Your Session has finished its work.';
+        }
+        else if (event.type === 'turn.completed' && event.status === 'failed') {
+            title = 'Work failed';
+            body = 'Open the conversation to see the error.';
+        }
+        else {
+            return;
+        }
+        if (!state.browserAlertsEnabled || browserAlertSupportError() || Notification.permission !== 'granted')
+            return;
+        if (document.visibilityState === 'visible' && document.hasFocus()
+            && state.consoleView === 'sessions' && !elements.messages.hidden)
+            return;
+        const session = state.selected;
+        const key = sessionViewKey(session);
+        try {
+            browserNotifications.get(key)?.close();
+            const notification = new Notification(`${title} · ${sessionDisplayName(session)}`, {
+                body: `${session.namespace} · ${body}`,
+                tag: `kelos-session-${key}`,
+            });
+            browserNotifications.set(key, notification);
+            notification.addEventListener('close', () => {
+                if (browserNotifications.get(key) === notification)
+                    browserNotifications.delete(key);
+            });
+            notification.addEventListener('click', () => {
+                notification.close();
+                window.focus();
+                if (session.namespace !== state.namespace)
+                    return;
+                const current = state.sessions.find(item => sessionViewKey(item) === key);
+                if (!current) {
+                    showToast(`Session ${session.name} is no longer available`);
+                    return;
+                }
+                selectSession(current);
+                setConsoleView('sessions');
+            });
+        }
+        catch (error) {
+            state.browserAlertsUnavailable = 'This browser could not display alerts from the console.';
+            closeBrowserNotifications();
+            renderBrowserAlerts();
+            showToast(`Could not display browser alert: ${errorMessage(error)}`);
+        }
     }
     const allResourceKind = '__all__';
     const resourceDescriptions = {
@@ -1842,6 +1988,7 @@
             if (generation !== state.namespaceGeneration || listGeneration !== state.sessionListGeneration)
                 return;
             state.sessions = sessions;
+            pruneBrowserNotifications(sessions);
             renderSectionOptions();
             if (state.selected) {
                 const selected = state.selected;
@@ -1961,6 +2108,7 @@ spec:
         namespace = namespace.trim();
         if (!namespace || namespace === state.namespace)
             return;
+        closeBrowserNotifications();
         const hadLoadedSource = Boolean(state.loadedSource);
         state.namespace = namespace;
         state.namespaceGeneration += 1;
@@ -3620,6 +3768,7 @@ spec:
                 return;
             }
         }
+        notifySessionEvent(event);
         if (event.id)
             state.lastEventID = Math.max(state.lastEventID, event.id);
         const recoveredCompletion = state.runtimeRecoveryActive && event.type === 'turn.completed' && event.status === 'interrupted';
@@ -5194,6 +5343,7 @@ spec:
         void refreshConsole();
     });
     requiredElement('#logout').addEventListener('click', async () => {
+        closeBrowserNotifications();
         await api('/api/logout', { method: 'POST' }).catch(() => { });
         window.location.replace('/login');
     });
@@ -5230,6 +5380,14 @@ spec:
         if (event.key === 'Escape' && elements.sidebar.classList.contains('open'))
             setSidebarOpen(false);
     });
+    elements.browserAlerts.addEventListener('click', toggleBrowserAlerts);
+    window.addEventListener('focus', renderBrowserAlerts);
+    window.addEventListener('pagehide', closeBrowserNotifications);
+    window.addEventListener('storage', event => {
+        if (event.key === browserAlertsStorageKey || event.key === null)
+            loadBrowserAlertPreference();
+    });
+    loadBrowserAlertPreference();
     const configReady = loadConfig();
     configReady.then(() => Promise.all([loadOptions(), loadSessions(), loadResources()])).then(() => {
         setConsoleView('overview');

--- a/internal/consoleserver/web/index.html
+++ b/internal/consoleserver/web/index.html
@@ -43,6 +43,10 @@
           <div class="session-list" id="session-list" aria-live="polite"></div>
         </div>
       </div>
+      <div class="browser-alert-settings">
+        <button class="quiet-button" id="browser-alerts" type="button" aria-pressed="false" aria-describedby="browser-alerts-status">Browser alerts: Off</button>
+        <small id="browser-alerts-status"></small>
+      </div>
       <div class="sidebar-footer">
         <button class="quiet-button" id="refresh-console">Refresh</button>
         <button class="quiet-button" id="logout">Sign out</button>

--- a/internal/consoleserver/web/styles.css
+++ b/internal/consoleserver/web/styles.css
@@ -120,6 +120,10 @@ button { color: inherit; }
 .session-model { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .sidebar-empty { padding: 14px 10px; color: var(--faint); font-size: 12px; line-height: 1.5; }
 .sidebar-footer { display: flex; justify-content: space-between; gap: 8px; margin-top: auto; padding: 7px 3px 0; border-top: 1px solid var(--line); }
+.browser-alert-settings { flex: none; padding: 7px 3px; border-top: 1px solid var(--line); }
+.browser-alert-settings button { width: 100%; text-align: left; }
+.browser-alert-settings button:disabled { cursor: default; color: var(--faint); }
+.browser-alert-settings small { display: block; padding: 0 8px 5px; color: var(--muted); font-size: 10px; line-height: 1.5; }
 .sidebar-scrim { display: none; }
 .quiet-button { min-height: 36px; padding: 7px 8px; border: 0; border-radius: 8px; background: none; color: var(--muted); font-size: 12px; font-weight: 500; cursor: pointer; }
 .quiet-button:hover { background: var(--line-soft); color: var(--ink); }
@@ -550,7 +554,7 @@ button { color: inherit; }
   .session-item-meta, .session-item-branch { margin-top: 2px; }
   .session-item-pull-request { margin-bottom: 6px; }
   .sidebar-footer { padding: 5px 3px 0; }
-  .sidebar-footer .quiet-button { min-height: 44px; }
+  .sidebar-footer .quiet-button, .browser-alert-settings .quiet-button { min-height: 44px; }
   .console-page { height: 100%; height: 100dvh; }
   .console-page-header { min-height: calc(58px + env(safe-area-inset-top)); padding: calc(7px + env(safe-area-inset-top)) calc(10px + env(safe-area-inset-right)) 7px calc(10px + env(safe-area-inset-left)); }
   .console-page-header h1 { font-size: 18px; }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Users currently need to watch a Session's conversation to notice when it needs input or finishes. Add an opt-in **Browser alerts** control in the sidebar that sends notifications for input requests and completed or failed work while the user is away from the connected Session's conversation. Clicking a notification opens that Session if it is still available in the active namespace.

The console saves the preference, requests notification permission only when the user enables alerts, and suppresses duplicate events, history replay, and interrupted work. Notification bodies use generic status text without including questions or error contents. Session refreshes dismiss alerts for deleted or replaced Sessions while preserving alerts for existing Sessions. The toggle follows the console's 44px mobile touch-target convention.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

Alerts cover the connected Session while the console tab remains open. They require HTTPS or localhost and a browser that supports notifications from an open page; most mobile browsers do not support these notifications.

Validation:

- `make update`
- `make verify`
- `env -u CODEX_HOME -u CODEX_AUTH_JSON make test`

Unit tests run with `CODEX_HOME` and `CODEX_AUTH_JSON` unset to isolate entrypoint fixtures from the agent environment. Tests exercise notification permissions, persistence, event filtering, click targets, failure handling, and cleanup of deleted or replaced Session alerts with a mocked browser API. Failed or stale Session refreshes preserve existing alerts.

#### Does this PR introduce a user-facing change?

```release-note
Kelos Console now offers opt-in browser alerts for input requests and completed or failed work in the connected Session while the console tab remains open.
```
