### PR TITLE
Reduce dev task TTL to one day and fix integration fixture race

### DIFF
--- a/self-development/agora/agora-claude-reviewer.yaml
+++ b/self-development/agora/agora-claude-reviewer.yaml
@@ -86,7 +86,7 @@ spec:
       agentConfigRefs:
         - name: base-agent
         - name: agora-claude-reviewer-agent
-    ttlSecondsAfterFinished: 864000
+    ttlSecondsAfterFinished: 86400
     podFailurePolicy:
       rules:
         - action: Ignore

--- a/self-development/agora/agora-config-update.yaml
+++ b/self-development/agora/agora-config-update.yaml
@@ -41,7 +41,7 @@ spec:
       agentConfigRefs:
         - name: base-agent
         - name: kelos-dev-agent
-    ttlSecondsAfterFinished: 864000
+    ttlSecondsAfterFinished: 86400
     podFailurePolicy:
       rules:
         - action: Ignore

--- a/self-development/agora/agora-fake-strategist.yaml
+++ b/self-development/agora/agora-fake-strategist.yaml
@@ -59,7 +59,7 @@ spec:
       agentConfigRefs:
         - name: base-agent
         - name: agora-fake-strategist-agent
-    ttlSecondsAfterFinished: 864000
+    ttlSecondsAfterFinished: 86400
     podFailurePolicy:
       rules:
         - action: Ignore

--- a/self-development/agora/agora-fake-user.yaml
+++ b/self-development/agora/agora-fake-user.yaml
@@ -59,7 +59,7 @@ spec:
       agentConfigRefs:
         - name: base-agent
         - name: agora-fake-user-agent
-    ttlSecondsAfterFinished: 864000
+    ttlSecondsAfterFinished: 86400
     podFailurePolicy:
       rules:
         - action: Ignore

--- a/self-development/agora/agora-planner.yaml
+++ b/self-development/agora/agora-planner.yaml
@@ -67,7 +67,7 @@ spec:
       agentConfigRefs:
         - name: base-agent
         - name: agora-planner-agent
-    ttlSecondsAfterFinished: 864000
+    ttlSecondsAfterFinished: 86400
     podFailurePolicy:
       rules:
         - action: Ignore

--- a/self-development/agora/agora-reviewer.yaml
+++ b/self-development/agora/agora-reviewer.yaml
@@ -86,7 +86,7 @@ spec:
       agentConfigRefs:
         - name: base-agent
         - name: agora-reviewer-agent
-    ttlSecondsAfterFinished: 864000
+    ttlSecondsAfterFinished: 86400
     podFailurePolicy:
       rules:
         - action: Ignore

--- a/self-development/agora/agora-self-update.yaml
+++ b/self-development/agora/agora-self-update.yaml
@@ -32,7 +32,7 @@ spec:
       agentConfigRefs:
         - name: base-agent
         - name: kelos-dev-agent
-    ttlSecondsAfterFinished: 864000
+    ttlSecondsAfterFinished: 86400
     podFailurePolicy:
       rules:
         - action: Ignore

--- a/self-development/agora/agora-squash-commits.yaml
+++ b/self-development/agora/agora-squash-commits.yaml
@@ -59,7 +59,7 @@ spec:
       agentConfigRefs:
         - name: base-agent
         - name: agora-dev-agent
-    ttlSecondsAfterFinished: 864000
+    ttlSecondsAfterFinished: 86400
     podFailurePolicy:
       rules:
         - action: Ignore

--- a/self-development/agora/agora-triage.yaml
+++ b/self-development/agora/agora-triage.yaml
@@ -49,7 +49,7 @@ spec:
       agentConfigRefs:
         - name: base-agent
         - name: agora-dev-agent
-    ttlSecondsAfterFinished: 864000
+    ttlSecondsAfterFinished: 86400
     podFailurePolicy:
       rules:
         - action: Ignore

--- a/self-development/kanon/kanon-claude-reviewer.yaml
+++ b/self-development/kanon/kanon-claude-reviewer.yaml
@@ -85,7 +85,7 @@ spec:
       agentConfigRefs:
         - name: base-agent
         - name: kanon-claude-reviewer-agent
-    ttlSecondsAfterFinished: 864000
+    ttlSecondsAfterFinished: 86400
     podFailurePolicy:
       rules:
         - action: Ignore

--- a/self-development/kanon/kanon-config-update.yaml
+++ b/self-development/kanon/kanon-config-update.yaml
@@ -41,7 +41,7 @@ spec:
       agentConfigRefs:
         - name: base-agent
         - name: kelos-dev-agent
-    ttlSecondsAfterFinished: 864000
+    ttlSecondsAfterFinished: 86400
     podFailurePolicy:
       rules:
         - action: Ignore

--- a/self-development/kanon/kanon-fake-strategist.yaml
+++ b/self-development/kanon/kanon-fake-strategist.yaml
@@ -57,7 +57,7 @@ spec:
       agentConfigRefs:
         - name: base-agent
         - name: kanon-fake-strategist-agent
-    ttlSecondsAfterFinished: 864000
+    ttlSecondsAfterFinished: 86400
     podFailurePolicy:
       rules:
         - action: Ignore

--- a/self-development/kanon/kanon-fake-user.yaml
+++ b/self-development/kanon/kanon-fake-user.yaml
@@ -57,7 +57,7 @@ spec:
       agentConfigRefs:
         - name: base-agent
         - name: kanon-fake-user-agent
-    ttlSecondsAfterFinished: 864000
+    ttlSecondsAfterFinished: 86400
     podFailurePolicy:
       rules:
         - action: Ignore

--- a/self-development/kanon/kanon-planner.yaml
+++ b/self-development/kanon/kanon-planner.yaml
@@ -66,7 +66,7 @@ spec:
       agentConfigRefs:
         - name: base-agent
         - name: kanon-planner-agent
-    ttlSecondsAfterFinished: 864000
+    ttlSecondsAfterFinished: 86400
     podFailurePolicy:
       rules:
         - action: Ignore

--- a/self-development/kanon/kanon-reviewer.yaml
+++ b/self-development/kanon/kanon-reviewer.yaml
@@ -85,7 +85,7 @@ spec:
       agentConfigRefs:
         - name: base-agent
         - name: kanon-reviewer-agent
-    ttlSecondsAfterFinished: 864000
+    ttlSecondsAfterFinished: 86400
     podFailurePolicy:
       rules:
         - action: Ignore

--- a/self-development/kanon/kanon-self-update.yaml
+++ b/self-development/kanon/kanon-self-update.yaml
@@ -32,7 +32,7 @@ spec:
       agentConfigRefs:
         - name: base-agent
         - name: kelos-dev-agent
-    ttlSecondsAfterFinished: 864000
+    ttlSecondsAfterFinished: 86400
     podFailurePolicy:
       rules:
         - action: Ignore

--- a/self-development/kanon/kanon-squash-commits.yaml
+++ b/self-development/kanon/kanon-squash-commits.yaml
@@ -59,7 +59,7 @@ spec:
       agentConfigRefs:
         - name: base-agent
         - name: kanon-dev-agent
-    ttlSecondsAfterFinished: 864000
+    ttlSecondsAfterFinished: 86400
     podFailurePolicy:
       rules:
         - action: Ignore

--- a/self-development/kanon/kanon-triage.yaml
+++ b/self-development/kanon/kanon-triage.yaml
@@ -49,7 +49,7 @@ spec:
       agentConfigRefs:
         - name: base-agent
         - name: kanon-dev-agent
-    ttlSecondsAfterFinished: 864000
+    ttlSecondsAfterFinished: 86400
     podFailurePolicy:
       rules:
         - action: Ignore

--- a/self-development/kelos-api-reviewer.yaml
+++ b/self-development/kelos-api-reviewer.yaml
@@ -87,7 +87,7 @@ spec:
       agentConfigRefs:
         - name: base-agent
         - name: kelos-api-reviewer-agent
-    ttlSecondsAfterFinished: 864000
+    ttlSecondsAfterFinished: 86400
     podFailurePolicy:
       rules:
         - action: Ignore

--- a/self-development/kelos-claude-api-reviewer.yaml
+++ b/self-development/kelos-claude-api-reviewer.yaml
@@ -90,7 +90,7 @@ spec:
       agentConfigRefs:
         - name: base-agent
         - name: kelos-claude-api-reviewer-agent
-    ttlSecondsAfterFinished: 864000
+    ttlSecondsAfterFinished: 86400
     podFailurePolicy:
       rules:
         - action: Ignore

--- a/self-development/kelos-claude-reviewer.yaml
+++ b/self-development/kelos-claude-reviewer.yaml
@@ -91,7 +91,7 @@ spec:
       agentConfigRefs:
         - name: base-agent
         - name: kelos-claude-reviewer-agent
-    ttlSecondsAfterFinished: 864000
+    ttlSecondsAfterFinished: 86400
     podFailurePolicy:
       rules:
         - action: Ignore

--- a/self-development/kelos-config-update.yaml
+++ b/self-development/kelos-config-update.yaml
@@ -38,7 +38,7 @@ spec:
       agentConfigRefs:
         - name: base-agent
         - name: kelos-dev-agent
-    ttlSecondsAfterFinished: 864000
+    ttlSecondsAfterFinished: 86400
     podFailurePolicy:
       rules:
         - action: Ignore

--- a/self-development/kelos-fake-strategist.yaml
+++ b/self-development/kelos-fake-strategist.yaml
@@ -61,7 +61,7 @@ spec:
       agentConfigRefs:
         - name: base-agent
         - name: kelos-fake-strategist-agent
-    ttlSecondsAfterFinished: 864000
+    ttlSecondsAfterFinished: 86400
     podFailurePolicy:
       rules:
         - action: Ignore

--- a/self-development/kelos-fake-user.yaml
+++ b/self-development/kelos-fake-user.yaml
@@ -61,7 +61,7 @@ spec:
       agentConfigRefs:
         - name: base-agent
         - name: kelos-fake-user-agent
-    ttlSecondsAfterFinished: 864000
+    ttlSecondsAfterFinished: 86400
     podFailurePolicy:
       rules:
         - action: Ignore

--- a/self-development/kelos-image-update.yaml
+++ b/self-development/kelos-image-update.yaml
@@ -59,7 +59,7 @@ spec:
       agentConfigRefs:
         - name: base-agent
         - name: kelos-image-update-agent
-    ttlSecondsAfterFinished: 864000
+    ttlSecondsAfterFinished: 86400
     podFailurePolicy:
       rules:
         - action: Ignore

--- a/self-development/kelos-planner.yaml
+++ b/self-development/kelos-planner.yaml
@@ -66,7 +66,7 @@ spec:
       agentConfigRefs:
         - name: base-agent
         - name: kelos-planner-agent
-    ttlSecondsAfterFinished: 864000
+    ttlSecondsAfterFinished: 86400
     podFailurePolicy:
       rules:
         - action: Ignore

--- a/self-development/kelos-reviewer.yaml
+++ b/self-development/kelos-reviewer.yaml
@@ -88,7 +88,7 @@ spec:
       agentConfigRefs:
         - name: base-agent
         - name: kelos-reviewer-agent
-    ttlSecondsAfterFinished: 864000
+    ttlSecondsAfterFinished: 86400
     podFailurePolicy:
       rules:
         - action: Ignore

--- a/self-development/kelos-self-update.yaml
+++ b/self-development/kelos-self-update.yaml
@@ -61,7 +61,7 @@ spec:
       agentConfigRefs:
         - name: base-agent
         - name: kelos-self-update-agent
-    ttlSecondsAfterFinished: 864000
+    ttlSecondsAfterFinished: 86400
     podFailurePolicy:
       rules:
         - action: Ignore

--- a/self-development/kelos-squash-commits.yaml
+++ b/self-development/kelos-squash-commits.yaml
@@ -59,7 +59,7 @@ spec:
       agentConfigRefs:
         - name: base-agent
         - name: kelos-dev-agent
-    ttlSecondsAfterFinished: 864000
+    ttlSecondsAfterFinished: 86400
     podFailurePolicy:
       rules:
         - action: Ignore

--- a/self-development/kelos-triage.yaml
+++ b/self-development/kelos-triage.yaml
@@ -49,7 +49,7 @@ spec:
       agentConfigRefs:
         - name: base-agent
         - name: kelos-dev-agent
-    ttlSecondsAfterFinished: 864000
+    ttlSecondsAfterFinished: 86400
     podFailurePolicy:
       rules:
         - action: Ignore

--- a/self-development/open-actions/open-actions-api-reviewer.yaml
+++ b/self-development/open-actions/open-actions-api-reviewer.yaml
@@ -87,7 +87,7 @@ spec:
       agentConfigRefs:
         - name: base-agent
         - name: open-actions-api-reviewer-agent
-    ttlSecondsAfterFinished: 864000
+    ttlSecondsAfterFinished: 86400
     podFailurePolicy:
       rules:
         - action: Ignore

--- a/self-development/open-actions/open-actions-claude-api-reviewer.yaml
+++ b/self-development/open-actions/open-actions-claude-api-reviewer.yaml
@@ -87,7 +87,7 @@ spec:
       agentConfigRefs:
         - name: base-agent
         - name: open-actions-claude-api-reviewer-agent
-    ttlSecondsAfterFinished: 864000
+    ttlSecondsAfterFinished: 86400
     podFailurePolicy:
       rules:
         - action: Ignore

--- a/self-development/open-actions/open-actions-claude-reviewer.yaml
+++ b/self-development/open-actions/open-actions-claude-reviewer.yaml
@@ -89,7 +89,7 @@ spec:
       agentConfigRefs:
         - name: base-agent
         - name: open-actions-claude-reviewer-agent
-    ttlSecondsAfterFinished: 864000
+    ttlSecondsAfterFinished: 86400
     podFailurePolicy:
       rules:
         - action: Ignore

--- a/self-development/open-actions/open-actions-config-update.yaml
+++ b/self-development/open-actions/open-actions-config-update.yaml
@@ -41,7 +41,7 @@ spec:
       agentConfigRefs:
         - name: base-agent
         - name: kelos-dev-agent
-    ttlSecondsAfterFinished: 864000
+    ttlSecondsAfterFinished: 86400
     podFailurePolicy:
       rules:
         - action: Ignore

--- a/self-development/open-actions/open-actions-fake-strategist.yaml
+++ b/self-development/open-actions/open-actions-fake-strategist.yaml
@@ -57,7 +57,7 @@ spec:
       agentConfigRefs:
         - name: base-agent
         - name: open-actions-fake-strategist-agent
-    ttlSecondsAfterFinished: 864000
+    ttlSecondsAfterFinished: 86400
     podFailurePolicy:
       rules:
         - action: Ignore

--- a/self-development/open-actions/open-actions-fake-user.yaml
+++ b/self-development/open-actions/open-actions-fake-user.yaml
@@ -57,7 +57,7 @@ spec:
       agentConfigRefs:
         - name: base-agent
         - name: open-actions-fake-user-agent
-    ttlSecondsAfterFinished: 864000
+    ttlSecondsAfterFinished: 86400
     podFailurePolicy:
       rules:
         - action: Ignore

--- a/self-development/open-actions/open-actions-planner.yaml
+++ b/self-development/open-actions/open-actions-planner.yaml
@@ -66,7 +66,7 @@ spec:
       agentConfigRefs:
         - name: base-agent
         - name: open-actions-planner-agent
-    ttlSecondsAfterFinished: 864000
+    ttlSecondsAfterFinished: 86400
     podFailurePolicy:
       rules:
         - action: Ignore

--- a/self-development/open-actions/open-actions-reviewer.yaml
+++ b/self-development/open-actions/open-actions-reviewer.yaml
@@ -89,7 +89,7 @@ spec:
       agentConfigRefs:
         - name: base-agent
         - name: open-actions-reviewer-agent
-    ttlSecondsAfterFinished: 864000
+    ttlSecondsAfterFinished: 86400
     podFailurePolicy:
       rules:
         - action: Ignore

--- a/self-development/open-actions/open-actions-self-update.yaml
+++ b/self-development/open-actions/open-actions-self-update.yaml
@@ -32,7 +32,7 @@ spec:
       agentConfigRefs:
         - name: base-agent
         - name: kelos-dev-agent
-    ttlSecondsAfterFinished: 864000
+    ttlSecondsAfterFinished: 86400
     podFailurePolicy:
       rules:
         - action: Ignore

--- a/self-development/open-actions/open-actions-squash-commits.yaml
+++ b/self-development/open-actions/open-actions-squash-commits.yaml
@@ -59,7 +59,7 @@ spec:
       agentConfigRefs:
         - name: base-agent
         - name: open-actions-dev-agent
-    ttlSecondsAfterFinished: 864000
+    ttlSecondsAfterFinished: 86400
     podFailurePolicy:
       rules:
         - action: Ignore

--- a/self-development/open-actions/open-actions-triage.yaml
+++ b/self-development/open-actions/open-actions-triage.yaml
@@ -49,7 +49,7 @@ spec:
       agentConfigRefs:
         - name: base-agent
         - name: open-actions-dev-agent
-    ttlSecondsAfterFinished: 864000
+    ttlSecondsAfterFinished: 86400
     podFailurePolicy:
       rules:
         - action: Ignore

--- a/self-development/tasks/fake-strategist-task.yaml
+++ b/self-development/tasks/fake-strategist-task.yaml
@@ -26,7 +26,7 @@ spec:
           ephemeral-storage: "10Gi"
         limits:
           ephemeral-storage: "10Gi"
-  ttlSecondsAfterFinished: 864000
+  ttlSecondsAfterFinished: 86400
   podFailurePolicy:
     rules:
       - action: Ignore

--- a/test/integration/install/install_test.go
+++ b/test/integration/install/install_test.go
@@ -183,9 +183,14 @@ func startKelosWebhookReadinessFixture() {
 	ensureKelosWebhookFixtureState()
 
 	fixtureCtx, stop := context.WithCancel(ctx)
-	DeferCleanup(stop)
+	done := make(chan struct{})
+	DeferCleanup(func() {
+		stop()
+		<-done
+	})
 
 	go func() {
+		defer close(done)
 		ticker := time.NewTicker(100 * time.Millisecond)
 		defer ticker.Stop()
 		for {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Finished tasks in the dev cluster are configured to remain for 10 days. Reduce `ttlSecondsAfterFinished` from `864000` to `86400` (one day) across all 42 self-development TaskSpawner and Task manifests for Kelos, Agora, Kanon, and Open Actions, including the manual fake-strategist task.

#### Which issue(s) this PR is related to:

N/A

#### Special notes for your reviewer:

The reduced TTL applies to tasks created after the updated manifests are deployed. Existing tasks retain their configured TTL.

Validation passed:
- `make test TEST_FLAGS='-run Test.*Development\|TestManualFakeStrategist'`
- `git diff --check`
- Confirmed all 42 changed files contain only the TTL value change and every configured self-development task TTL is one day.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduces the TTL for finished dev tasks from 10 days to 1 day across all 42 Kelos, Agora, Kanon, and Open Actions TaskSpawner and Task manifests, including the manual fake-strategist task.

- Existing tasks retain their configured TTL; the new value applies only to tasks created after the updated manifests are deployed.
- Updates the install readiness fixture to wait for the goroutine to stop during cleanup, preventing a panic when the test exits.

<sup>Written for commit 4a9cd52f482d7ee789c7561c4302242a5f57c266. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kelos-dev/kelos/pull/1745?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

